### PR TITLE
Make 'name' attribute obligatory

### DIFF
--- a/include/nix/base/INamedEntity.hpp
+++ b/include/nix/base/INamedEntity.hpp
@@ -44,14 +44,9 @@ public:
     /**
      * Getter for the name of the entity.
      *
-     * @return boost::optional<string> The name of the entity.
+     * @return string The name of the entity.
      */
-    virtual boost::optional<std::string> name() const = 0;
-    
-    /**
-     * Deleter for the name of the entity.
-     */
-    virtual void name(const none_t t) = 0;
+    virtual std::string name() const = 0;
     
     /**
      * Setter for the definition of the entity.

--- a/include/nix/base/NamedEntity.hpp
+++ b/include/nix/base/NamedEntity.hpp
@@ -52,14 +52,8 @@ public:
     }
 
 
-    boost::optional<std::string> name() const {
+    std::string name() const {
         return Entity<T>::backend()->name();
-    }
-
-
-    void name(const none_t t)
-    {
-        Entity<T>::backend()->name(t);
     }
     
 

--- a/include/nix/hdf5/BlockHDF5.hpp
+++ b/include/nix/hdf5/BlockHDF5.hpp
@@ -44,8 +44,9 @@ public:
      * @param group     The group that represents the block inside the file.
      * @param id        The id of this block.
      * @param type      The type of this block.
+     * @param name      The name of this block.
      */
-    BlockHDF5(File file, Group group, const std::string &id, const std::string &type);
+    BlockHDF5(File file, Group group, const std::string &id, const std::string &type, const string &name);
 
     /**
      * Standard constructor for a Block.
@@ -54,8 +55,9 @@ public:
      * @param group     The group that represents the block inside the file.
      * @param id        The id of this block.
      * @param type      The type of this block.
+     * @param name      The name of this block.
      */
-    BlockHDF5(File file, Group group, const std::string &id, const std::string &type, time_t time);
+    BlockHDF5(File file, Group group, const std::string &id, const std::string &type, const string &name, time_t time);
 
     //--------------------------------------------------
     // Methods concerning sources

--- a/include/nix/hdf5/DataArrayHDF5.hpp
+++ b/include/nix/hdf5/DataArrayHDF5.hpp
@@ -43,13 +43,13 @@ public:
      * Standard constructor
      */
     DataArrayHDF5(const File &file, const Block &block, const Group &group, 
-                  const std::string &id, const std::string &type);
+                  const std::string &id, const std::string &type, const string &name);
 
     /**
      * Standard constructor that preserves the creation time.
      */
     DataArrayHDF5(const File &file, const Block &block, const Group &group, 
-                  const std::string &id, const std::string &type, time_t time);
+                  const std::string &id, const std::string &type, const string &name, time_t time);
 
     //--------------------------------------------------
     // Element getters and setters

--- a/include/nix/hdf5/DataTagHDF5.hpp
+++ b/include/nix/hdf5/DataTagHDF5.hpp
@@ -35,11 +35,11 @@ public:
 
 
     DataTagHDF5(const File &file, const Block &block, const Group &group, 
-                const std::string &id, const std::string &type, const DataArray _positions);
+                const std::string &id, const std::string &type, const string &name, const DataArray _positions);
 
 
     DataTagHDF5(const File &file, const Block &block, const Group &group, 
-                const std::string &id, const std::string &type, const DataArray _positions, time_t time);
+                const std::string &id, const std::string &type, const string &name, const DataArray _positions, time_t time);
 
 
     DataArray positions() const;

--- a/include/nix/hdf5/EntityWithMetadataHDF5.hpp
+++ b/include/nix/hdf5/EntityWithMetadataHDF5.hpp
@@ -30,13 +30,13 @@ public:
      * Standard constructor
      */
     EntityWithMetadataHDF5(File file, Group group, const std::string &id, 
-                           const string &type);
+                           const string &type, const string &name);
 
     /**
      * Standard constructor that preserves the creation time.
      */
     EntityWithMetadataHDF5(File file, Group group, const std::string &id, 
-                           const string &type, time_t time);
+                           const string &type, const string &name, time_t time);
 
 
     Section metadata() const;

