### PR TITLE
Attribute: new slim wrapper for H5 attributes

### DIFF
--- a/include/nix/hdf5/Attribute.hpp
+++ b/include/nix/hdf5/Attribute.hpp
@@ -1,0 +1,41 @@
+// Copyright © 2015 German Neuroinformatics Node (G-Node)
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted under the terms of the BSD License. See
+// LICENSE file in the root of the Project.
+//
+// Author: Christian Kellner <kellner@bio.lmu.de>
+
+#ifndef NIX_ATTRIBUTE_H5_H
+#define NIX_ATTRIBUTE_H5_H
+
+#include <nix/hdf5/BaseHDF5.hpp>
+
+namespace nix {
+
+namespace hdf5 {
+
+
+class NIXAPI Attribute : public BaseHDF5 {
+public:
+    using BaseHDF5::BaseHDF5;
+
+    void read(H5::DataType mem_type, const NDSize &size, void *data);
+    void read(H5::DataType mem_type, const NDSize &size, std::string *data);
+
+    void write(H5::DataType mem_type, const NDSize &size, const void *data);
+    void write(H5::DataType mem_type, const NDSize &size, const std::string *data);
+
+    hid_t getSpace() const;
+    NDSize extent() const;
+};
+
+
+}
+
+}
+
+
+#endif

--- a/include/nix/hdf5/Attribute.hpp
+++ b/include/nix/hdf5/Attribute.hpp
@@ -20,7 +20,9 @@ namespace hdf5 {
 
 class NIXAPI Attribute : public BaseHDF5 {
 public:
-    using BaseHDF5::BaseHDF5;
+    Attribute();
+    Attribute(hid_t hid);
+    Attribute(const Attribute &other);
 
     void read(H5::DataType mem_type, const NDSize &size, void *data);
     void read(H5::DataType mem_type, const NDSize &size, std::string *data);

--- a/include/nix/hdf5/BaseHDF5.hpp
+++ b/include/nix/hdf5/BaseHDF5.hpp
@@ -108,15 +108,6 @@ public:
 
     BaseHDF5& operator=(BaseHDF5 &&other);
 
-    bool hasAttr(const std::string &name) const;
-    void removeAttr(const std::string &name) const;
-
-    template <typename T>
-    void setAttr(const std::string &name, const T &value) const;
-
-    template <typename T>
-    bool getAttr(const std::string &name, T &value) const;
-
     bool operator==(const BaseHDF5 &other) const;
 
     bool operator!=(const BaseHDF5 &other) const;
@@ -137,66 +128,7 @@ protected:
     void dec() const;
 
     void invalidate();
-
-private:
-
-    H5::Attribute openAttr(const std::string &name) const;
-    H5::Attribute createAttr(const std::string &name, H5::DataType fileType, H5::DataSpace fileSpace) const;
-
-    static void readAttr(const H5::Attribute &attr, H5::DataType mem_type, const NDSize &size, void *data);
-    static void readAttr(const H5::Attribute &attr, H5::DataType mem_type, const NDSize &size, std::string *data);
-
-    static void writeAttr(const H5::Attribute &attr, H5::DataType mem_type, const NDSize &size, const void *data);
-    static void writeAttr(const H5::Attribute &attr, H5::DataType mem_type, const NDSize &size, const std::string *data);
 };
-
-
-template<typename T> void BaseHDF5::setAttr(const std::string &name, const T &value) const
-{
-    typedef Hydra<const T> hydra_t;
-
-    const hydra_t hydra(value);
-    DataType dtype = hydra.element_data_type();
-    NDSize shape = hydra.shape();
-
-    H5::Attribute attr;
-
-    if (hasAttr(name)) {
-        attr = openAttr(name);
-    } else {
-        H5::DataType fileType = data_type_to_h5_filetype(dtype);
-        H5::DataSpace fileSpace = DataSpace::create(shape, false);
-        attr = createAttr(name, fileType, fileSpace);
-    }
-
-    writeAttr(attr, data_type_to_h5_memtype(dtype), shape, hydra.data());
-}
-
-
-
-template<typename T> bool BaseHDF5::getAttr(const std::string &name, T &value) const
-{
-    if (!hasAttr(name)) {
-        return false;
-    }
-
-    Hydra<T> hydra(value);
-
-    //determine attr's size and resize value accordingly
-    H5::Attribute attr = openAttr(name);
-    H5::DataSpace space = attr.getSpace();
-    int rank = space.getSimpleExtentNdims();
-    NDSize dims(static_cast<size_t>(rank));
-    space.getSimpleExtentDims (dims.data(), nullptr);
-    hydra.resize(dims);
-
-    DataType dtype = hydra.element_data_type();
-    H5::DataType mem_type = data_type_to_h5_memtype(dtype);
-
-    readAttr(attr, mem_type, dims, hydra.data());
-
-    return true;
-}
 
 
 } // namespace hdf5

