### PR TITLE
File Open modes: Use a real enum instead of const values

### DIFF
--- a/include/pandora/File.hpp
+++ b/include/pandora/File.hpp
@@ -25,6 +25,14 @@ class Block;
 class BlockIterator;
 class Section;
 class SectionIterator;
+
+enum class FileMode {
+  ReadOnly = 0,
+  ReadWrite,
+  Overwrite
+};
+  
+  
 /**
  * Class that represents a pandora file.
  */
@@ -46,21 +54,14 @@ public:
   /** The version of the pandora format */
   static const std::string VERSION;
 
-  /** Read only file open mode */
-  static const size_t READ_ONLY;
-  /** Read/write file open mode */
-  static const size_t READ_WRITE;
-  /** Overwrite file open mode */
-  static const size_t OVERWRITE;
-
   /**
    * Constructor that is used to open the file.
    *
    * @param name    The name of the file to open.
    * @param prefix  The prefix used for IDs.
-   * @param mode    File open mode READ_ONLY, READ_WRITE or OVERWRITE.
+   * @param mode    File open mode ReadOnly, ReadWrite or Overwrite.
    */
-  File(std::string name, std::string prefix, int mode = READ_WRITE);
+  File(std::string name, std::string prefix, FileMode mode = FileMode::ReadWrite);
 
   /**
    * Copy constructor.

--- a/src/File.cpp
+++ b/src/File.cpp
@@ -31,20 +31,35 @@ namespace pandora {
 const string File::VERSION = "1.0";
 const string File::FORMAT  = "pandora";
 
-// File open modes
-const size_t File::READ_ONLY  = H5F_ACC_RDONLY;
-const size_t File::READ_WRITE = H5F_ACC_RDWR;
-const size_t File::OVERWRITE  = H5F_ACC_TRUNC;
+
+static unsigned int map_file_mode(FileMode mode) {
+  switch (mode) {
+    case FileMode::ReadWrite:
+      return H5F_ACC_RDWR;
+      
+    case FileMode::ReadOnly:
+      return H5F_ACC_RDONLY;
+      
+    case FileMode::Overwrite:
+      return H5F_ACC_TRUNC;
+
+    default:
+      return H5F_ACC_DEFAULT;
+  }
+  
+}
 
 /*SEE: File.hpp*/
-File::File(string name, string prefix, int mode)
+File::File(string name, string prefix, FileMode mode)
 : prefix(prefix)
 {
-  if (fileExists(name)) {
-    h5file = H5::H5File(name.c_str(), mode);
-  } else {
-    h5file = H5::H5File(name.c_str(), File::OVERWRITE);
+  if (!fileExists(name)) {
+    mode = FileMode::Overwrite;
   }
+
+  unsigned int h5mode =  map_file_mode(mode);
+  h5file = H5::H5File(name.c_str(), h5mode);
+
   root = Group(h5file.openGroup("/"));
   metadata = root.openGroup("metadata");
   data = root.openGroup("data");


### PR DESCRIPTION
This will also silence compiler warnings about sign mismatches