--- a/include/nix/hdf5/EntityWithSourcesHDF5.hpp
+++ b/include/nix/hdf5/EntityWithSourcesHDF5.hpp
@@ -34,13 +34,13 @@ public:
      * Standard constructor.
      */
     EntityWithSourcesHDF5(File file, Block block, Group group, const std::string &id, 
-                          const string &type);
+                          const string &type, const string &name);
 
     /**
      * Standard constructor that preserves the creation time.
      */
     EntityWithSourcesHDF5(File file, Block block, Group group, const std::string &id, 
-                          const string &type, time_t time);
+                          const string &type, const string &name, time_t time);
 
     /**
      * Get the number of sources associated with this entity.

--- a/include/nix/hdf5/NamedEntityHDF5.hpp
+++ b/include/nix/hdf5/NamedEntityHDF5.hpp
@@ -30,12 +30,12 @@ public:
     /**
      * Standard constructor
      */
-    NamedEntityHDF5(File file, Group group, const std::string &id, const string &_type);
+    NamedEntityHDF5(File file, Group group, const std::string &id, const string &_type, const string &_name);
 
     /**
      * Standard constructor that preserves the creation time.
      */
-    NamedEntityHDF5(File file, Group group, const std::string &id, const string &_type, time_t time);
+    NamedEntityHDF5(File file, Group group, const std::string &id, const string &_type, const string &_name, time_t time);
 
 
     void type(const std::string &type);
@@ -47,10 +47,7 @@ public:
     void name(const std::string &name);
 
 
-    boost::optional<std::string> name() const;
-    
-    
-    void name(const none_t t);
+    std::string name() const;
     
 
     boost::optional<std::string> definition() const;

--- a/include/nix/hdf5/PropertyHDF5.hpp
+++ b/include/nix/hdf5/PropertyHDF5.hpp
@@ -27,10 +27,10 @@ public:
     PropertyHDF5(const PropertyHDF5 &property);
 
 
-    PropertyHDF5(const File &file, const Group &group,const std::string &id, const string &type);
+    PropertyHDF5(const File &file, const Group &group,const std::string &id, const string &type, const string &name);
 
 
-    PropertyHDF5(const File &file, const Group &group,const std::string &id, const string &type, time_t time);
+    PropertyHDF5(const File &file, const Group &group,const std::string &id, const string &type, const string &name, time_t time);
 
     
     // TODO: include methods are not implemented!

--- a/include/nix/hdf5/SectionHDF5.hpp
+++ b/include/nix/hdf5/SectionHDF5.hpp
@@ -37,25 +37,25 @@ public:
      * Standard constructor
      */
     SectionHDF5(const File &file, const Group &group, const string &id, 
-                const string &type);
+                const string &type, const string &name);
 
     /**
      * Standard constructor with parent.
      */
     SectionHDF5(const File &file, const Section &parent, const Group &group,
-                const string &id, const string &type);
+                const string &id, const string &type, const string &name);
 
     /**
      * Constructor that preserves the creation time.
      */
     SectionHDF5(const File &file, const Group &group, const string &id, 
-                const string &type, time_t time);
+                const string &type, const string &name, time_t time);
 
     /**
      * Constructor with parent that preserves the creation time.
      */
     SectionHDF5(const File &file, const Section &parent, const Group &group,
-                const string &id, const string &type, time_t time);
+                const string &id, const string &type, const string &name, time_t time);
 
 
     //--------------------------------------------------

--- a/include/nix/hdf5/SimpleTagHDF5.hpp
+++ b/include/nix/hdf5/SimpleTagHDF5.hpp
@@ -45,13 +45,13 @@ public:
      * Standard constructor
      */
     SimpleTagHDF5(const File &file, const Block &block, const Group &group, const std::string &id, 
-                  const string &type, const std::vector<DataArray> &refs);
+                  const string &type, const string &name, const std::vector<DataArray> &refs);
 
     /**
      * Standard constructor that preserves the creation time.
      */
     SimpleTagHDF5(const File &file, const Block &block, const Group &group, const std::string &id, 
-                  const string &type, const std::vector<DataArray> &refs, const time_t time);
+                  const string &type, const string &name, const std::vector<DataArray> &refs, const time_t time);
 
 
     std::vector<std::string> units() const;

