### PR TITLE
File and FileHDF5 now have the method location

### DIFF
--- a/include/nix/File.hpp
+++ b/include/nix/File.hpp
@@ -268,6 +268,11 @@ public:
     }
 
 
+    std::string location() const {
+        return backend()->location();
+    }
+
+
     time_t createdAt() const {
         return backend()->createdAt();
     }

--- a/include/nix/base/IFile.hpp
+++ b/include/nix/base/IFile.hpp
@@ -178,6 +178,13 @@ public:
     virtual std::string format() const = 0;
 
     /**
+     * @brief Return the location / uri.
+     *
+     * @return uri string.
+     */
+    virtual std::string location() const = 0;
+
+    /**
      * @brief Get the creation date of the file.
      *
      * @return The creation date of the file.

--- a/include/nix/hdf5/FileHDF5.hpp
+++ b/include/nix/hdf5/FileHDF5.hpp
@@ -106,6 +106,9 @@ public:
     std::string format() const;
 
 
+    std::string location() const;
+
+
     time_t createdAt() const;
 
 

--- a/src/hdf5/FileHDF5.cpp
+++ b/src/hdf5/FileHDF5.cpp
@@ -233,6 +233,11 @@ string FileHDF5::format() const {
 }
 
 
+string FileHDF5::location() const {
+    return h5file.getFileName();
+}
+
+
 void FileHDF5::close() {
 
     if (!isOpen())

--- a/test/TestFile.cpp
+++ b/test/TestFile.cpp
@@ -34,6 +34,12 @@ void TestFile::testFormat() {
 }
 
 
+void TestFile::testLocation() {
+    CPPUNIT_ASSERT(file_open.location() == "test_file.h5");
+    CPPUNIT_ASSERT(file_other.location() == "test_file_other.h5");
+}
+
+
 void TestFile::testVersion() {
     CPPUNIT_ASSERT(file_open.version() == "1.0");
 }

--- a/test/TestFile.hpp
+++ b/test/TestFile.hpp
@@ -27,6 +27,7 @@ private:
 
     CPPUNIT_TEST_SUITE(TestFile);
     CPPUNIT_TEST(testFormat);
+    CPPUNIT_TEST(testLocation);
     CPPUNIT_TEST(testVersion);
     CPPUNIT_TEST(testCreatedAt);
     CPPUNIT_TEST(testUpdatedAt);
@@ -44,6 +45,7 @@ public:
     void setUp();
     void tearDown();
     void testFormat();
+    void testLocation();
     void testVersion();
     void testCreatedAt();
     void testUpdatedAt();


### PR DESCRIPTION
`File` and `FileHDF5` now have the method `location` to get a uri (`string`) for the `File` entity. In the case of the HDF5 backend this uri is the file name returned by `H5File::getFileName()`.
Implemented tests as well.
