### PR TITLE
Using "index" instead of "size_t" in "Dump.cpp" to avoid warning

### DIFF
--- a/cli/modules/Dump.cpp
+++ b/cli/modules/Dump.cpp
@@ -533,8 +533,8 @@ std::string Dump::call(const po::variables_map &vm, const po::options_descriptio
                         if (data_array.dataExtent().size() == 2) {
                             file_name = "data_array_" + data_array.id();
                             fout.open(file_name + ".txt");
-                            size_t dim1 = data_array.dataExtent()[0];
-                            size_t dim2 = data_array.dataExtent()[1];
+                            index dim1 = static_cast<index>(data_array.dataExtent()[0]);
+                            index dim2 = static_cast<index>(data_array.dataExtent()[1]);
                             array_type A(boost::extents[ dim1 ]
                                                        [ dim2 ]);
                             data_array.getData(A);
@@ -552,7 +552,7 @@ std::string Dump::call(const po::variables_map &vm, const po::options_descriptio
                             #ifndef _WIN32
                             if (vm.count(PLOT_OPTION)) {
                                 std::cout << "press ctrl+c for next plot" << std::endl;
-                                plot_script script(A_min, A_max, dim1, dim2, file_name + ".txt");
+                                plot_script script(A_min, A_max, static_cast<size_t>(dim1), static_cast<size_t>(dim2), file_name + ".txt");
                                 fout.open(file_name + ".gnu");
                                 fout << script.str();
                                 fout.close();


### PR DESCRIPTION
The warnings now should be gone - imho there is no pretty solution for this whole thing as boost's "index" is a black box type which thus shouldn't be used with own arrays / types at all. That however would (in this case) mean to iterate over a 2nd set of own-type vars (and use those instead of "index" where required).
Long story short, I chose to cast instead - might not work in future if the boost team makes "index" some weirdo type.