--- a/include/nix/hdf5/DataSetHDF5.hpp
+++ b/include/nix/hdf5/DataSetHDF5.hpp
@@ -13,7 +13,7 @@
 #include <nix/hdf5/Selection.hpp>
 #include <nix/hdf5/DataSpace.hpp>
 #include <nix/hdf5/DataTypeHDF5.hpp>
-#include <nix/hdf5/BaseHDF5.hpp>
+#include <nix/hdf5/LocID.hpp>
 #include <nix/Hydra.hpp>
 #include <nix/Value.hpp>
 
@@ -22,11 +22,11 @@
 namespace nix {
 namespace hdf5 {
 
-class NIXAPI DataSet : public BaseHDF5 {
+class NIXAPI DataSet : public LocID {
 
 public:
 
-    DataSet() : BaseHDF5() { };
+    DataSet() : LocID() { };
 
     DataSet(hid_t hid);
 

--- a/include/nix/hdf5/Group.hpp
+++ b/include/nix/hdf5/Group.hpp
@@ -12,7 +12,7 @@
 #include <string>
 
 #include <nix/hdf5/hdf5include.hpp>
-#include <nix/hdf5/BaseHDF5.hpp>
+#include "LocID.hpp"
 #include <nix/hdf5/DataSetHDF5.hpp>
 #include <nix/hdf5/DataSpace.hpp>
 #include <nix/Hydra.hpp>
@@ -28,7 +28,7 @@ struct optGroup;
 /**
  * TODO documentation
  */
-class NIXAPI Group : public BaseHDF5 {
+class NIXAPI Group : public LocID {
 
 public:
 

--- a/include/nix/hdf5/LocID.hpp
+++ b/include/nix/hdf5/LocID.hpp
@@ -1,0 +1,105 @@
+// Copyright © 2015 German Neuroinformatics Node (G-Node)
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted under the terms of the BSD License. See
+// LICENSE file in the root of the Project.
+//
+// Author: Christian Kellner <kellner@bio.lmu.de>
+
+#ifndef NIX_LOCATION_H5_H
+#define NIX_LOCATION_H5_H
+
+#include <nix/hdf5/BaseHDF5.hpp>
+
+namespace nix {
+namespace hdf5 {
+
+class NIXAPI LocID : public BaseHDF5 {
+public:
+    LocID();
+
+    LocID(hid_t hid);
+
+    LocID(const LocID &other);
+
+    LocID(const H5::Group &h5group);
+
+
+    bool hasAttr(const std::string &name) const;
+    void removeAttr(const std::string &name) const;
+
+    template <typename T>
+    void setAttr(const std::string &name, const T &value) const;
+
+    template <typename T>
+    bool getAttr(const std::string &name, T &value) const;
+
+private:
+
+    H5::Attribute openAttr(const std::string &name) const;
+    H5::Attribute createAttr(const std::string &name, H5::DataType fileType, H5::DataSpace fileSpace) const;
+
+    static void readAttr(const H5::Attribute &attr, H5::DataType mem_type, const NDSize &size, void *data);
+    static void readAttr(const H5::Attribute &attr, H5::DataType mem_type, const NDSize &size, std::string *data);
+
+    static void writeAttr(const H5::Attribute &attr, H5::DataType mem_type, const NDSize &size, const void *data);
+    static void writeAttr(const H5::Attribute &attr, H5::DataType mem_type, const NDSize &size, const std::string *data);
+};
+
+
+template<typename T> void LocID::setAttr(const std::string &name, const T &value) const
+{
+    typedef Hydra<const T> hydra_t;
+
+    const hydra_t hydra(value);
+    DataType dtype = hydra.element_data_type();
+    NDSize shape = hydra.shape();
+
+    H5::Attribute attr;
+
+    if (hasAttr(name)) {
+        attr = openAttr(name);
+    } else {
+        H5::DataType fileType = data_type_to_h5_filetype(dtype);
+        H5::DataSpace fileSpace = DataSpace::create(shape, false);
+        attr = createAttr(name, fileType, fileSpace);
+    }
+
+    writeAttr(attr, data_type_to_h5_memtype(dtype), shape, hydra.data());
+}
+
+
+
+template<typename T> bool LocID::getAttr(const std::string &name, T &value) const
+{
+    if (!hasAttr(name)) {
+        return false;
+    }
+
+    Hydra<T> hydra(value);
+
+    //determine attr's size and resize value accordingly
+    H5::Attribute attr = openAttr(name);
+    H5::DataSpace space = attr.getSpace();
+    int rank = space.getSimpleExtentNdims();
+    NDSize dims(static_cast<size_t>(rank));
+    space.getSimpleExtentDims (dims.data(), nullptr);
+    hydra.resize(dims);
+
+    DataType dtype = hydra.element_data_type();
+    H5::DataType mem_type = data_type_to_h5_memtype(dtype);
+
+    readAttr(attr, mem_type, dims, hydra.data());
+
+    return true;
+}
+
+
+
+} //nix::hdf5
+
+} //nix
+
+#endif

--- a/src/hdf5/Attribute.cpp
+++ b/src/hdf5/Attribute.cpp
@@ -1,0 +1,73 @@
+
+#include <nix/hdf5/Attribute.hpp>
+#include <NDSize.hpp>
+#include <nix/hdf5/ExceptionHDF5.hpp>
+#include <H5Ipublic.h>
+
+namespace nix {
+namespace hdf5 {
+
+
+void Attribute::read(H5::DataType mem_type, const NDSize &size, void *data) {
+    herr_t status = H5Aread(hid, mem_type.getId(), data);
+    H5Error::check(status, "Attribute::read(): Could not read data");
+}
+
+void Attribute::read(H5::DataType mem_type, const NDSize &size, std::string *data) {
+    StringWriter writer(size, data);
+    read(mem_type, size, *writer);
+    writer.finish();
+
+    hid_t space = getSpace();
+
+    herr_t status = H5Dvlen_reclaim(mem_type.getId(), space, H5P_DEFAULT, *writer);
+    H5Error::check(status, "Attribute::read(): Could not reclaim variable length data");
+
+    H5Sclose(space);
+
+}
+
+void Attribute::write(H5::DataType mem_type, const NDSize &size, const void *data) {
+    herr_t status = H5Awrite(hid, mem_type.getId(), data);
+    H5Error::check(status, "Attribute::write(): Could not write data");
+}
+
+void Attribute::write(H5::DataType mem_type, const NDSize &size, const std::string *data) {
+    StringReader reader(size, data);
+    write(mem_type, size, *reader);
+}
+
+
+hid_t Attribute::getSpace() const {
+
+    hid_t space = H5Aget_space(hid);
+    if (space < 0) {
+        throw H5Exception("Attribute::getSpace(): Dould not get data space");
+    }
+
+    return space;
+}
+
+
+NDSize Attribute::extent() const {
+    hid_t space = getSpace();
+
+    //Fixme: duplicated code with DataSet::size()
+    int ndims = H5Sget_simple_extent_ndims(space);
+    if (ndims < 0) {
+        throw H5Exception("DataSet::size(): could not obtain number of dimensions");
+    }
+    size_t rank = static_cast<size_t>(ndims);
+    NDSize dims(rank);
+    int res = H5Sget_simple_extent_dims(space, dims.data(), nullptr);
+
+    if (res < 0) {
+        throw H5Exception("DataSet::size(): could not obtain extents");
+    }
+
+    H5Sclose(space);
+
+    return dims;
+}
+} //nix::hdf5::
+} //nix::

--- a/src/hdf5/Attribute.cpp
+++ b/src/hdf5/Attribute.cpp
@@ -1,8 +1,6 @@
 
 #include <nix/hdf5/Attribute.hpp>
-#include <NDSize.hpp>
 #include <nix/hdf5/ExceptionHDF5.hpp>
-#include <H5Ipublic.h>
 
 namespace nix {
 namespace hdf5 {

--- a/src/hdf5/Attribute.cpp
+++ b/src/hdf5/Attribute.cpp
@@ -1,9 +1,20 @@
 
 #include <nix/hdf5/Attribute.hpp>
 #include <nix/hdf5/ExceptionHDF5.hpp>
+#include <H5Ipublic.h>
 
 namespace nix {
 namespace hdf5 {
+
+
+Attribute::Attribute() : BaseHDF5() {
+}
+
+Attribute::Attribute(hid_t hid) : BaseHDF5(hid) {
+}
+
+Attribute::Attribute(const Attribute &other) : BaseHDF5(other) {
+}
 
 
 void Attribute::read(H5::DataType mem_type, const NDSize &size, void *data) {

--- a/src/hdf5/BaseHDF5.cpp
+++ b/src/hdf5/BaseHDF5.cpp
@@ -56,52 +56,6 @@ BaseHDF5& BaseHDF5::operator=(BaseHDF5 &&other) {
 }
 
 
-bool BaseHDF5::hasAttr(const std::string &name) const {
-    return H5Aexists(hid, name.c_str());
-}
-
-
-void BaseHDF5::removeAttr(const std::string &name) const {
-    H5Adelete(hid, name.c_str());
-}
-
-
-H5::Attribute BaseHDF5::openAttr(const std::string &name) const {
-    hid_t ha = H5Aopen(hid, name.c_str(), H5P_DEFAULT);
-    return H5::Attribute(ha);
-}
-
-
-H5::Attribute BaseHDF5::createAttr(const std::string &name, H5::DataType fileType, H5::DataSpace fileSpace) const {
-    hid_t ha = H5Acreate(hid, name.c_str(), fileType.getId(), fileSpace.getId(), H5P_DEFAULT, H5P_DEFAULT);
-    return H5::Attribute(ha);
-}
-
-
-void BaseHDF5::readAttr(const H5::Attribute &attr, H5::DataType mem_type, const NDSize &size, void *data) {
-    attr.read(mem_type, data);
-}
-
-
-void BaseHDF5::readAttr(const H5::Attribute &attr, H5::DataType mem_type, const NDSize &size, std::string *data) {
-    StringWriter writer(size, data);
-    attr.read(mem_type, *writer);
-    writer.finish();
-    H5::DataSet::vlenReclaim(*writer, mem_type, attr.getSpace()); //recycle space?
-}
-
-
-void BaseHDF5::writeAttr(const H5::Attribute &attr, H5::DataType mem_type, const NDSize &size, const void *data) {
-    attr.write(mem_type, data);
-}
-
-
-void BaseHDF5::writeAttr(const H5::Attribute &attr, H5::DataType mem_type, const NDSize &size, const std::string *data) {
-    StringReader reader(size, data);
-    attr.write(mem_type, *reader);
-}
-
-
 bool BaseHDF5::operator==(const BaseHDF5 &other) const {
     if (H5Iis_valid(hid) && H5Iis_valid(other.hid))
         return hid == other.hid;

--- a/src/hdf5/DataSetHDF5.cpp
+++ b/src/hdf5/DataSetHDF5.cpp
@@ -31,12 +31,12 @@ struct to_data_type<const char *> {
 namespace hdf5 {
 
 DataSet::DataSet(hid_t hid)
-        : BaseHDF5(hid) {
+        : LocID(hid) {
 
 }
 
 DataSet::DataSet(const DataSet &other)
-        : BaseHDF5(other)  {
+        : LocID(other)  {
 
 }
 

--- a/src/hdf5/DataSetHDF5.cpp
+++ b/src/hdf5/DataSetHDF5.cpp
@@ -257,6 +257,8 @@ NDSize DataSet::size() const
         throw H5Exception("DataSet::size(): could not obtain extents");
     }
 
+    H5Sclose(space);
+
     return dims;
 }
 

--- a/src/hdf5/Group.cpp
+++ b/src/hdf5/Group.cpp
@@ -30,16 +30,16 @@ boost::optional<Group> optGroup::operator() (bool create) const {
 }
 
 
-Group::Group() : BaseHDF5() {}
+Group::Group() : LocID() {}
 
 
-Group::Group(hid_t hid) : BaseHDF5(hid) {}
+Group::Group(hid_t hid) : LocID(hid) {}
 
 
-Group::Group(const Group &other) : BaseHDF5(other) {}
+Group::Group(const Group &other) : LocID(other) {}
 
 
-Group::Group(const H5::Group &h5group) : BaseHDF5(h5group.getLocId()) {}
+Group::Group(const H5::Group &h5group) : LocID(h5group.getLocId()) {}
 
 
 bool Group::hasObject(const std::string &name) const {

--- a/src/hdf5/LocID.cpp
+++ b/src/hdf5/LocID.cpp
@@ -35,40 +35,21 @@ void LocID::removeAttr(const std::string &name) const {
 }
 
 
-H5::Attribute LocID::openAttr(const std::string &name) const {
+Attribute LocID::openAttr(const std::string &name) const {
     hid_t ha = H5Aopen(hid, name.c_str(), H5P_DEFAULT);
-    return H5::Attribute(ha);
+    Attribute attr = Attribute(ha);
+    H5Idec_ref(ha);
+    return attr;
 }
 
 
-H5::Attribute LocID::createAttr(const std::string &name, H5::DataType fileType, H5::DataSpace fileSpace) const {
+Attribute LocID::createAttr(const std::string &name, H5::DataType fileType, H5::DataSpace fileSpace) const {
     hid_t ha = H5Acreate(hid, name.c_str(), fileType.getId(), fileSpace.getId(), H5P_DEFAULT, H5P_DEFAULT);
-    return H5::Attribute(ha);
+    Attribute attr = Attribute(ha);
+    H5Idec_ref(ha);
+    return attr;
 }
 
-
-void LocID::readAttr(const H5::Attribute &attr, H5::DataType mem_type, const NDSize &size, void *data) {
-    attr.read(mem_type, data);
-}
-
-
-void LocID::readAttr(const H5::Attribute &attr, H5::DataType mem_type, const NDSize &size, std::string *data) {
-    StringWriter writer(size, data);
-    attr.read(mem_type, *writer);
-    writer.finish();
-    H5::DataSet::vlenReclaim(*writer, mem_type, attr.getSpace()); //recycle space?
-}
-
-
-void LocID::writeAttr(const H5::Attribute &attr, H5::DataType mem_type, const NDSize &size, const void *data) {
-    attr.write(mem_type, data);
-}
-
-
-void LocID::writeAttr(const H5::Attribute &attr, H5::DataType mem_type, const NDSize &size, const std::string *data) {
-    StringReader reader(size, data);
-    attr.write(mem_type, *reader);
-}
 
 } // nix::hdf5
 

--- a/src/hdf5/LocID.cpp
+++ b/src/hdf5/LocID.cpp
@@ -1,0 +1,75 @@
+// Copyright © 2015 German Neuroinformatics Node (G-Node)
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted under the terms of the BSD License. See
+// LICENSE file in the root of the Project.
+//
+// Author: Christian Kellner <kellner@bio.lmu.de>
+
+#include <nix/hdf5/LocID.hpp>
+
+namespace nix {
+
+namespace hdf5 {
+
+LocID::LocID() : BaseHDF5() {}
+
+
+LocID::LocID(hid_t hid) : BaseHDF5(hid) {}
+
+
+LocID::LocID(const LocID &other) : BaseHDF5(other) {}
+
+
+LocID::LocID(const H5::Group &h5group) : LocID(h5group.getLocId()) {}
+
+bool LocID::hasAttr(const std::string &name) const {
+    return H5Aexists(hid, name.c_str());
+}
+
+
+void LocID::removeAttr(const std::string &name) const {
+    H5Adelete(hid, name.c_str());
+}
+
+
+H5::Attribute LocID::openAttr(const std::string &name) const {
+    hid_t ha = H5Aopen(hid, name.c_str(), H5P_DEFAULT);
+    return H5::Attribute(ha);
+}
+
+
+H5::Attribute LocID::createAttr(const std::string &name, H5::DataType fileType, H5::DataSpace fileSpace) const {
+    hid_t ha = H5Acreate(hid, name.c_str(), fileType.getId(), fileSpace.getId(), H5P_DEFAULT, H5P_DEFAULT);
+    return H5::Attribute(ha);
+}
+
+
+void LocID::readAttr(const H5::Attribute &attr, H5::DataType mem_type, const NDSize &size, void *data) {
+    attr.read(mem_type, data);
+}
+
+
+void LocID::readAttr(const H5::Attribute &attr, H5::DataType mem_type, const NDSize &size, std::string *data) {
+    StringWriter writer(size, data);
+    attr.read(mem_type, *writer);
+    writer.finish();
+    H5::DataSet::vlenReclaim(*writer, mem_type, attr.getSpace()); //recycle space?
+}
+
+
+void LocID::writeAttr(const H5::Attribute &attr, H5::DataType mem_type, const NDSize &size, const void *data) {
+    attr.write(mem_type, data);
+}
+
+
+void LocID::writeAttr(const H5::Attribute &attr, H5::DataType mem_type, const NDSize &size, const std::string *data) {
+    StringReader reader(size, data);
+    attr.write(mem_type, *reader);
+}
+
+} // nix::hdf5
+
+} // nix::


### PR DESCRIPTION
Another step in getting rid of H5Cpp bindings completely (cf. issue #452).