### PR TITLE
Delegated in all ctors without time to those with time as parameter.

### DIFF
--- a/include/nix/hdf5/ReferenceList.hpp
+++ b/include/nix/hdf5/ReferenceList.hpp
@@ -18,7 +18,15 @@
 namespace nix {
 namespace hdf5 {
 
-
+/**
+ * ReferenceList is a sub-class of {@link Group} classes: it always
+ * lives in a group and requires one upon construction to nest itself
+ * in. Thus when copying an entity it is enough to copy its group(s),
+ * any ReferenceList will come along.
+ * Its' intended use is to store references to other entities, e.g.
+ * referenced {@link DataArray} entities in {@link SimpleTag} or 
+ * {@link DataTag} entities. 
+ */
 class NIXAPI ReferenceList {
 
     static const NDSize MIN_CHUNK_SIZE;

--- a/src/hdf5/BlockHDF5.cpp
+++ b/src/hdf5/BlockHDF5.cpp
@@ -27,12 +27,8 @@ BlockHDF5::BlockHDF5(const BlockHDF5 &block)
 
 
 BlockHDF5::BlockHDF5(File file, Group group, const string &id, const string &type)
-    : EntityWithMetadataHDF5(file, group, id, type)
+    : BlockHDF5(file, group, id, type, util::getTime())
 {
-    source_group = group.openGroup("sources");
-    data_array_group = group.openGroup("data_arrays");
-    simple_tag_group = group.openGroup("simple_tags");
-    data_tag_group = group.openGroup("data_tags");
 }
 
 

--- a/src/hdf5/DataArrayHDF5.cpp
+++ b/src/hdf5/DataArrayHDF5.cpp
@@ -26,9 +26,8 @@ DataArrayHDF5::DataArrayHDF5(const DataArrayHDF5 &data_array)
 
 DataArrayHDF5::DataArrayHDF5(const File &file, const Block &block, const Group &group, 
                              const string &id, const string &type)
-    : EntityWithSourcesHDF5(file, block, group, id, type)
+    : DataArrayHDF5(file, block, group, id, type, util::getTime())
 {
-    dimension_group = this->group().openGroup("dimensions", true);
 }
 
 

--- a/src/hdf5/DataTagHDF5.cpp
+++ b/src/hdf5/DataTagHDF5.cpp
@@ -22,20 +22,14 @@ DataTagHDF5::DataTagHDF5(const DataTagHDF5 &tag)
       reference_list(tag.reference_list)
 {
     representation_group = tag.representation_group;
-    // TODO: the line below currently throws an exception if the DataArray
-    // is not in block - to consider if we prefer copying it to the block
     positions(tag.positions().id());
 }
 
 
 DataTagHDF5::DataTagHDF5(const File &file, const Block &block, const Group &group, 
                          const string &id, const std::string &type, const DataArray _positions)
-    : EntityWithSourcesHDF5(file, block, group, id, type), reference_list(group, "references")
+    : DataTagHDF5(file, block, group, id, type, _positions, util::getTime())
 {
-    representation_group = this->group().openGroup("representations");
-    // TODO: the line below currently throws an exception if positions is
-    // not in block - to consider if we prefer copying it to the block
-    positions(_positions.id());
 }
 
 
@@ -44,6 +38,8 @@ DataTagHDF5::DataTagHDF5(const File &file, const Block &block, const Group &grou
     : EntityWithSourcesHDF5(file, block, group, id, type, time), reference_list(group, "references")
 {
     representation_group = this->group().openGroup("representations");
+    // TODO: the line below currently throws an exception if positions is
+    // not in block - to consider if we prefer copying it to the block
     positions(_positions.id());
 }
 

--- a/src/hdf5/EntityWithMetadataHDF5.cpp
+++ b/src/hdf5/EntityWithMetadataHDF5.cpp
@@ -16,7 +16,7 @@ namespace hdf5 {
 
 
 EntityWithMetadataHDF5::EntityWithMetadataHDF5(File file, Group group, const string &id, const string &type)
-    : NamedEntityHDF5(file, group, id, type)
+    : EntityWithMetadataHDF5(file, group, id, type, util::getTime())
 {
 }
 

--- a/src/hdf5/EntityWithSourcesHDF5.cpp
+++ b/src/hdf5/EntityWithSourcesHDF5.cpp
@@ -19,7 +19,7 @@ namespace hdf5 {
 EntityWithSourcesHDF5::EntityWithSourcesHDF5
                     (File file, Block block, Group group, const string &id, 
                      const string &type)
-    : EntityWithMetadataHDF5(file, group, id, type), entity_block(block), sources_refs(group, "sources")
+    : EntityWithSourcesHDF5(file, block, group, id, type, util::getTime())
 {
 }
 

--- a/src/hdf5/FileHDF5.cpp
+++ b/src/hdf5/FileHDF5.cpp
@@ -61,7 +61,7 @@ FileHDF5::FileHDF5(const string &name, FileMode mode)
     setUpdatedAt();
 
     if(!checkHeader()) {
-        /// TODO throw an exception here
+        throw std::runtime_error("Invalid file header: either file format or file version not correct");
     }
 }
 

--- a/src/hdf5/NamedEntityHDF5.cpp
+++ b/src/hdf5/NamedEntityHDF5.cpp
@@ -18,9 +18,8 @@ namespace hdf5 {
 
 
 NamedEntityHDF5::NamedEntityHDF5(File file, Group group, const string &id, const string &_type)
-    : EntityHDF5(file, group, id)
+    : NamedEntityHDF5(file, group, id, _type, util::getTime())
 {
-    type(_type);
 }
 
 

--- a/src/hdf5/PropertyHDF5.cpp
+++ b/src/hdf5/PropertyHDF5.cpp
@@ -23,7 +23,7 @@ PropertyHDF5::PropertyHDF5(const PropertyHDF5 &property)
 
 
 PropertyHDF5::PropertyHDF5(const File &file, const Group &group, const string &id, const string &type)
-    : NamedEntityHDF5(file, group, id, type)
+    : PropertyHDF5(file, group, id, type, util::getTime())
 {
 }
 

--- a/src/hdf5/RepresentationHDF5.cpp
+++ b/src/hdf5/RepresentationHDF5.cpp
@@ -40,12 +40,8 @@ RepresentationHDF5::RepresentationHDF5(const RepresentationHDF5 &representation)
 
 RepresentationHDF5::RepresentationHDF5(const File &file, const Block &block, const Group &group,
                                        const string &id, DataArray _data, LinkType _link_type)
-    : EntityHDF5(file, group, id), block(block)
+    : RepresentationHDF5(file, block, group, id, _data, _link_type, util::getTime())
 {
-    linkType(_link_type);
-    // TODO: the line below currently throws an exception if the DataArray
-    // is not in block - to consider if we prefer copying it to the block
-    data(_data.id());
 }
 
 

--- a/src/hdf5/SectionHDF5.cpp
+++ b/src/hdf5/SectionHDF5.cpp
@@ -33,10 +33,8 @@ SectionHDF5::SectionHDF5(const File &file, const Group &group, const string &id,
 
 SectionHDF5::SectionHDF5(const File &file, const Section &parent, const Group &group,
                          const string &id, const string &type)
-    : NamedEntityHDF5(file, group, id, type), parent_section(parent)
+    : SectionHDF5(file, parent, group, id, type, util::getTime())
 {
-    property_group = this->group().openGroup("properties");
-    section_group = this->group().openGroup("sections");
 }
 
 

--- a/src/hdf5/SourceHDF5.cpp
+++ b/src/hdf5/SourceHDF5.cpp
@@ -23,9 +23,8 @@ SourceHDF5::SourceHDF5(const SourceHDF5 &source)
 
 
 SourceHDF5::SourceHDF5(File file, Group group, const std::string &id, const string &type)
-    : EntityWithMetadataHDF5(file, group, id, type)
+    : SourceHDF5(file, group, id, type, util::getTime())
 {
-    source_group = group.openGroup("sources");
 }
 
 


### PR DESCRIPTION
Using the new "util::getTime()" function all classes with 2 ctors, one with time and without time as parameter, that are otherwise similar, the timeless ctors now delegate to the ctors with time parameter.
Added some notes to "ReferenceList" class.
