### PR TITLE
Fixed EntityWithSources: getSource overloads, addSource & sources-setter

### DIFF
--- a/include/nix/Block.hpp
+++ b/include/nix/Block.hpp
@@ -116,15 +116,15 @@ public:
      * Go through the tree of sources originating from every source in this 
      * block until a max. level of "max_depth" and check for each source
      * whether to return it depending on predicate function "filter".
-     * Return resulting vector of sources, which may contain duplicates.
+     * Return resulting vector of sources (which may contain duplicates)
+     * or empty vector if none found.
      * 
      * @param object filter function of type std::function<bool(const Source &)>
      * @param int maximum depth to search tree
      * @return object vector of sources
      */
-    std::vector<Source> findSources(
-                           util::AcceptAll<Source> filter, 
-                           size_t max_depth) const;
+    std::vector<Source> findSources(std::function<bool(Source)> filter = util::AcceptAll<Source>(),
+                                    size_t max_depth = std::numeric_limits<size_t>::max()) const;
 
     /**
      * Create a new root source.

--- a/include/nix/Source.hpp
+++ b/include/nix/Source.hpp
@@ -109,7 +109,7 @@ public:
      * Go through the tree of sources originating from this source until
      * a max. level of "max_depth" and check for each source whether
      * to return it depending on predicate function "filter".
-     * Return resulting vector of sources.
+     * Return resulting vector of sources or empty vector if none found.
      * 
      * @param object filter function of type {@link nix::util::Filter::type}
      * @param int maximum depth to search tree

--- a/include/nix/util/filter.hpp
+++ b/include/nix/util/filter.hpp
@@ -11,6 +11,7 @@
 #define NIX_FILTER_H
 
 #include <functional>
+#include <unordered_set>
 
 namespace nix {
 namespace util {
@@ -58,6 +59,26 @@ struct IdFilter : public Filter<T> {
 
     virtual bool operator()(const T &e) {
         return e.id() == id;
+    }
+
+};
+
+
+template<typename T>
+struct IdsFilter : public Filter<T> {
+
+    std::unordered_set<std::string> ids;
+
+
+    IdsFilter(const std::vector<std::string> &ids_vect)
+        : ids(ids_vect.begin(), ids_vect.end())
+    {}
+
+
+    virtual bool operator()(const T &e) {
+        // std::unordered_set.count is a fast by-hash-getter that
+        // returns 1 (if val found) or 0 (if not found).
+        return (bool) ids.count(e.id());
     }
 
 };

--- a/src/Block.cpp
+++ b/src/Block.cpp
@@ -14,19 +14,8 @@ using namespace std;
 
 namespace nix {
 
-    /**
-     * Go through the tree of sources originating from every source in this 
-     * block until a max. level of "max_depth" and check for each source
-     * whether to return it depending on predicate function "filter".
-     * Return resulting vector of sources, which may contain duplicates.
-     * 
-     * @param object filter function of type std::function<bool(const Source &)>
-     * @param int maximum depth to search tree
-     * @return object vector of sources
-     */
-    std::vector<Source> Block::findSources(
-                           util::AcceptAll<Source> filter, 
-                           size_t max_depth) const
+    std::vector<Source> Block::findSources(std::function<bool(Source)> filter,
+                                           size_t max_depth) const 
     {
         vector<Source> probes = sources();
         vector<Source> matches;

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -50,7 +50,7 @@ struct SourceCont {
 
 
 std::vector<Source> Source::findSources(std::function<bool(Source)> filter,
-                                size_t max_depth) const 
+                                        size_t max_depth) const 
 {
     std::vector<Source>  results;
     std::list<SourceCont> todo;


### PR DESCRIPTION
getSource(const size_t index) & getSource(const string &id) now both check whether the requested source is part of the source_refs group and they use "findSources" to retrieve the source.
If either the source is not part of source_refs or is not found an empty source object is returned. (The latter being a behavior yet to be implemented for all instanes).

The sources(vector<Source> ids) setter is now reducing the given ids-vector to those ids that are actually found in the block. It does so by using a new "IdsFilter" struct with "findSources".

Thus also a new filter has been added and cosmetic changes to the "findSources" functions and function-docs have been made.

Adresses issue #136
