### PR TITLE
improved stability of guess chunking

### DIFF
--- a/src/hdf5/DataSet.cpp
+++ b/src/hdf5/DataSet.cpp
@@ -205,7 +205,6 @@ double psize_product(const NDSize &dims)
  */
 NDSize DataSet::guessChunking(NDSize dims, DataType dtype)
 {
-
     const size_t type_size = data_type_to_size(dtype);
     NDSize chunks = guessChunking(dims, type_size);
     return chunks;
@@ -271,7 +270,6 @@ NDSize DataSet::guessChunking(NDSize chunks, size_t element_size)
         }
         i++;
     }
-   
     return chunks;
 }
 


### PR DESCRIPTION
guess chunking had a little problem with rather "unbalanced" data sizes. E.g. in the case of a 4d like 640x480x3x20 matrix the guess chunking algorithm reduced the third dimension to 0 size, which cannot work.
The fix only divides the size of a dimension if it is larger than 1.
