### PR TITLE
As discussed @gnode headquarters there are now optional groups

### DIFF
--- a/include/nix/hdf5/BlockHDF5.hpp
+++ b/include/nix/hdf5/BlockHDF5.hpp
@@ -27,10 +27,9 @@ class BlockHDF5 : virtual public base::IBlock, public EntityWithMetadataHDF5,
 
 private:
 
-    mutable boost::optional<Group> source_group_opt;
     Group data_array_group, tag_group, multi_tag_group;
 
-    boost::optional<Group> source_group(bool create = false) const;
+    optGroup source_group;
 
 public:
 

--- a/src/hdf5/Group.cpp
+++ b/src/hdf5/Group.cpp
@@ -12,6 +12,18 @@
 namespace nix {
 namespace hdf5 {
 
+optGroup::optGroup(const Group &parent, const std::string &g_name)
+    : parent(parent), g_name(g_name)
+{}
+
+boost::optional<Group> optGroup::operator() (bool create) const {
+    if (parent.hasGroup(g_name)) {
+        g = boost::optional<Group>(parent.openGroup(g_name));
+    } else if (create) {
+        g = boost::optional<Group>(parent.openGroup(g_name, true));
+    }
+    return g;
+}
 
 Group::Group()
     : h5group()
@@ -145,6 +157,11 @@ Group Group::openGroup(const std::string &name, bool create) const {
 }
 
 
+optGroup Group::openOptGroup(const std::string &name) {
+    return optGroup(*this, name);
+}
+
+
 void Group::removeGroup(const std::string &name) {
     if (hasGroup(name))
         h5group.unlink(name);
@@ -155,18 +172,6 @@ void Group::renameGroup(const std::string &old_name, const std::string &new_name
     if (hasGroup(old_name)) {
         h5group.move(old_name, new_name);
     }
-}
-
-
-boost::optional<Group> Group::getGroupIfExists(const std::string &name, bool create) {
-    boost::optional<Group> opt_group;
-
-    if (hasGroup(name)) {
-        opt_group = boost::optional<Group>(openGroup(name));
-    } else if (create) {
-        opt_group = boost::optional<Group>(openGroup(name, true));
-    }
-    return opt_group;
 }
 
 


### PR DESCRIPTION
Optional groups are a functor struct that opens a group in the file if allowed by the user and if it is not open already. Other then `Group::openGroup` in the case that it is _not_ allowed and does not exist an unset optional is returned an not an error thrown.
The `optGroup` is primed and created by `Group::openOptGroup`.
So far implemented on `BlockHDF5::source_group` only.
