### PR TITLE
Implemented new abstract pattern for "find*" methods using a "findEntities"

### DIFF
--- a/include/nix/Block.hpp
+++ b/include/nix/Block.hpp
@@ -105,7 +105,7 @@ public:
                                 = util::AcceptAll<Source>()) const
     {
         auto f = [this] (size_t i) { return getSource(i); };
-        return getMultiple<Source>(f,
+        return getEntities<Source>(f,
                                    sourceCount(),
                                    filter);
     }
@@ -122,7 +122,7 @@ public:
      * @return object vector of sources
      */
     std::vector<Source> findSources(
-                           std::function<bool(const Source &)> filter, 
+                           util::AcceptAll<Source> filter, 
                            size_t max_depth) const;
 
     /**
@@ -202,7 +202,7 @@ public:
                                       = util::AcceptAll<DataArray>()) const
     {
         auto f = [this] (size_t i) { return getDataArray(i); };
-        return getMultiple<DataArray>(f,
+        return getEntities<DataArray>(f,
                                       dataArrayCount(),
                                       filter);
     }
@@ -291,7 +291,7 @@ public:
                                       = util::AcceptAll<SimpleTag>()) const
     {
         auto f = [this] (size_t i) { return getSimpleTag(i); };
-        return getMultiple<SimpleTag>(f,
+        return getEntities<SimpleTag>(f,
                                       simpleTagCount(),
                                       filter);
     }
@@ -363,7 +363,6 @@ public:
      *
      * @return The data tag at the specified index.
      */
-    // TODO maybe remove this method?
     DataTag getDataTag(size_t index) const {
         return impl_ptr->getDataTag(index);
     }
@@ -382,7 +381,7 @@ public:
                                   = util::AcceptAll<DataTag>()) const
     {
         auto f = [this] (size_t i) { return getDataTag(i); };
-        return getMultiple<DataTag>(f,
+        return getEntities<DataTag>(f,
                                     dataTagCount(),
                                     filter);
     }

--- a/include/nix/DataArray.hpp
+++ b/include/nix/DataArray.hpp
@@ -137,7 +137,7 @@ public:
                                       = util::AcceptAll<Dimension>()) const
     {
         auto f = [this] (size_t i) { return getDimension(i); };
-        return getMultiple<Dimension>(f,
+        return getEntities<Dimension>(f,
                                       dimensionCount(),
                                       filter);
     }

--- a/include/nix/DataTag.hpp
+++ b/include/nix/DataTag.hpp
@@ -186,7 +186,7 @@ public:
                                       = util::AcceptAll<DataArray>()) const
     {
         auto f = [this] (size_t i) { return getReference(i); };
-        return getMultiple<DataArray>(f,
+        return getEntities<DataArray>(f,
                                       referenceCount(),
                                       filter);
     }
@@ -298,7 +298,7 @@ public:
                                   = util::AcceptAll<Representation>()) const
     {
         auto f = [this] (size_t i) { return getRepresentation(i); };
-        return getMultiple<Representation>(f,
+        return getEntities<Representation>(f,
                                     representationCount(),
                                     filter);
     }

--- a/include/nix/File.hpp
+++ b/include/nix/File.hpp
@@ -82,7 +82,7 @@ public:
                                   = util::AcceptAll<Block>()) const
     {
         auto f = [this] (size_t i) { return getBlock(i); };
-        return getMultiple<Block>(f, 
+        return getEntities<Block>(f, 
                                   blockCount(), 
                                   filter);
     }
@@ -113,7 +113,6 @@ public:
     }
 
 
