### PR TITLE
PropertyHDF5: remove declaration dataType(none_t)

### DIFF
--- a/include/nix/hdf5/PropertyHDF5.hpp
+++ b/include/nix/hdf5/PropertyHDF5.hpp
@@ -102,7 +102,7 @@ private:
 };
 
 
-} // namespace hdf5
+} // namespace hdf5 
 } // namespace nix
 
 #endif // NIX_PROPERTY_HDF5_H


### PR DESCRIPTION
The method PropertyHDF5::dataType(none_t t) was declared
in the header but was not implemented and not used by
the front facing Property class.

This fixes issue #269
