### PR TITLE
Value: call default constructor in copy constructor

### DIFF
--- a/include/nix/Value.hpp
+++ b/include/nix/Value.hpp
@@ -70,7 +70,7 @@ public:
         set(std::string(value));
     }
 
-    Value(const Value &other) {
+    Value(const Value &other) : Value() {
         assign_variant_from(other);
     }
 


### PR DESCRIPTION
Cf. issue #180, linked valgrind log. 
