### PR TITLE
Implemented use of "boost::optional" for some of the instances where "bo...

### DIFF
--- a/include/nix/Property.hpp
+++ b/include/nix/Property.hpp
@@ -60,7 +60,7 @@ public:
     }
 
 
-    std::string mapping() const {
+    boost::optional<std::string> mapping() const {
         return impl_ptr->mapping();
     }
     
@@ -90,7 +90,7 @@ public:
     }
 
 
-    std::string unit() const {
+    boost::optional<std::string> unit() const {
         return impl_ptr->unit();
     }
     

--- a/include/nix/Section.hpp
+++ b/include/nix/Section.hpp
@@ -58,9 +58,9 @@ public:
     /**
      * Returns the repository url.
      *
-     * @return string the url.
+     * @return boost::optional<string> the url.
      */
-    std::string repository() const {
+    boost::optional<std::string> repository() const {
         return impl_ptr->repository();
     }
     
@@ -117,9 +117,9 @@ public:
     /**
      * Return the mapping information.
      *
-     * @return string
+     * @return boost::optional<std::string>
      */
-    std::string mapping() const {
+    boost::optional<std::string> mapping() const {
         return impl_ptr->mapping();
     }
     

--- a/include/nix/base/IProperty.hpp
+++ b/include/nix/base/IProperty.hpp
@@ -33,7 +33,7 @@ public:
     virtual void mapping(const std::string &mapping) = 0;
 
 
-    virtual std::string mapping() const = 0;
+    virtual boost::optional<std::string> mapping() const = 0;
 
 
     virtual void mapping(const none_t t) = 0;
@@ -51,7 +51,7 @@ public:
     virtual void unit(const std::string &unit) = 0;
 
 
-    virtual std::string unit() const = 0;
+    virtual boost::optional<std::string> unit() const = 0;
 
 
     virtual void unit(const none_t t) = 0;

--- a/include/nix/base/ISection.hpp
+++ b/include/nix/base/ISection.hpp
@@ -43,9 +43,9 @@ public:
     /**
      * Returns the repository url.
      *
-     * @return string the url.
+     * @return boost::optional<string> the url.
      */
-    virtual std::string repository() const = 0;
+    virtual boost::optional<std::string> repository() const = 0;
 
     /**
      * Deleter for the repository url.
@@ -88,9 +88,9 @@ public:
     /**
      * Return the mapping information.
      *
-     * @return string
+     * @return boost::optional<std::string>
      */
-    virtual std::string mapping() const = 0;
+    virtual boost::optional<std::string> mapping() const = 0;
 
     /**
      * Deleter for the mapping information.

--- a/include/nix/hdf5/PropertyHDF5.hpp
+++ b/include/nix/hdf5/PropertyHDF5.hpp
@@ -42,7 +42,7 @@ public:
     void mapping(const std::string &mapping);
 
 
-    std::string mapping() const;
+    boost::optional<std::string> mapping() const;
 
 
     void mapping(const none_t t);
@@ -60,7 +60,7 @@ public:
     void unit(const std::string &unit);
 
 
-    std::string unit() const;
+    boost::optional<std::string> unit() const;
 
 
     void unit(const none_t t);

--- a/include/nix/hdf5/SectionHDF5.hpp
+++ b/include/nix/hdf5/SectionHDF5.hpp
@@ -63,7 +63,7 @@ public:
     void repository(const std::string &repository);
 
 
-    std::string repository() const;
+    boost::optional<std::string> repository() const;
 
 
     void repository(const none_t t);
@@ -81,7 +81,7 @@ public:
     void mapping(const std::string &mapping);
 
 
-    std::string mapping() const;
+    boost::optional<std::string> mapping() const;
 
 
     void mapping(const none_t t);

--- a/src/hdf5/PropertyHDF5.cpp
+++ b/src/hdf5/PropertyHDF5.cpp
@@ -68,10 +68,13 @@ void PropertyHDF5::mapping(const string &mapping) {
 }
 
 
-string PropertyHDF5::mapping() const {
+boost::optional<string> PropertyHDF5::mapping() const {
+    boost::optional<string> ret;
     string mapping;
-    group().getAttr("mapping", mapping);
-    return mapping;
+    if(group().getAttr("mapping", mapping)) {
+		ret = mapping;
+	}
+    return ret;
 }
 
 
@@ -84,17 +87,20 @@ void PropertyHDF5::mapping(const none_t t) {
 
 
 void PropertyHDF5::unit(const string &unit) {
-    if (valueCount() > 0 && this->unit().length() > 0) {
+    if (valueCount() > 0 && this->unit()) {
         throw runtime_error("Cannot change unit of a not-empty property!");
     }
     group().setAttr("unit", unit);
 }
 
 
-string PropertyHDF5::unit() const {
+boost::optional<string> PropertyHDF5::unit() const {
+    boost::optional<std::string> ret;
     string unit;
-    group().getAttr("unit", unit);
-    return unit;
+    if(group().getAttr("unit", unit)) {
+		ret = unit;
+	}
+    return ret;
 }
 
 

--- a/src/hdf5/SectionHDF5.cpp
+++ b/src/hdf5/SectionHDF5.cpp
@@ -62,10 +62,13 @@ void SectionHDF5::repository(const string &repository) {
 }
 
 
-string SectionHDF5::repository() const {
+boost::optional<string> SectionHDF5::repository() const {
+    boost::optional<string> ret;
     string repository;
-    group().getAttr("repository", repository);
-    return repository;
+    if(group().getAttr("repository", repository)) {
+		ret = repository;
+	}
+    return ret;
 }
 
 
@@ -119,10 +122,13 @@ void SectionHDF5::mapping(const string &mapping) {
 }
 
 
-string SectionHDF5::mapping() const {
+boost::optional<string> SectionHDF5::mapping() const {
+    boost::optional<string> ret;
     string mapping;
-    group().getAttr("mapping", mapping);
-    return mapping;
+    if(group().getAttr("mapping", mapping)) {
+		ret = mapping;
+	}
+    return ret;
 }
 
 

--- a/test/TestSection.cpp
+++ b/test/TestSection.cpp
@@ -68,7 +68,7 @@ void TestSection::testParent() {
 
 
 void TestSection::testRepository() {
-    CPPUNIT_ASSERT(section.repository() == "");
+    CPPUNIT_ASSERT(!section.repository());
     string rep = "http://foo.bar/" + util::createId("", 32);
     section.repository(rep);
     CPPUNIT_ASSERT(section.repository() == rep);
@@ -88,7 +88,7 @@ void TestSection::testLink() {
 
 
 void TestSection::testMapping() {
-    CPPUNIT_ASSERT(section.mapping() == "");
+    CPPUNIT_ASSERT(!section.mapping());
     string map = "http://foo.bar/" + util::createId("", 32);
     section.mapping(map);
     CPPUNIT_ASSERT(section.mapping() == map);


### PR DESCRIPTION
...ost::none_t" was already being used:

mapping, unit, repository.
Not implemented for many yet to clarify cases: "dataType", "labels", "extents", "units", "values", "link", "extent", "metadata".
