### PR TITLE
renaming of data related methods in DataArray

### DIFF
--- a/include/nix/DataArray.hpp
+++ b/include/nix/DataArray.hpp
@@ -342,16 +342,16 @@ public:
         backend()->write(dtype, data, count, offset);
     }
 
-    NDSize getDataExtent() const {
-        return backend()->getExtent();
+    NDSize dataExtent() const {
+        return backend()->dataExtent();
     }
 
-    void setDataExtent(const NDSize &extent) {
-        backend()->setExtent(extent);
+    void dataExtent(const NDSize &extent) {
+        backend()->dataExtent(extent);
     }
 
-    DataType getDataType(void) const {
-        return backend()->getDataType();
+    DataType dataType(void) const {
+        return backend()->dataType();
     }
 
  };
@@ -370,7 +370,7 @@ void DataArray::getData(T &value) const
 {
     Hydra<T> hydra(value);
 
-    NDSize extent = backend()->getExtent();
+    NDSize extent = backend()->dataExtent();
     hydra.resize(extent);
 
     DataType dtype = hydra.element_data_type();
@@ -390,7 +390,7 @@ void DataArray::setData(const T &value)
     if(!backend()->hasData()) { 
         backend()->createData(dtype, shape);
     }
-    backend()->setExtent(shape);
+    backend()->dataExtent(shape);
     backend()->write(dtype, hydra.data(), shape, {});
 }
 

--- a/include/nix/base/IDataArray.hpp
+++ b/include/nix/base/IDataArray.hpp
@@ -156,10 +156,10 @@ public:
     virtual void write(DataType dtype, const void *data, const NDSize &count, const NDSize &offset) = 0;
     virtual void read(DataType dtype, void *buffer, const NDSize &count, const NDSize &offset) const = 0;
 
-    virtual NDSize getExtent(void) const = 0;
-    virtual void   setExtent(const NDSize &extent) = 0;
+    virtual NDSize dataExtent(void) const = 0;
+    virtual void   dataExtent(const NDSize &extent) = 0;
 
-    virtual DataType getDataType(void) const = 0;
+    virtual DataType dataType(void) const = 0;
 
     // TODO add missing methods
 

--- a/include/nix/hdf5/DataArrayHDF5.hpp
+++ b/include/nix/hdf5/DataArrayHDF5.hpp
@@ -142,10 +142,10 @@ public:
     void write(DataType dtype, const void *data, const NDSize &count, const NDSize &offset);
     void read(DataType dtype, void *buffer, const NDSize &count, const NDSize &offset) const;
 
-    NDSize getExtent(void) const;
-    void   setExtent(const NDSize &extent);
+    NDSize dataExtent(void) const;
+    void   dataExtent(const NDSize &extent);
 
-    DataType getDataType(void) const;
+    DataType dataType(void) const;
 };
 
 

--- a/src/hdf5/DataArrayHDF5.cpp
+++ b/src/hdf5/DataArrayHDF5.cpp
@@ -378,7 +378,7 @@ void DataArrayHDF5::read(DataType dtype, void *data, const NDSize &count, const 
 
 }
 
-NDSize DataArrayHDF5::getExtent(void) const
+NDSize DataArrayHDF5::dataExtent(void) const
 {
     if (!group().hasData("data")) {
         return NDSize{};
@@ -388,7 +388,7 @@ NDSize DataArrayHDF5::getExtent(void) const
     return ds.size();
 }
 
-void DataArrayHDF5::setExtent(const NDSize &extent)
+void DataArrayHDF5::dataExtent(const NDSize &extent)
 {
     if (!group().hasData("data")) {
         throw runtime_error("Data field not found in DataArray!");
@@ -398,7 +398,7 @@ void DataArrayHDF5::setExtent(const NDSize &extent)
     ds.setExtent(extent);
 }
 
-DataType DataArrayHDF5::getDataType(void) const
+DataType DataArrayHDF5::dataType(void) const
 {
     if (!group().hasData("data")) {
         //we could also throw an exception but I think returning

--- a/src/hdf5/DataTagHDF5.cpp
+++ b/src/hdf5/DataTagHDF5.cpp
@@ -281,7 +281,7 @@ ostream& operator<<(ostream &out, const DataTagHDF5 &ent) {
 
 
 bool DataTagHDF5::checkDimensions(const DataArray &a, const DataArray &b)const {
-    return a.getDataExtent() == b.getDataExtent();
+    return a.dataExtent() == b.dataExtent();
 }
 
 

--- a/src/util/dataAccess.cpp
+++ b/src/util/dataAccess.cpp
@@ -138,8 +138,8 @@ void getOffsetAndCount(const SimpleTag &tag, const DataArray &array, NDSize &off
 void getOffsetAndCount(const DataTag &tag, const DataArray &array, size_t index, NDSize &offsets, NDSize &counts) {
     DataArray positions = tag.positions();
     DataArray extents = tag.extents();
-    NDSize position_extent = positions.getDataExtent();
-    NDSize extent_extent = extents.getDataExtent();
+    NDSize position_extent = positions.dataExtent();
+    NDSize extent_extent = extents.dataExtent();
     size_t dimension_count = array.dimensionCount();
 
     if (index >= position_extent[0] || index >= extent_extent[0]) {
@@ -150,8 +150,8 @@ void getOffsetAndCount(const DataTag &tag, const DataArray &array, size_t index,
     }
     NDSize temp_offset = NDSize{static_cast<NDSize::value_type>(index), static_cast<NDSize::value_type>(0)};
     NDSize temp_count{static_cast<NDSize::value_type>(1), static_cast<NDSize::value_type>(dimension_count)};
-    NDArray offset(positions.getDataType(), temp_count);
-    NDArray extent(extents.getDataType(), temp_count);
+    NDArray offset(positions.dataType(), temp_count);
+    NDArray extent(extents.dataType(), temp_count);
     positions.getData(offset, temp_count, temp_offset);
     extents.getData(extent, temp_count, temp_offset);
 
@@ -182,7 +182,7 @@ void getOffsetAndCount(const DataTag &tag, const DataArray &array, size_t index,
 
 
 bool positionInData(const DataArray &data, const NDSize &position) {
-    NDSize data_size = data.getDataExtent();
+    NDSize data_size = data.dataExtent();
     bool valid = true;
 
     if (!(data_size.size() == position.size())) {
@@ -209,16 +209,16 @@ NDArray retrieveData(const DataTag &tag, size_t position_index, size_t reference
     if (refs.size() == 0) {
         throw nix::OutOfBounds("There are no references in this tag!", 0);
     }
-    if (position_index >= positions.getDataExtent()[0] ||
-        (extents && position_index >= extents.getDataExtent()[0])) {
+    if (position_index >= positions.dataExtent()[0] ||
+        (extents && position_index >= extents.dataExtent()[0])) {
         throw nix::OutOfBounds("Index out of bounds of positions or extents!", 0);
     }
     if (!(reference_index < tag.referenceCount())) {
         throw nix::OutOfBounds("Reference index out of bounds.", 0);
     }
     size_t dimension_count = refs[reference_index].dimensionCount();
-    if (positions.getDataExtent()[1] > dimension_count ||
-        (extents &&extents.getDataExtent()[1] > dimension_count)) {
+    if (positions.dataExtent()[1] > dimension_count ||
+        (extents &&extents.dataExtent()[1] > dimension_count)) {
         throw nix::IncompatibleDimensions("Number of dimensions in position or extent do not match dimensionality of data","util::retrieveData");
     }
 
@@ -227,7 +227,7 @@ NDArray retrieveData(const DataTag &tag, size_t position_index, size_t reference
     if (!positionAndExtentInData(refs[reference_index], offset, count)) {
         throw nix::OutOfBounds("References data slice out of the extent of the DataArray!", 0);
     }
-    NDArray data(refs[reference_index].getDataType(), count);
+    NDArray data(refs[reference_index].dataType(), count);
     refs[reference_index].getData(data, count, offset);
     return data;
 }
@@ -253,7 +253,7 @@ NDArray retrieveData(const SimpleTag &tag, size_t reference_index) {
     if (!positionAndExtentInData(refs[reference_index], offset, count)) {
         throw nix::OutOfBounds("Referenced data slice out of the extent of the DataArray!", 0);
     }
-    NDArray data(refs[reference_index].getDataType(), count);
+    NDArray data(refs[reference_index].dataType(), count);
     refs[reference_index].getData(data, count, offset);
     return data;
 }

--- a/test/TestDataArray.cpp
+++ b/test/TestDataArray.cpp
@@ -72,15 +72,15 @@ void TestDataArray::testData()
                 A[i][j][k] = values++;
 
     CPPUNIT_ASSERT_EQUAL(array1.hasData(), false);
-    CPPUNIT_ASSERT_EQUAL(array1.getDataType(), nix::DataType::Nothing);
-    CPPUNIT_ASSERT(array1.getDataExtent() == nix::NDSize{});
+    CPPUNIT_ASSERT_EQUAL(array1.dataType(), nix::DataType::Nothing);
+    CPPUNIT_ASSERT(array1.dataExtent() == nix::NDSize{});
     CPPUNIT_ASSERT(array1.getDimension(1) == false);
     array1.createData(A, {3, 4, 2});
     CPPUNIT_ASSERT_EQUAL(array1.hasData(), true);
     array1.setData(A);
     
     //test the getDataType() function
-    nix::DataType dtype = array1.getDataType();
+    nix::DataType dtype = array1.dataType();
     CPPUNIT_ASSERT_EQUAL(dtype, nix::DataType::Double);
 
     array_type B(boost::extents[1][1][1]);
@@ -111,11 +111,11 @@ void TestDataArray::testData()
     CPPUNIT_ASSERT_EQUAL(array2.hasData(), false);
     array2.createData(C, {20, 20});
     CPPUNIT_ASSERT_EQUAL(array2.hasData(), true);
-    CPPUNIT_ASSERT_EQUAL(array2.getDataExtent(), (nix::NDSize{20, 20}));
+    CPPUNIT_ASSERT_EQUAL(array2.dataExtent(), (nix::NDSize{20, 20}));
 
     array2.setData(C, {0,0});
-    array2.setDataExtent({40, 40});
-    CPPUNIT_ASSERT_EQUAL(array2.getDataExtent(), (nix::NDSize{40, 40}));
+    array2.dataExtent({40, 40});
+    CPPUNIT_ASSERT_EQUAL(array2.dataExtent(), (nix::NDSize{40, 40}));
 
     array2D_type D(boost::extents[5][5]);
     for(index i = 0; i != 5; ++i)
@@ -147,8 +147,8 @@ void TestDataArray::testData()
     nix::DataArray da3 = block.createDataArray("direct-vector", "double");
 
     CPPUNIT_ASSERT_EQUAL(da3.hasData(), false);
-    CPPUNIT_ASSERT_EQUAL(da3.getDataType(), nix::DataType::Nothing);
-    CPPUNIT_ASSERT(da3.getDataExtent() == nix::NDSize{});
+    CPPUNIT_ASSERT_EQUAL(da3.dataType(), nix::DataType::Nothing);
+    CPPUNIT_ASSERT(da3.dataExtent() == nix::NDSize{});
     CPPUNIT_ASSERT(da3.getDimension(1) == false);
 
     da3.createData(nix::DataType::Double, {5});


### PR DESCRIPTION
did not rename get- and setData for the reasons in issue #221 speak your mind if these should be renamed as well.