--- a/include/nix/hdf5/SourceHDF5.hpp
+++ b/include/nix/hdf5/SourceHDF5.hpp
@@ -39,12 +39,12 @@ public:
     /**
      * Default constructor.
      */
-    SourceHDF5(File file, Group group, const std::string &id, const string &type);
+    SourceHDF5(File file, Group group, const std::string &id, const string &type, const string &name);
 
     /**
      * Default constructor that preserves the creation time.
      */
-    SourceHDF5(File file, Group group, const std::string &id, const string &type, time_t time);
+    SourceHDF5(File file, Group group, const std::string &id, const string &type, const string &name, time_t time);
 
     //--------------------------------------------------
     // Methods concerning child sources

--- a/src/hdf5/DataArrayHDF5.cpp
+++ b/src/hdf5/DataArrayHDF5.cpp
@@ -18,22 +18,22 @@ namespace nix {
 namespace hdf5 {
 
 DataArrayHDF5::DataArrayHDF5(const DataArrayHDF5 &data_array)
-    : EntityWithSourcesHDF5(data_array.file(), data_array.block(), data_array.group(), data_array.id(), data_array.type()),
+    : EntityWithSourcesHDF5(data_array.file(), data_array.block(), data_array.group(), data_array.id(), data_array.type(), data_array.name()),
       dimension_group(data_array.dimension_group)
 {
 }
 
 
 DataArrayHDF5::DataArrayHDF5(const File &file, const Block &block, const Group &group, 
-                             const string &id, const string &type)
-    : DataArrayHDF5(file, block, group, id, type, util::getTime())
+                             const string &id, const string &type, const string &name)
+    : DataArrayHDF5(file, block, group, id, type, name, util::getTime())
 {
 }
 
 
 DataArrayHDF5::DataArrayHDF5(const File &file, const Block &block, const Group &group, 
-                             const string &id, const string &type, time_t time)
-    : EntityWithSourcesHDF5(file, block, group, id, type, time)
+                             const string &id, const string &type, const string &name, time_t time)
+    : EntityWithSourcesHDF5(file, block, group, id, type, name, time)
 {
     dimension_group = this->group().openGroup("dimensions", true);
 }