-
     /**
      * Get sections associated with this file.
      *
@@ -128,7 +127,7 @@ public:
                                   = util::AcceptAll<Section>()) const
     {
         auto f = [this] (size_t i) { return getSection(i); };
-        return getMultiple<Section>(f,
+        return getEntities<Section>(f,
                                     sectionCount(),
                                     filter);
     }

--- a/include/nix/Section.hpp
+++ b/include/nix/Section.hpp
@@ -25,8 +25,9 @@ namespace nix {
 
 
 class NIXAPI Section : virtual public base::ISection, public base::NamedEntity<base::ISection> {
-
+    
 public:
+
 
     Section();
 
@@ -162,6 +163,15 @@ public:
         return impl_ptr->getSection(index);
     }
 
+    /**
+     * Equivalent to {@link sections} method, returning all children.
+     *
+     * @param object filter function of type {@link nix::util::Filter::type}
+     * @return object sections as a vector
+     */
+    std::vector<Section> children() const {
+        return sections();
+    }
 
     /**
      * Get sub sections associated with this section.
@@ -177,24 +187,29 @@ public:
                                   = util::AcceptAll<Section>()) const
     {
         auto f = [this] (size_t i) { return getSection(i); };
-        return getMultiple<Section>(f,
+        return getEntities<Section>(f,
                                     sectionCount(),
                                     filter);
     }
 
     /**
-     * Recoursively searches through all child sections and their descendents and returns every
-     * section that passes the specified filter. Further the result of the method is limited by
-     * the maximum epth.
-     *
-     * @param filter        A simple filter funcion that is applied on every section.
-     * @param max_depth     The maximum depth of the search.
-     *
-     * @return All matching section as a vector.
+     * Go through the tree of sources originating from this source until
+     * a max. level of "max_depth" and check for each source whether
+     * to return it depending on predicate function "filter".
+     * Return resulting vector of sources.
+     * 
+     * @param object filter function of type {@link nix::util::Filter::type}
+     * @param int maximum depth to search tree
+     * @return object vector of sources
      */
