### PR TITLE
Give ImplContainer new base IdContainer storing & checking entity ID

### DIFF
--- a/include/nix/Exception.hpp
+++ b/include/nix/Exception.hpp
@@ -54,6 +54,13 @@ public:
     }
 };
 
+class DetachedEntity : public std::exception {
+public:
+    DetachedEntity() { }
+    const char *what() const NOEXCEPT {
+        return "The ID of the Entity being accessed does not match the stored id anymore!";
+    }
+};
 
 class EmptyString: public std::exception {
 public:


### PR DESCRIPTION
ImplContainer now hase a new base IdContainer that first of all stores the entity ID upon creation and provides a checkID method that compares the stored frontend id with the one returned by the backend.
ImplContainer::backend() now uses this IdContainer::checkID() to make sure that the referenced backend entities IDs never changes. This brings further safety e.g. for future backend implementations that might not care to store the id themselves.