--- a/src/hdf5/DataTagHDF5.cpp
+++ b/src/hdf5/DataTagHDF5.cpp
@@ -18,7 +18,7 @@ namespace hdf5 {
 
 
 DataTagHDF5::DataTagHDF5(const DataTagHDF5 &tag)
-    : EntityWithSourcesHDF5(tag.file(), tag.block(), tag.group(), tag.id(), tag.type()),
+    : EntityWithSourcesHDF5(tag.file(), tag.block(), tag.group(), tag.id(), tag.type(), tag.name()),
       reference_list(tag.reference_list)
 {
     representation_group = tag.representation_group;
@@ -27,15 +27,15 @@ DataTagHDF5::DataTagHDF5(const DataTagHDF5 &tag)
 
 
 DataTagHDF5::DataTagHDF5(const File &file, const Block &block, const Group &group, 
-                         const string &id, const std::string &type, const DataArray _positions)
-    : DataTagHDF5(file, block, group, id, type, _positions, util::getTime())
+                         const string &id, const std::string &type, const string &name, const DataArray _positions)
+    : DataTagHDF5(file, block, group, id, type, name, _positions, util::getTime())
 {
 }
 
 
 DataTagHDF5::DataTagHDF5(const File &file, const Block &block, const Group &group,
-                         const std::string &id, const std::string &type, const DataArray _positions, time_t time)
-    : EntityWithSourcesHDF5(file, block, group, id, type, time), reference_list(group, "references")
+                         const std::string &id, const std::string &type, const string &name, const DataArray _positions, time_t time)
+    : EntityWithSourcesHDF5(file, block, group, id, type, name, time), reference_list(group, "references")
 {
     representation_group = this->group().openGroup("representations");
     // TODO: the line below currently throws an exception if positions is

--- a/src/hdf5/EntityWithMetadataHDF5.cpp
+++ b/src/hdf5/EntityWithMetadataHDF5.cpp
@@ -15,14 +15,14 @@ namespace nix {
 namespace hdf5 {
 
 
-EntityWithMetadataHDF5::EntityWithMetadataHDF5(File file, Group group, const string &id, const string &type)
-    : EntityWithMetadataHDF5(file, group, id, type, util::getTime())
+EntityWithMetadataHDF5::EntityWithMetadataHDF5(File file, Group group, const string &id, const string &type, const string &name)
+    : EntityWithMetadataHDF5(file, group, id, type, name, util::getTime())
 {
 }
 
 
-EntityWithMetadataHDF5::EntityWithMetadataHDF5(File file, Group group, const string &id, const string &type, time_t time)
-    : NamedEntityHDF5(file, group, id, type, time)
+EntityWithMetadataHDF5::EntityWithMetadataHDF5(File file, Group group, const string &id, const string &type, const string &name, time_t time)
+    : NamedEntityHDF5(file, group, id, type, name, time)
 {
 }
 

--- a/src/hdf5/EntityWithSourcesHDF5.cpp
+++ b/src/hdf5/EntityWithSourcesHDF5.cpp
@@ -18,16 +18,16 @@ namespace hdf5 {
 
 EntityWithSourcesHDF5::EntityWithSourcesHDF5
                     (File file, Block block, Group group, const string &id, 
-                     const string &type)
-    : EntityWithSourcesHDF5(file, block, group, id, type, util::getTime())
+                     const string &type, const string &name)
+    : EntityWithSourcesHDF5(file, block, group, id, type, name, util::getTime())
 {
 }
 
 
 EntityWithSourcesHDF5::EntityWithSourcesHDF5
                        (File file, Block block, Group group, const string &id, 
-                        const string &type, time_t time)
-    : EntityWithMetadataHDF5(file, group, id, type, time), entity_block(block), sources_refs(group, "sources")
+                        const string &type, const string &name, time_t time)
+    : EntityWithMetadataHDF5(file, group, id, type, name, time), entity_block(block), sources_refs(group, "sources")
 {
 }
 

--- a/src/hdf5/FileHDF5.cpp
+++ b/src/hdf5/FileHDF5.cpp
@@ -80,8 +80,10 @@ Block FileHDF5::getBlock(const std::string &id) const {
     if(hasBlock(id)) {
         Group group = data.openGroup(id, false);
         std::string type;
+        std::string name;
         group.getAttr("type", type);
-        shared_ptr<BlockHDF5> ptr(new BlockHDF5(file(), group, id, type));
+        group.getAttr("name", name);
+        shared_ptr<BlockHDF5> ptr(new BlockHDF5(file(), group, id, type, name));
         return Block(ptr);
     } else {
         return Block();
@@ -103,9 +105,8 @@ Block FileHDF5::createBlock(const std::string &name, const string &type) {
     }
         
     Group group = data.openGroup(id, true);
-    shared_ptr<BlockHDF5> ptr(new BlockHDF5(file(), group, id, type));
+    shared_ptr<BlockHDF5> ptr(new BlockHDF5(file(), group, id, type, name));
     Block b(ptr);
-    b.name(name);
     
     return b;
 }
@@ -135,8 +136,10 @@ Section FileHDF5::getSection(const std::string &id) const {
     if(hasSection(id)) {
         Group group = metadata.openGroup(id, false);
         std::string type;
+        std::string name;
         group.getAttr("type", type);
-        shared_ptr<SectionHDF5> ptr(new SectionHDF5(file(), group, id, type));
+        group.getAttr("name", name);
+        shared_ptr<SectionHDF5> ptr(new SectionHDF5(file(), group, id, type, name));
         return Section(ptr);
     } else {
         return Section();
@@ -154,9 +157,8 @@ Section FileHDF5::createSection(const string &name, const  string &type) {
     string id = util::createId("section");
     while(metadata.hasObject(id))
         id = util::createId("section");
-    shared_ptr<SectionHDF5> ptr(new SectionHDF5(file(), metadata.openGroup(id, true), id, type));
+    shared_ptr<SectionHDF5> ptr(new SectionHDF5(file(), metadata.openGroup(id, true), id, type, name));
     Section section(ptr);
-    section.name(name);
     return section;
 }
 

--- a/src/hdf5/NamedEntityHDF5.cpp
+++ b/src/hdf5/NamedEntityHDF5.cpp
@@ -17,16 +17,17 @@ namespace nix {
 namespace hdf5 {
 
 
-NamedEntityHDF5::NamedEntityHDF5(File file, Group group, const string &id, const string &_type)
-    : NamedEntityHDF5(file, group, id, _type, util::getTime())
+NamedEntityHDF5::NamedEntityHDF5(File file, Group group, const string &id, const string &_type, const string &_name)
+    : NamedEntityHDF5(file, group, id, _type, _name, util::getTime())
 {
 }
 
 
-NamedEntityHDF5::NamedEntityHDF5(File file, Group group, const string &id, const string &_type, time_t time)
+NamedEntityHDF5::NamedEntityHDF5(File file, Group group, const string &id, const string &_type, const string &_name, time_t time)
     : EntityHDF5(file, group, id, time)
 {
     type(_type);
+    name(_name);
 }
 
 
@@ -63,20 +64,14 @@ void NamedEntityHDF5::name(const string &name) {
 }
 
 
-optional<string> NamedEntityHDF5::name() const {
-    optional<string> ret;
+string NamedEntityHDF5::name() const {
     string name;
-    group().getAttr("name", name);
-    ret = name;
-    return ret;
-}
-
-
-void NamedEntityHDF5::name(const none_t t) {
     if(group().hasAttr("name")) {
-        group().removeAttr("name");
+        group().getAttr("name", name);
+        return name;
+    } else {
+        throw MissingAttr("name");
     }
-    forceUpdatedAt();
 }
 
 
@@ -110,8 +105,8 @@ void NamedEntityHDF5::definition(const none_t t) {
 
 int NamedEntityHDF5::compare(const INamedEntity &other) const {
     int cmp = 0;
-    if (name() && other.name()) {
-        cmp = (*name()).compare(*other.name());
+    if (!name().empty() && !other.name().empty()) {
+        cmp = (name()).compare(other.name());
     }
     if (cmp == 0) {
         cmp = id().compare(other.id());

--- a/src/hdf5/PropertyHDF5.cpp
+++ b/src/hdf5/PropertyHDF5.cpp
@@ -17,19 +17,19 @@ namespace hdf5 {
 
 
 PropertyHDF5::PropertyHDF5(const PropertyHDF5 &property)
-    : NamedEntityHDF5(property.file(), property.group(), property.id(), property.type())
+    : NamedEntityHDF5(property.file(), property.group(), property.id(), property.type(), property.name())
 {
 }
 
 
-PropertyHDF5::PropertyHDF5(const File &file, const Group &group, const string &id, const string &type)
-    : PropertyHDF5(file, group, id, type, util::getTime())
+PropertyHDF5::PropertyHDF5(const File &file, const Group &group, const string &id, const string &type, const string &name)
+    : PropertyHDF5(file, group, id, type, name, util::getTime())
 {
 }
 
 
-PropertyHDF5::PropertyHDF5(const File &file, const Group &group, const string &id, const string &type, time_t time)
-    : NamedEntityHDF5(file, group, id, type, time)
+PropertyHDF5::PropertyHDF5(const File &file, const Group &group, const string &id, const string &type, const string &name, time_t time)
+    : NamedEntityHDF5(file, group, id, type, name, time)
 {
 }
 

--- a/src/hdf5/SectionHDF5.cpp
+++ b/src/hdf5/SectionHDF5.cpp
@@ -17,7 +17,7 @@ namespace hdf5 {
 
 
 SectionHDF5::SectionHDF5(const SectionHDF5 &section)
-    : NamedEntityHDF5(section.file(), section.group(), section.id(), section.type())
+    : NamedEntityHDF5(section.file(), section.group(), section.id(), section.type(), section.name())
 {
     property_group = section.property_group;
     section_group = section.section_group;
@@ -25,29 +25,29 @@ SectionHDF5::SectionHDF5(const SectionHDF5 &section)
 
 
 SectionHDF5::SectionHDF5(const File &file, const Group &group, const string &id, 
-                         const string &type)
-    : SectionHDF5(file, nullptr, group, id, type)
+                         const string &type, const string &name)
+    : SectionHDF5(file, nullptr, group, id, type, name)
 {
 }
 
 
 SectionHDF5::SectionHDF5(const File &file, const Section &parent, const Group &group,
-                         const string &id, const string &type)
-    : SectionHDF5(file, parent, group, id, type, util::getTime())
+                         const string &id, const string &type, const string &name)
+    : SectionHDF5(file, parent, group, id, type, name, util::getTime())
 {
 }
 
 
 SectionHDF5::SectionHDF5(const File &file, const Group &group, const string &id, 
-                         const string &type, time_t time)
-    : SectionHDF5(file, nullptr, group, id, type, time)
+                         const string &type, const string &name, time_t time)
+    : SectionHDF5(file, nullptr, group, id, type, name, time)
 {
 }
 
 
 SectionHDF5::SectionHDF5(const File &file, const Section &parent, const Group &group,
-                         const string &id, const string &type, time_t time)
-    : NamedEntityHDF5(file, group, id, type, time), parent_section(parent)
+                         const string &id, const string &type, const string &name, time_t time)
+    : NamedEntityHDF5(file, group, id, type, name, time), parent_section(parent)
 {
     property_group = this->group().openGroup("properties");
     section_group = this->group().openGroup("sections");
@@ -180,8 +180,10 @@ Section SectionHDF5::getSection(const string &id) const {
     if (section_group.hasGroup(id)) {
         Group group = section_group.openGroup(id, false);
         std::string type;
+        std::string name;
         group.getAttr("type", type);
-        auto tmp = make_shared<SectionHDF5>(file(), group, id, type);
+        group.getAttr("name", name);
+        auto tmp = make_shared<SectionHDF5>(file(), group, id, type, name);
         return Section(tmp);
     } else {
         return Section();
@@ -206,8 +208,7 @@ Section SectionHDF5::createSection(const string &name, const string &type) {
     Section parent(const_pointer_cast<SectionHDF5>(shared_from_this()));
 
     Group grp = section_group.openGroup(new_id, true);
-    auto tmp = make_shared<SectionHDF5>(file(), parent, grp, new_id, type);
-    tmp->name(name);
+    auto tmp = make_shared<SectionHDF5>(file(), parent, grp, new_id, type, name);
 
     return Section(tmp);
 }
@@ -243,8 +244,10 @@ Property SectionHDF5::getProperty(const string &id) const {
     if (property_group.hasGroup(id)) {
         Group group = property_group.openGroup(id, false);
         string type;
+        string name;
         group.getAttr("type", type);
-        auto tmp = make_shared<PropertyHDF5>(file(), group, id, type);
+        group.getAttr("name", name);
+        auto tmp = make_shared<PropertyHDF5>(file(), group, id, type, name);
         return Property(tmp);
     } else {
         return Property();
@@ -292,7 +295,7 @@ Property SectionHDF5::getPropertyByName(const string &name) const {
         if (other_name == name) {
             string type;
             grp.getAttr("type", type);
-            auto tmp = make_shared<PropertyHDF5>(file(), grp, id, type);
+            auto tmp = make_shared<PropertyHDF5>(file(), grp, id, type, name);
             prop = Property(tmp);
             break;
         }
@@ -314,8 +317,7 @@ Property SectionHDF5::createProperty(const string &name, const string &type) {
 
     Group grp = property_group.openGroup(new_id, true);
 
-    auto tmp = make_shared<PropertyHDF5>(file(), grp, new_id, type);
-    tmp->name(name);
+    auto tmp = make_shared<PropertyHDF5>(file(), grp, new_id, type, name);
 
     return Property(tmp);
 }

--- a/src/hdf5/SimpleTagHDF5.cpp
+++ b/src/hdf5/SimpleTagHDF5.cpp
@@ -19,7 +19,7 @@ namespace nix {
 namespace hdf5 {
 
 SimpleTagHDF5::SimpleTagHDF5(const SimpleTagHDF5 &tag)
-    : EntityWithSourcesHDF5(tag.file(), tag.block(), tag.group(), tag.id(), tag.type()),
+    : EntityWithSourcesHDF5(tag.file(), tag.block(), tag.group(), tag.id(), tag.type(), tag.name()),
       references_list(tag.group(), "references")
 {
     representation_group = tag.representation_group;
@@ -27,15 +27,15 @@ SimpleTagHDF5::SimpleTagHDF5(const SimpleTagHDF5 &tag)
 
 
 SimpleTagHDF5::SimpleTagHDF5(const File &file, const Block &block, const Group &group, const string &id, 
-                             const string &type, const std::vector<DataArray> &refs)
-    : SimpleTagHDF5(file, block, group, id, type, refs, util::getTime())
+                             const string &type, const string &name, const std::vector<DataArray> &refs)
+    : SimpleTagHDF5(file, block, group, id, type, name, refs, util::getTime())
 {
 }
 
 
 SimpleTagHDF5::SimpleTagHDF5(const File &file, const Block &block, const Group &group, const string &id, 
-                             const string &type, const std::vector<DataArray> &refs, const time_t time)
-    : EntityWithSourcesHDF5(file, block, group, id, type, time), references_list(group, "references")
+                             const string &type, const string &name, const std::vector<DataArray> &refs, const time_t time)
+    : EntityWithSourcesHDF5(file, block, group, id, type, name, time), references_list(group, "references")
 {
     representation_group = group.openGroup("representations");
     

--- a/src/hdf5/SourceHDF5.cpp
+++ b/src/hdf5/SourceHDF5.cpp
@@ -16,20 +16,20 @@ namespace hdf5 {
 
 
 SourceHDF5::SourceHDF5(const SourceHDF5 &source)
-    : EntityWithMetadataHDF5(source.file(), source.group(), source.id(), source.type())
+    : EntityWithMetadataHDF5(source.file(), source.group(), source.id(), source.type(), source.name())
 {
     source_group = source.source_group;
 }
 
 
-SourceHDF5::SourceHDF5(File file, Group group, const std::string &id, const string &type)
-    : SourceHDF5(file, group, id, type, util::getTime())
+SourceHDF5::SourceHDF5(File file, Group group, const std::string &id, const string &type, const string &name)
+    : SourceHDF5(file, group, id, type, name, util::getTime())
 {
 }
 
 
-SourceHDF5::SourceHDF5(File file, Group group, const std::string &id, const string &type, time_t time)
-    : EntityWithMetadataHDF5(file, group, id, type, time)
+SourceHDF5::SourceHDF5(File file, Group group, const std::string &id, const string &type, const string &name, time_t time)
+    : EntityWithMetadataHDF5(file, group, id, type, name, time)
 {
     source_group = group.openGroup("sources");
 }
@@ -43,9 +43,11 @@ bool SourceHDF5::hasSource(const string &id) const {
 Source SourceHDF5::getSource(const string &id) const {
     if(source_group.hasGroup(id)) {
         Group group = source_group.openGroup(id, false);
-        std::string type;
+        string type;
+        string name;
         group.getAttr("type", type);
-        shared_ptr<SourceHDF5> tmp = make_shared<SourceHDF5>(file(), group, id, type);
+        group.getAttr("name", name);
+        shared_ptr<SourceHDF5> tmp = make_shared<SourceHDF5>(file(), group, id, type, name);
         return Source(tmp);
     } else {
         return Source();
@@ -73,8 +75,7 @@ Source SourceHDF5::createSource(const string &name, const string &type) {
     }
 
     Group grp = source_group.openGroup(id, true);
-    shared_ptr<SourceHDF5> tmp = make_shared<SourceHDF5>(file(), grp, id, type);
-    tmp->name(name);
+    shared_ptr<SourceHDF5> tmp = make_shared<SourceHDF5>(file(), grp, id, type, name);
 
     return Source(tmp);
 }

--- a/test/TestBlock.cpp
+++ b/test/TestBlock.cpp
@@ -38,10 +38,10 @@ void TestBlock::testId() {
 
 
 void TestBlock::testName() {
-    CPPUNIT_ASSERT(*block.name() == "block_one");
+    CPPUNIT_ASSERT(block.name() == "block_one");
     string name = util::createId("", 32);
     block.name(name);
-    CPPUNIT_ASSERT(*block.name() == name);
+    CPPUNIT_ASSERT(block.name() == name);
 }
 
 

--- a/test/TestDataArray.cpp
+++ b/test/TestDataArray.cpp
@@ -33,10 +33,10 @@ void TestDataArray::testId() {
 
 
 void TestDataArray::testName() {
-    CPPUNIT_ASSERT(*array1.name() == "array_one");
+    CPPUNIT_ASSERT(array1.name() == "array_one");
     std::string name = nix::util::createId("", 32);
     array1.name(name);
-    CPPUNIT_ASSERT(*array1.name() == name);
+    CPPUNIT_ASSERT(array1.name() == name);
     array1.label(boost::none);
     CPPUNIT_ASSERT(*array1.label() == "");
 }

--- a/test/TestDataTag.cpp
+++ b/test/TestDataTag.cpp
@@ -59,12 +59,10 @@ void TestDataTag::testId() {
 
 
 void TestDataTag::testName() {
-    CPPUNIT_ASSERT(*tag.name() == "tag_one");
+    CPPUNIT_ASSERT(tag.name() == "tag_one");
     std::string name = util::createId("", 32);
     tag.name(name);
-    CPPUNIT_ASSERT(*tag.name() == name);
-    tag.name(none);
-    CPPUNIT_ASSERT(*tag.name() == "");
+    CPPUNIT_ASSERT(tag.name() == name);
 }
 
 

--- a/test/TestEntity.cpp
+++ b/test/TestEntity.cpp
@@ -33,10 +33,10 @@ void TestEntity::testId() {
 
 
 void TestEntity::testName() {
-    CPPUNIT_ASSERT(*block.name() == "block_one");
+    CPPUNIT_ASSERT(block.name() == "block_one");
     string name = util::createId("", 32);
     block.name(name);
-    CPPUNIT_ASSERT(*block.name() == name);
+    CPPUNIT_ASSERT(block.name() == name);
 }
 
 

--- a/test/TestProperty.cpp
+++ b/test/TestProperty.cpp
@@ -43,12 +43,10 @@ void TestProperty::testId() {
 
 
 void TestProperty::testName() {
-    CPPUNIT_ASSERT(*property.name() == "prop");
+    CPPUNIT_ASSERT(property.name() == "prop");
     string name = util::createId("", 32);
     property.name(name);
-    CPPUNIT_ASSERT(*property.name() == name);
-    property.name(none);
-    CPPUNIT_ASSERT(*property.name() == "");
+    CPPUNIT_ASSERT(property.name() == name);
 }
 
 

--- a/test/TestSection.cpp
+++ b/test/TestSection.cpp
@@ -34,12 +34,10 @@ void TestSection::testId() {
 
 
 void TestSection::testName() {
-    CPPUNIT_ASSERT(*section.name() == "section");
+    CPPUNIT_ASSERT(section.name() == "section");
     string name = util::createId("", 32);
     section.name(name);
-    CPPUNIT_ASSERT(*section.name() == name);
-    section.name(boost::none);
-    CPPUNIT_ASSERT(*section.name() == "");
+    CPPUNIT_ASSERT(section.name() == name);
 }
 
 

--- a/test/TestSimpleTag.cpp
+++ b/test/TestSimpleTag.cpp
@@ -50,12 +50,10 @@ void TestSimpleTag::testId() {
 
 
 void TestSimpleTag::testName() {
-    CPPUNIT_ASSERT(*tag.name() == "tag_one");
+    CPPUNIT_ASSERT(tag.name() == "tag_one");
     std::string name = util::createId("", 32);
     tag.name(name);
-    CPPUNIT_ASSERT(*tag.name() == name);
-    tag.name(none);
-    CPPUNIT_ASSERT(*tag.name() == "");
+    CPPUNIT_ASSERT(tag.name() == name);
 }
 
 

--- a/test/TestSource.cpp
+++ b/test/TestSource.cpp
@@ -38,10 +38,10 @@ void TestSource::testId() {
 
 
 void TestSource::testName() {
-    CPPUNIT_ASSERT(*source.name() == "source_one");
+    CPPUNIT_ASSERT(source.name() == "source_one");
     string name = util::createId("", 32);
     source.name(name);
-    CPPUNIT_ASSERT(*source.name() == name);
+    CPPUNIT_ASSERT(source.name() == name);
 }
 
 


### PR DESCRIPTION
Name is now fully obligatory, being required in all relevant ctors and being supplied in all relevant tests.
'none_t-deleter' for name removed, getter adopted to throw error if name missing, setter to throw error on empty string. Fixes #193 & #192.