-    std::vector<Section> findSections(std::function<bool(const Section&)> filter = util::AcceptAll<Section>(),
-                                      size_t max_depth = std::numeric_limits<size_t>::max()) const;
-
+    std::vector<Section> findSections(util::AcceptAll<Section>::type filter = util::AcceptAll<Section>(),
+                                      size_t max_depth = std::numeric_limits<size_t>::max()) const
+    {
+        return findEntities<Section>(*this,
+                                    filter,
+                                    max_depth);
+    }
+    
     /**
      * Determines whether this section has a related section of the specified type.
      *
@@ -318,7 +333,7 @@ public:
                                   = util::AcceptAll<Property>()) const
     {
         auto f = [this] (size_t i) { return getProperty(i); };
-        return getMultiple<Property>(f,
+        return getEntities<Property>(f,
                                     propertyCount(),
                                     filter);
     }

--- a/include/nix/SimpleTag.hpp
+++ b/include/nix/SimpleTag.hpp
@@ -156,7 +156,7 @@ public:
                                       = util::AcceptAll<DataArray>()) const
     {
         auto f = [this] (size_t i) { return getReference(i); };
-        return getMultiple<DataArray>(f,
+        return getEntities<DataArray>(f,
                                       referenceCount(),
                                       filter);
     }
@@ -236,7 +236,7 @@ public:
                                   = util::AcceptAll<Representation>()) const
     {
         auto f = [this] (size_t i) { return getRepresentation(i); };
-        return getMultiple<Representation>(f,
+        return getEntities<Representation>(f,
                                     representationCount(),
                                     filter);
     }

--- a/include/nix/base/ISource.hpp
+++ b/include/nix/base/ISource.hpp
@@ -65,13 +65,6 @@ public:
     virtual size_t sourceCount() const = 0;
 
     /**
-     * Returns all sources that are direct descendant of this source as a vector.
-     *
-     * @return All direct child sources.
-     */
-    virtual std::vector<Source> sources() const = 0;
-
-    /**
      * Create a new root source.
      *
      * @param name      The name of the source to create.

--- a/include/nix/hdf5/SourceHDF5.hpp
+++ b/include/nix/hdf5/SourceHDF5.hpp
@@ -63,9 +63,6 @@ public:
     size_t sourceCount() const;
 
 
-    std::vector<Source> sources() const;
-
-
     Source createSource(const std::string &name, const std::string &type);
 
 

--- a/src/Block.cpp
+++ b/src/Block.cpp
@@ -25,7 +25,7 @@ namespace nix {
      * @return object vector of sources
      */
     std::vector<Source> Block::findSources(
-                           std::function<bool(const Source &)> filter, 
+                           util::AcceptAll<Source> filter, 
                            size_t max_depth) const
     {
         vector<Source> probes = sources();

--- a/src/Section.cpp
+++ b/src/Section.cpp
@@ -54,37 +54,6 @@ struct SectionCont {
 };
 
 
-std::vector<Section> Section::findSections(std::function<bool (const Section &)> filter,
-                                           size_t max_depth) const {
-    vector<Section>   results;
-    list<SectionCont> todo;
-
-    todo.push_back(SectionCont(*this));
-
-    while(todo.size() > 0) {
-
-        SectionCont current = todo.front();
-        todo.pop_front();
-
-        bool filter_ok = filter(current.section);
-        if (filter_ok) {
-            results.push_back(current.section);
-        }
-
-        if (current.depth < max_depth) {
-            vector<Section> children = current.section.sections();
-            size_t next_depth = current.depth + 1;
-
-            for (auto it = children.begin(); it != children.end(); ++it) {
-                todo.push_back(SectionCont(*it, next_depth));
-            }
-        }
-
-    }
-
-    return results;
-}
-
 //-----------------------------------------------------
 // Methods for property access
 //-----------------------------------------------------

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -36,58 +36,6 @@ Source::Source(const std::shared_ptr<base::ISource> &p_impl)
 //--------------------------------------------------
 
 
-struct SourceCont {
-
-    SourceCont(Source s, size_t d = 0)
-        : source(s), depth(d)
-    {}
-
-    Source source;
-    size_t depth;
-};
-
-/**
- * Go through the tree of sources originating from this source until
- * a max. level of "max_depth" and check for each source whether
- * to return it depending on predicate function "filter".
- * Return resulting vector of sources.
- * 
- * @param object filter function of type {@link nix::util::Filter::type}
- * @param int maximum depth to search tree
- * @return object vector of sources
- */
-std::vector<Source> Source::findSources(std::function<bool(const Source &)> filter,
-                                        size_t max_depth) const {
-    vector<Source>   results;
-    list<SourceCont> todo;
-
-    todo.push_back(SourceCont(*this));
-
-    while(todo.size() > 0) {
-
-        SourceCont current = todo.front();
-        todo.pop_front();
-
-        bool filter_ok = filter(current.source);
-        if (filter_ok) {
-            results.push_back(current.source);
-        }
-
-        if (current.depth < max_depth) {
-            vector<Source> children = current.source.sources();
-            size_t next_depth = current.depth + 1;
-
-            for (auto it = children.begin(); it != children.end(); ++it) {
-                todo.push_back(SourceCont(*it, next_depth));
-            }
-        }
-
-    }
-
-    return results;
-}
-
-
 //------------------------------------------------------
 // Operators and other functions
 //------------------------------------------------------

--- a/src/hdf5/SourceHDF5.cpp
+++ b/src/hdf5/SourceHDF5.cpp
@@ -60,22 +60,6 @@ size_t SourceHDF5::sourceCount() const {
 }
 
 
-std::vector<Source> SourceHDF5::sources() const {
-    vector<Source> srcs;
-
-    size_t src_count = sourceCount();
-    for (size_t i = 0; i < src_count; i++) {
-        string id  = source_group.objectName(i);
-        Group  grp = source_group.openGroup(id, false);
-
-        shared_ptr<SourceHDF5> tmp(new SourceHDF5(file(), grp, id));
-        srcs.push_back(Source(tmp));
-    }
-
-    return srcs;
-}
-
-
 Source SourceHDF5::createSource(const string &name, const string &type) {
     string id = util::createId("source");
 

--- a/test/TestFile.hpp
+++ b/test/TestFile.hpp
@@ -31,9 +31,8 @@ private:
     CPPUNIT_TEST(testCreatedAt);
     CPPUNIT_TEST(testUpdatedAt);
     CPPUNIT_TEST(testBlockAccess);
-
-    CPPUNIT_TEST(testOperators);
     CPPUNIT_TEST(testSectionAccess);
+    CPPUNIT_TEST(testOperators);
     CPPUNIT_TEST_SUITE_END ();
 
     nix::File file_open, file_other, file_null;
@@ -48,9 +47,6 @@ public:
     void testCreatedAt();
     void testUpdatedAt();
     void testBlockAccess();
-
-    void testOperators();
     void testSectionAccess();
-
+    void testOperators();
 };
-


### PR DESCRIPTION
Implemented new abstract pattern for "find*" methods using a "findEntities" method in the base class "ImplContainer".

To achieve this a "children()" method was added to "Sections" and "Sources" that wraps "sections()" or "sources()" methods.
For naming consistency "getMultiple" was renamed to "getEntities".
