### PR TITLE
DataSet::guessChunking: throw InvalidRank for empty NDSize

### DIFF
--- a/src/hdf5/DataSet.cpp
+++ b/src/hdf5/DataSet.cpp
@@ -201,8 +201,8 @@ NDSize DataSet::guessChunking(NDSize chunks, size_t element_size)
     // original source:
     //    https://github.com/h5py/h5py/blob/2.1.3/h5py/_hl/filters.py
 
-    if(chunks.size() == 0) {
-        throw 1;
+    if (chunks.size() == 0) {
+        throw InvalidRank("Cannot guess chunks for 0-dimensional data");
     }
 
     double product = 1;

--- a/test/TestDataSet.cpp
+++ b/test/TestDataSet.cpp
@@ -119,6 +119,9 @@ void TestDataSet::testNDSize() {
 
 void TestDataSet::testChunkGuessing() {
 
+    CPPUNIT_ASSERT_THROW(DataSet::guessChunking(NDSize{}, DataType::Double),
+                         InvalidRank);
+
     NDSize dims = {1024, 1024};
 
     NDSize chunks = DataSet::guessChunking(dims, DataType::Double);


### PR DESCRIPTION
Currently we just threw "1". Includes a test.
