### PR TITLE
Use std::make_shared<> to create shared pointer

### DIFF
--- a/src/hdf5/BlockHDF5.cpp
+++ b/src/hdf5/BlockHDF5.cpp
@@ -57,14 +57,14 @@ bool BlockHDF5::hasSource(const string &id) const {
 
 
 Source BlockHDF5::getSource(const string &id) const {
-    shared_ptr<SourceHDF5> tmp(new SourceHDF5(file(), source_group.openGroup(id, false), id));
+    auto tmp = make_shared<SourceHDF5>(file(), source_group.openGroup(id, false), id);
     return Source(tmp);
 }
 
 
 Source BlockHDF5::getSource(size_t index) const {
     string id = source_group.objectName(index);
-    shared_ptr<SourceHDF5> tmp(new SourceHDF5(file(), source_group.openGroup(id, false), id));
+    auto tmp = make_shared<SourceHDF5>(file(), source_group.openGroup(id, false), id);
     return Source(tmp);
 }
 
@@ -82,7 +82,7 @@ Source BlockHDF5::createSource(const string &name,const string &type) {
     }
 
     Group group = source_group.openGroup(id, true);
-    shared_ptr<SourceHDF5> tmp(new SourceHDF5(file(), group, id));
+    shared_ptr<SourceHDF5> tmp = make_shared<SourceHDF5>(file(), group, id);
     tmp->name(name);
     tmp->type(type);
 
@@ -111,7 +111,7 @@ bool BlockHDF5::hasSimpleTag(const string &id) const {
 
 SimpleTag BlockHDF5::getSimpleTag(const string &id) const {
     if (hasSimpleTag(id)) {
-        shared_ptr<SimpleTagHDF5> tmp(new SimpleTagHDF5(file(), block(), simple_tag_group.openGroup(id, true), id));
+        auto tmp = make_shared<SimpleTagHDF5>(file(), block(), simple_tag_group.openGroup(id, true), id);
         return SimpleTag(tmp);
     } else {
         throw runtime_error("Unable to find SimpleTag with id " + id + "!");
@@ -122,7 +122,7 @@ SimpleTag BlockHDF5::getSimpleTag(const string &id) const {
 SimpleTag BlockHDF5::getSimpleTag(size_t index) const {
     if (index < simpleTagCount()) {
         string id = simple_tag_group.objectName(index);
-        shared_ptr<SimpleTagHDF5> tmp(new SimpleTagHDF5(file(), block(), simple_tag_group.openGroup(id, true), id));
+        auto tmp = make_shared<SimpleTagHDF5>(file(), block(), simple_tag_group.openGroup(id, true), id);
         return SimpleTag(tmp);
     } else {
         throw runtime_error("Unable to find SimpleTag with the given index!");
@@ -142,7 +142,7 @@ SimpleTag BlockHDF5::createSimpleTag(const string &name, const string &type) {
         id = util::createId("simple_tag");
     }
 
-    shared_ptr<SimpleTagHDF5> tmp(new SimpleTagHDF5(file(), block(), simple_tag_group.openGroup(id, true), id));
+    auto tmp = make_shared<SimpleTagHDF5>(file(), block(), simple_tag_group.openGroup(id, true), id);
     tmp->name(name);
     tmp->type(type);
 
@@ -171,7 +171,7 @@ bool BlockHDF5::hasDataArray(const string &id) const {
 
 DataArray BlockHDF5::getDataArray(const string &id) const {
     if (hasDataArray(id)) {
-        shared_ptr<DataArrayHDF5> tmp(new DataArrayHDF5(file(), block(), data_array_group.openGroup(id, true), id));
+        auto tmp = make_shared<DataArrayHDF5>(file(), block(), data_array_group.openGroup(id, true), id);
         return DataArray(tmp);
     } else {
         throw runtime_error("Unable to find DataArray with id " + id + "!");
@@ -182,7 +182,7 @@ DataArray BlockHDF5::getDataArray(const string &id) const {
 DataArray BlockHDF5::getDataArray(size_t index) const {
     if (index < dataArrayCount()) {
         string id = data_array_group.objectName(index);
-        shared_ptr<DataArrayHDF5> tmp(new DataArrayHDF5(file(), block(), data_array_group.openGroup(id, true), id));
+        auto tmp = make_shared<DataArrayHDF5>(file(), block(), data_array_group.openGroup(id, true), id);
         return DataArray(tmp);
     } else {
         throw runtime_error("Unable to find DataArray with the given index!");
@@ -202,7 +202,7 @@ DataArray BlockHDF5::createDataArray(const std::string &name, const std::string 
         id = util::createId("data_array");
     }
 
-    shared_ptr<DataArrayHDF5> tmp(new DataArrayHDF5(file(), block(), data_array_group.openGroup(id, true), id));
+    auto tmp = make_shared<DataArrayHDF5>(file(), block(), data_array_group.openGroup(id, true), id);
     tmp->name(name);
     tmp->type(type);
 
@@ -230,7 +230,7 @@ DataTag BlockHDF5::createDataTag(const std::string &name, const std::string &typ
         id = util::createId("data_tag");
     }
 
-    shared_ptr<DataTagHDF5> tmp(new DataTagHDF5(file(), block(), data_tag_group.openGroup(id), id));
+    auto tmp = make_shared<DataTagHDF5>(file(), block(), data_tag_group.openGroup(id), id);
     tmp->name(name);
     tmp->type(type);
 
@@ -245,7 +245,7 @@ bool BlockHDF5::hasDataTag(const std::string &id) const{
 
 DataTag BlockHDF5::getDataTag(const std::string &id) const{
     if (hasDataTag(id)) {
-        shared_ptr<DataTagHDF5> tmp(new DataTagHDF5(file(), block(), data_tag_group.openGroup(id), id));
+        auto tmp = make_shared<DataTagHDF5>(file(), block(), data_tag_group.openGroup(id), id);
         return DataTag(tmp);
     } else {
         throw runtime_error("Unable to find DataTag with id " + id + "!");
@@ -256,7 +256,7 @@ DataTag BlockHDF5::getDataTag(const std::string &id) const{
 DataTag BlockHDF5::getDataTag(size_t index) const {
     if (index < dataTagCount()) {
         string id = data_tag_group.objectName(index);
-        shared_ptr<DataTagHDF5> tmp(new DataTagHDF5(file(), block(), data_tag_group.openGroup(id, true), id));
+        auto tmp = make_shared<DataTagHDF5>(file(), block(), data_tag_group.openGroup(id, true), id);
         return DataTag(tmp);
     } else {
         throw runtime_error("Unable to find DataTag with the given index!");

--- a/src/hdf5/DataArrayHDF5.cpp
+++ b/src/hdf5/DataArrayHDF5.cpp
@@ -127,13 +127,13 @@ Dimension DataArrayHDF5::getDimension(size_t id) const {
         Dimension dim;
 
         if (dim_type == DimensionType::Set ) {
-            shared_ptr<SetDimensionHDF5> tmp(new SetDimensionHDF5(dim_group, id));
+            auto tmp = make_shared<SetDimensionHDF5>(dim_group, id);
             dim = SetDimension(tmp);
         } else if (dim_type == DimensionType::Range) {
-            shared_ptr<RangeDimensionHDF5> tmp(new RangeDimensionHDF5(dim_group, id));
+            auto tmp = make_shared<RangeDimensionHDF5>(dim_group, id);
             dim = RangeDimension(tmp);
         } else if (dim_type == DimensionType::Sample) {
-            shared_ptr<SampledDimensionHDF5> tmp(new SampledDimensionHDF5(dim_group, id));
+            auto tmp = make_shared<SampledDimensionHDF5>(dim_group, id);
             dim = SampledDimension(tmp);
         } else {
             throw runtime_error("Invalid dimension type");
@@ -163,13 +163,13 @@ Dimension DataArrayHDF5::createDimension(size_t id, DimensionType type) {
     Dimension dim;
 
     if (type == DimensionType::Set ) {
-        shared_ptr<SetDimensionHDF5> tmp(new SetDimensionHDF5(dim_group, id));
+        auto tmp = make_shared<SetDimensionHDF5>(dim_group, id);
         dim = SetDimension(tmp);
     } else if (type == DimensionType::Range) {
-        shared_ptr<RangeDimensionHDF5> tmp(new RangeDimensionHDF5(dim_group, id));
+        auto tmp = make_shared<RangeDimensionHDF5>(dim_group, id);
         dim = RangeDimension(tmp);
     } else if (type == DimensionType::Sample) {
-        shared_ptr<SampledDimensionHDF5> tmp(new SampledDimensionHDF5(dim_group, id));
+        auto tmp = make_shared<SampledDimensionHDF5>(dim_group, id);
         dim = SampledDimension(tmp);
     } else {
         throw runtime_error("Invalid dimension type");

--- a/src/hdf5/DataTagHDF5.cpp
+++ b/src/hdf5/DataTagHDF5.cpp
@@ -194,7 +194,7 @@ size_t DataTagHDF5::representationCount() const{
 
 Representation DataTagHDF5::getRepresentation(const std::string &id) const  {
     Group group = representation_group.openGroup(id, false);
-    shared_ptr<RepresentationHDF5> tmp(new RepresentationHDF5(file(), block(), group, id));
+    auto tmp = make_shared<RepresentationHDF5>(file(), block(), group, id);
 
     return Representation(tmp);
 }
@@ -203,7 +203,7 @@ Representation DataTagHDF5::getRepresentation(const std::string &id) const  {
 Representation DataTagHDF5::getRepresentation(size_t index) const{
     string id = representation_group.objectName(index);
     Group group = representation_group.openGroup(id, false);
-    shared_ptr<RepresentationHDF5> tmp(new RepresentationHDF5(file(), block(), group, id));
+    auto tmp = make_shared<RepresentationHDF5>(file(), block(), group, id);
 
     return Representation(tmp);
 }
@@ -215,7 +215,7 @@ Representation DataTagHDF5::createRepresentation(DataArray data, LinkType link_t
         id = util::createId("representation");
 
     Group group = representation_group.openGroup(id, true);
-    shared_ptr<RepresentationHDF5> tmp(new RepresentationHDF5(file(), block(), group, id));
+    auto tmp = make_shared<RepresentationHDF5>(file(), block(), group, id);
     tmp->linkType(link_type);
     tmp->data(data);
 

--- a/src/hdf5/SectionHDF5.cpp
+++ b/src/hdf5/SectionHDF5.cpp
@@ -162,7 +162,7 @@ Section SectionHDF5::getSection(const string &id) const {
     if (section_group.hasGroup(id)) {
         Group grp = section_group.openGroup(id, false);
 
-        shared_ptr<SectionHDF5> tmp(new SectionHDF5(file(), grp, id));
+        auto tmp = make_shared<SectionHDF5>(file(), grp, id);
         return Section(tmp);
     } else {
         return Section();
@@ -187,7 +187,7 @@ Section SectionHDF5::createSection(const string &name, const string &type) {
     Section parent(const_pointer_cast<SectionHDF5>(shared_from_this()));
 
     Group grp = section_group.openGroup(new_id, true);
-    shared_ptr<SectionHDF5> tmp(new SectionHDF5(file(), parent, grp, new_id));
+    auto tmp = make_shared<SectionHDF5>(file(), parent, grp, new_id);
     tmp->name(name);
     tmp->type(type);
 
@@ -225,7 +225,7 @@ Property SectionHDF5::getProperty(const string &id) const {
     if (property_group.hasGroup(id)) {
         Group g = property_group.openGroup(id,false);
 
-        shared_ptr<PropertyHDF5> tmp(new PropertyHDF5(file(), g, id));
+        auto tmp = make_shared<PropertyHDF5>(file(), g, id);
         return Property(tmp);
     } else {
         return Property();
@@ -271,7 +271,7 @@ Property SectionHDF5::getPropertyByName(const string &name) const {
         grp.getAttr("name", other_name);
 
         if (other_name == name) {
-            shared_ptr<PropertyHDF5> tmp(new PropertyHDF5(file(), grp, id));
+            auto tmp = make_shared<PropertyHDF5>(file(), grp, id);
             prop = Property(tmp);
             break;
         }
@@ -292,7 +292,7 @@ Property SectionHDF5::createProperty(const string &name) {
 
     Group grp = property_group.openGroup(new_id, true);
 
-    shared_ptr<PropertyHDF5> tmp(new PropertyHDF5(file(), grp, new_id));
+    auto tmp = make_shared<PropertyHDF5>(file(), grp, new_id);
     tmp->name(name);
 
     return Property(tmp);

--- a/src/hdf5/SimpleTagHDF5.cpp
+++ b/src/hdf5/SimpleTagHDF5.cpp
@@ -180,7 +180,7 @@ size_t SimpleTagHDF5::representationCount() const {
 
 Representation SimpleTagHDF5::getRepresentation(const std::string &id) const {
     Group rep_g = representation_group.openGroup(id, false);
-    shared_ptr<RepresentationHDF5> tmp(new RepresentationHDF5(file(), block(), rep_g, id));
+    auto tmp = make_shared<RepresentationHDF5>(file(), block(), rep_g, id);
 
     return Representation(tmp);
 }
@@ -189,7 +189,7 @@ Representation SimpleTagHDF5::getRepresentation(const std::string &id) const {
 Representation SimpleTagHDF5::getRepresentation(size_t index) const{
     string rep_id = representation_group.objectName(index);
     Group rep_g = representation_group.openGroup(rep_id, false);
-    shared_ptr<RepresentationHDF5> tmp(new RepresentationHDF5(file(), block(), rep_g, rep_id));
+    auto tmp = make_shared<RepresentationHDF5>(file(), block(), rep_g, rep_id);
 
     return Representation(tmp);
 }
@@ -201,7 +201,7 @@ Representation SimpleTagHDF5::createRepresentation(DataArray data, LinkType link
         rep_id = util::createId("representation");
 
     Group rep_g = representation_group.openGroup(rep_id, false);
-    shared_ptr<RepresentationHDF5> tmp(new RepresentationHDF5(file(), block(), rep_g, rep_id));
+    auto tmp = make_shared<RepresentationHDF5>(file(), block(), rep_g, rep_id);
     tmp->linkType(link_type);
     tmp->data(data);
 

--- a/src/hdf5/SourceHDF5.cpp
+++ b/src/hdf5/SourceHDF5.cpp
@@ -43,7 +43,7 @@ bool SourceHDF5::hasSource(const string &id) const {
 
 Source SourceHDF5::getSource(const string &id) const {
     Group grp = source_group.openGroup(id, false);
-    shared_ptr<SourceHDF5> tmp(new SourceHDF5(file(), grp, id));
+    shared_ptr<SourceHDF5> tmp = make_shared<SourceHDF5>(file(), grp, id);
     return Source(tmp);
 }
 
@@ -68,7 +68,7 @@ Source SourceHDF5::createSource(const string &name, const string &type) {
     }
 
     Group grp = source_group.openGroup(id, true);
-    shared_ptr<SourceHDF5> tmp(new SourceHDF5(file(), grp, id));
+    shared_ptr<SourceHDF5> tmp = make_shared<SourceHDF5>(file(), grp, id);
     tmp->name(name);
     tmp->type(type);
 


### PR DESCRIPTION
Using std::make_shared<>[1] will safe one allocation compared
to std::shared_ptr<T> tmp(new T(...)).

I use auto quite in most of the places just to keep the lines short. The actual type of the auto is quite clear from the make_shared<> template argument.

[1] http://en.cppreference.com/w/cpp/memory/shared_ptr/make_shared
