### PR TITLE
[travis] enable static analysis via clang-check

### DIFF
--- a/.travis.ctest
+++ b/.travis.ctest
@@ -12,8 +12,15 @@ set(CTEST_NOTES_FILES ${CTEST_BINARY_DIRECTORY}/travis.cfg)
 set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 set(CTEST_BUILD_CONFIGURATION "$ENV{CMAKE_BUILD_TYPE}")
 
+find_program(CLANG_CHECK clang-check)
+
 ctest_start(Continuous)
 ctest_configure()
 ctest_build()
+
+if(CLANG_CHECK AND $ENV{COMPILER} MATCHES "clang")
+  ctest_build(TARGET check)
+endif()
+
 ctest_test()
 ctest_submit()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,19 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/main.cpp")
   target_link_libraries(playground pandora)
 endif()
 
+
+######## static analysis
+find_program(CLANG_CHECK clang-check)
+if(CLANG_CHECK)
+  MESSAGE(STATUS "FOUND clang-check: ${CLANG_CHECK}")
+  set(CMAKE_EXPORT_COMPILE_COMMANDS ON) #should maybe check for generator
+
+  add_custom_target(check COMMAND ${CLANG_CHECK} -p ${CMAKE_BINARY_DIR} ${pandora_SOURCES}
+                    DEPENDS pandora
+		    SOURCES ${pandora_SOURCES})
+endif()
+
+
 ########################################
 # Tests
 


### PR DESCRIPTION
It would be nice to have static analysis as well.
