### PR TITLE
Modified "objectName" in "Group" to use native "H5Lget_name_by_idx".

### DIFF
--- a/src/hdf5/Group.cpp
+++ b/src/hdf5/Group.cpp
@@ -57,7 +57,33 @@ size_t Group::objectCount() const {
 
 
 std::string Group::objectName(size_t index) const {
-    return h5group.getObjnameByIdx(index);
+    std::string str_name;
+    // check whether name is found by index
+    ssize_t name_len = H5Lget_name_by_idx(h5group.getLocId(), 
+                                                  ".", 
+                                                  H5_INDEX_NAME, 
+                                                  H5_ITER_NATIVE, 
+                                                  (hsize_t) index, 
+                                                  NULL, 
+                                                  0, 
+                                                  H5P_DEFAULT);
+    if(name_len > 0) {
+        char* name = new char[name_len+1];
+        name_len = H5Lget_name_by_idx(h5group.getLocId(), 
+                                      ".", 
+                                      H5_INDEX_NAME, 
+                                      H5_ITER_NATIVE, 
+                                      (hsize_t) index, 
+                                      name, 
+                                      name_len+1, 
+                                      H5P_DEFAULT);
+        str_name = name;
+        delete [] name;
+    } else {
+        str_name = "";
+    }
+    
+    return str_name;
 }
 
 


### PR DESCRIPTION
"objectName" in "Group" now uses the native "H5Lget_name_by_idx" instead of the CommonFG wrapper method "getObjnameByIdx". Only but important difference: "objectName" will now not cause an exception if the index is not found but return an empty string.
