### PR TITLE
DataArray throws a proper exception if range dim with empty ticks is created

### DIFF
--- a/include/nix/DataArray.hpp
+++ b/include/nix/DataArray.hpp
@@ -308,7 +308,10 @@ public:
      *
      * @return The newly created RangeDimension
      */
-    RangeDimension appendRangeDimension(const std::vector<double> &ticks) {
+    RangeDimension appendRangeDimension(const std::vector<double> &ticks) { 
+        if (ticks.size() == 0) {
+            throw std::runtime_error("The ticks of a range dimension must not be empty!");
+        }
         return backend()->createRangeDimension(backend()->dimensionCount() + 1, ticks);
     }
 
@@ -349,6 +352,9 @@ public:
      * @return The created dimension descriptor.
      */
     RangeDimension createRangeDimension(size_t id, const std::vector<double> &ticks) {
+        if (ticks.size() == 0) {
+            throw std::runtime_error("The ticks of a range dimension must not be empty!");
+        }
         return backend()->createRangeDimension(id, ticks);
     }
 

--- a/include/nix/DataArray.hpp
+++ b/include/nix/DataArray.hpp
@@ -310,7 +310,8 @@ public:
      */
     RangeDimension appendRangeDimension(const std::vector<double> &ticks) { 
         if (ticks.size() == 0) {
-            throw std::runtime_error("The ticks of a range dimension must not be empty!");
+            throw nix::InvalidDimension("The ticks of a range dimension must not be empty!", 
+                                        "DataArray::appendRangeDimension");
         }
         return backend()->createRangeDimension(backend()->dimensionCount() + 1, ticks);
     }
@@ -353,7 +354,8 @@ public:
      */
     RangeDimension createRangeDimension(size_t id, const std::vector<double> &ticks) {
         if (ticks.size() == 0) {
-            throw std::runtime_error("The ticks of a range dimension must not be empty!");
+            throw nix::InvalidDimension("The ticks of a range dimension must not be empty!", 
+                                        "DataArray::createRangeDimension");
         }
         return backend()->createRangeDimension(id, ticks);
     }

--- a/include/nix/Exception.hpp
+++ b/include/nix/Exception.hpp
@@ -166,6 +166,25 @@ private:
     std::string caller;
 };
 
+
+class InvalidDimension : public std::exception {
+
+public:
+    InvalidDimension(const std::string &message, const std::string &caller):
+        msg(message), caller(caller){ }
+
+    const char *what() const NOEXCEPT {
+        std::stringstream sstream("InvalidDimension: ");
+        sstream << msg << " evoked at: " << caller;
+        return sstream.str().c_str();
+    }
+
+private:
+    std::string msg;
+    std::string caller;
+};
+
+
 class InvalidRank : public std::out_of_range {
 public:
     InvalidRank(const std::string &message)

--- a/test/TestDataArray.cpp
+++ b/test/TestDataArray.cpp
@@ -382,8 +382,8 @@ void TestDataArray::testDimension()
         ticks.push_back(i * boost::math::constants::pi<double>());
     }
     
-    CPPUNIT_ASSERT_THROW(array2.appendRangeDimension(std::vector<double>{}), std::runtime_error);
-    CPPUNIT_ASSERT_THROW(array2.createRangeDimension(1, std::vector<double>{}), std::runtime_error);
+    CPPUNIT_ASSERT_THROW(array2.appendRangeDimension(std::vector<double>{}), nix::InvalidDimension);
+    CPPUNIT_ASSERT_THROW(array2.createRangeDimension(1, std::vector<double>{}), nix::InvalidDimension);
 
     dims.push_back(array2.createSampledDimension(1, samplingInterval));
     dims.push_back(array2.createSetDimension(2));

--- a/test/TestDataArray.cpp
+++ b/test/TestDataArray.cpp
@@ -381,6 +381,9 @@ void TestDataArray::testDimension()
     for(size_t i = 0; i < 5; i++) {
         ticks.push_back(i * boost::math::constants::pi<double>());
     }
+    
+    CPPUNIT_ASSERT_THROW(array2.appendRangeDimension(std::vector<double>{}), std::runtime_error);
+    CPPUNIT_ASSERT_THROW(array2.createRangeDimension(1, std::vector<double>{}), std::runtime_error);
 
     dims.push_back(array2.createSampledDimension(1, samplingInterval));
     dims.push_back(array2.createSetDimension(2));


### PR DESCRIPTION
So far, DataArray::appendRangeDimension(ticks) with empty ticks vector led to an HDF5 Exception which was shown as unidentifiable C++ Exception in nixpy, actually providing no information about the real cause. 