### PR TITLE
SimpleTag::units convert argument from ref to const ref

### DIFF
--- a/include/nix/SimpleTag.hpp
+++ b/include/nix/SimpleTag.hpp
@@ -112,7 +112,7 @@ public:
         return backend()->units();
     }
 
-    void units(std::vector<std::string> &units) {
+    void units(const std::vector<std::string> &units) {
         std::vector<std::string> sanitized;
         sanitized.reserve(units.size());
         std::transform(begin(units), end(units), std::back_inserter(sanitized), [](const std::string &x) {

--- a/include/nix/base/ISimpleTag.hpp
+++ b/include/nix/base/ISimpleTag.hpp
@@ -48,7 +48,7 @@ public:
      *
      * @param units     All units as a vector.
      */
-    virtual void units(std::vector<std::string> &units) = 0;
+    virtual void units(const std::vector<std::string> &units) = 0;
 
     /**
      * @brief Deleter for the units of a tag.

--- a/include/nix/hdf5/SimpleTagHDF5.hpp
+++ b/include/nix/hdf5/SimpleTagHDF5.hpp
@@ -57,7 +57,7 @@ public:
     std::vector<std::string> units() const;
 
 
-    void units(std::vector<std::string> &units);
+    void units(const std::vector<std::string> &units);
 
 
     void units(const none_t t);

--- a/src/hdf5/SimpleTagHDF5.cpp
+++ b/src/hdf5/SimpleTagHDF5.cpp
@@ -61,7 +61,7 @@ vector<string> SimpleTagHDF5::units() const {
 }
 
 
-void SimpleTagHDF5::units(vector<string> &units) {
+void SimpleTagHDF5::units(const vector<string> &units) {
     group().setData("units", units);
     forceUpdatedAt();
 }


### PR DESCRIPTION
Do this so we can bind to rvalues and thus enable calls to units
with initialiser list, i.e. SimpleTag::units({"mV", "cm", "m^2"});

This should fix issue #252
