### PR TITLE
Modified dimension producing factories to return specific dim types

### DIFF
--- a/include/nix/DataArray.hpp
+++ b/include/nix/DataArray.hpp
@@ -299,7 +299,7 @@ public:
      *
      * @return The newly created SetDimension.
      */
-    Dimension appendSetDimension() {
+    SetDimension appendSetDimension() {
         return backend()->createSetDimension(backend()->dimensionCount() + 1);
     }
 
@@ -310,7 +310,7 @@ public:
      *
      * @return The newly created RangeDimension
      */
-    Dimension appendRangeDimension(std::vector<double> ticks) {
+    RangeDimension appendRangeDimension(std::vector<double> ticks) {
         return backend()->createRangeDimension(backend()->dimensionCount() + 1, ticks);
     }
 
@@ -321,7 +321,7 @@ public:
      *
      * @return The newly created SampledDimension.
      */
-    Dimension appendSampledDimension(double sampling_interval) {
+    SampledDimension appendSampledDimension(double sampling_interval) {
         return backend()->createSampledDimension(backend()->dimensionCount() + 1, sampling_interval);
     }
 
@@ -335,7 +335,7 @@ public:
      *
      * @return The created dimension descriptor.
      */
-    Dimension createSetDimension(size_t id) {
+    SetDimension createSetDimension(size_t id) {
         return backend()->createSetDimension(id);
     }
 
@@ -350,7 +350,7 @@ public:
      *
      * @return The created dimension descriptor.
      */
-    Dimension createRangeDimension(size_t id, std::vector<double> ticks) {
+    RangeDimension createRangeDimension(size_t id, std::vector<double> ticks) {
         return backend()->createRangeDimension(id, ticks);
     }
 
@@ -365,7 +365,7 @@ public:
      *
      * @return The created dimension descriptor.
      */
-    Dimension createSampledDimension(size_t id, double sampling_interval) {
+    SampledDimension createSampledDimension(size_t id, double sampling_interval) {
         return backend()->createSampledDimension(id, sampling_interval);
     }
 

--- a/include/nix/base/IDataArray.hpp
+++ b/include/nix/base/IDataArray.hpp
@@ -20,6 +20,9 @@
 namespace nix {
 
 class Dimension;
+class SetDimension;
+class RangeDimension;
+class SampledDimension;
 enum class DimensionType : int;
 
 
@@ -165,7 +168,7 @@ public:
      *
      * @return The created dimension descriptor.
      */
-    virtual Dimension createSetDimension(size_t id) = 0;
+    virtual SetDimension createSetDimension(size_t id) = 0;
 
     /**
      * @brief Create a new RangeDimension at a specified dimension index.
@@ -178,7 +181,7 @@ public:
      *
      * @return The created dimension descriptor.
      */
-    virtual Dimension createRangeDimension(size_t id, std::vector<double> ticks) = 0;
+    virtual RangeDimension createRangeDimension(size_t id, std::vector<double> ticks) = 0;
 
     /**
      * @brief Create a new SampledDimension at a specified dimension index.
@@ -192,7 +195,7 @@ public:
      *
      * @return The created dimension descriptor.
      */
-    virtual Dimension createSampledDimension(size_t id, double sampling_interval) = 0;
+    virtual SampledDimension createSampledDimension(size_t id, double sampling_interval) = 0;
 
     /**
      * @brief Remove a dimension descriptor at a specified index.

--- a/include/nix/hdf5/DataArrayHDF5.hpp
+++ b/include/nix/hdf5/DataArrayHDF5.hpp
@@ -102,17 +102,21 @@ public:
     Dimension getDimension(size_t id) const;
 
 
-    Dimension createSetDimension(size_t id);
+    SetDimension createSetDimension(size_t id);
 
 
-    Dimension createRangeDimension(size_t id, std::vector<double> ticks);
+    RangeDimension createRangeDimension(size_t id, std::vector<double> ticks);
 
 
-    Dimension createSampledDimension(size_t id, double sampling_interval);
+    SampledDimension createSampledDimension(size_t id, double sampling_interval);
 
 
-    template<DimensionType type, typename T = none_t>
-    Dimension _createDimension(size_t id, T var = none);
+    template<DimensionType dtype, typename T>
+    typename std::conditional<dtype == DimensionType::Range, RangeDimension, SampledDimension>::type
+    _createDimension(size_t id, T var);
+
+    template<DimensionType dtype>
+    SetDimension _createDimension(size_t id);
 
 
     bool deleteDimension(size_t id);

--- a/test/TestDataArray.cpp
+++ b/test/TestDataArray.cpp
@@ -233,6 +233,11 @@ void TestDataArray::testDimension()
     dims.push_back(array2.appendSampledDimension(samplingInterval));
     dims.push_back(array2.appendSetDimension());
     dims[3] = array2.createRangeDimension(4, ticks);
+    
+    // have some explicit dimension types
+    nix::RangeDimension dim_range = array1.appendRangeDimension(ticks);
+    nix::SampledDimension dim_sampled = array1.appendSampledDimension(samplingInterval);
+    nix::SetDimension dim_set = array1.appendSetDimension();
 
     CPPUNIT_ASSERT(array2.getDimension(dims[0].index()).dimensionType() == nix::DimensionType::Sample);
     CPPUNIT_ASSERT(array2.getDimension(dims[1].index()).dimensionType() == nix::DimensionType::Set);
@@ -267,6 +272,9 @@ void TestDataArray::testDimension()
     array2.deleteDimension(1);
     array2.deleteDimension(1);
     array2.deleteDimension(1);
+    array1.deleteDimension(1);
+    array1.deleteDimension(1);
+    array1.deleteDimension(1);
 
     dims = array2.dimensions();
     CPPUNIT_ASSERT(array2.dimensionCount() == 0);


### PR DESCRIPTION
All `create*Dimension` and `append*Dimension` factories now return their specific type denoted as `*` and thus it is now possible to write

```
RangeDimension dim = data_array.appendRangeDimension(ticks);
```

while it still remains possible to do

```
Dimension dim = data_array.appendRangeDimension(ticks);
```

Both is implemented as test. Fixing issue #256.
