### PR TITLE
Fix for segmentation fault (issue #430)

### DIFF
--- a/src/util/dataAccess.cpp
+++ b/src/util/dataAccess.cpp
@@ -21,7 +21,7 @@ using namespace std;
 namespace nix {
 namespace util {
 
-//TODO maybe a relaxed handling of units would be better, e.g. if none given, take the one from the dimension...
+
 int positionToIndex(double position, const string &unit, const Dimension &dimension) {
     if (dimension.dimensionType() == nix::DimensionType::Sample) {
         SampledDimension dim;
@@ -126,9 +126,9 @@ void getOffsetAndCount(const Tag &tag, const DataArray &array, NDSize &offset, N
     }
     for (size_t i = 0; i < position.size(); ++i) {
         Dimension dim = array.getDimension(i+1);
-        temp_offset[i] = positionToIndex(position[i], i > units.size() ? "none" : units[i], dim);
+        temp_offset[i] = positionToIndex(position[i], i >= units.size() ? "none" : units[i], dim);
         if (i < extent.size()) {
-            size_t c = positionToIndex(position[i] + extent[i], i > units.size() ? "none" : units[i], dim) - temp_offset[i];
+            size_t c = positionToIndex(position[i] + extent[i], i >= units.size() ? "none" : units[i], dim) - temp_offset[i];
             temp_count[i] = (c > 1) ? c : 1;
         }
     }

--- a/test/TestDataAccess.cpp
+++ b/test/TestDataAccess.cpp
@@ -163,12 +163,28 @@ void TestDataAccess::testOffsetAndCount() {
     CPPUNIT_ASSERT(offsets[0] == 0 && offsets[1] == 2 && offsets[2] == 2);
     CPPUNIT_ASSERT(counts[0] == 1 && counts[1] == 1 && counts[2] == 1);
 
+    position_tag.units(vector<string>());
+    util::getOffsetAndCount(position_tag, data_array, offsets, counts);
+
+    CPPUNIT_ASSERT(position_tag.units().size() == 0);
+    CPPUNIT_ASSERT(offsets.size() == 3);
+    CPPUNIT_ASSERT(counts.size() == 3);
+    CPPUNIT_ASSERT(offsets[0] == 0 && offsets[1] == 2 && offsets[2] == 2);
+    CPPUNIT_ASSERT(counts[0] == 1 && counts[1] == 1 && counts[2] == 1);
+
     util::getOffsetAndCount(segment_tag, data_array, offsets, counts);
     CPPUNIT_ASSERT(offsets.size() == 3);
     CPPUNIT_ASSERT(counts.size() == 3);
     CPPUNIT_ASSERT(offsets[0] == 0 && offsets[1] == 2 && offsets[2] == 2);
     CPPUNIT_ASSERT(counts[0] == 1 && counts[1] == 6 && counts[2] == 2);
-
+    
+    segment_tag.units(vector<string>());
+    util::getOffsetAndCount(segment_tag, data_array, offsets, counts);
+    CPPUNIT_ASSERT(offsets.size() == 3);
+    CPPUNIT_ASSERT(counts.size() == 3);
+    CPPUNIT_ASSERT(offsets[0] == 0 && offsets[1] == 2 && offsets[2] == 2);
+    CPPUNIT_ASSERT(counts[0] == 1 && counts[1] == 6 && counts[2] == 2);
+    
     CPPUNIT_ASSERT_THROW(util::getOffsetAndCount(multi_tag, data_array, -1, offsets, counts), nix::OutOfBounds);
     CPPUNIT_ASSERT_THROW(util::getOffsetAndCount(multi_tag, data_array, 3, offsets, counts), nix::OutOfBounds);
 


### PR DESCRIPTION
[dataAccess] fixed segfault bug in getOffsetAndCount, added test

If the tag had no units there was an access into an empty units vector