### PR TITLE
H5::BaseHDF5: change ref-count behaviour of hid_t ctor

### DIFF
--- a/include/nix/hdf5/BaseHDF5.hpp
+++ b/include/nix/hdf5/BaseHDF5.hpp
@@ -99,6 +99,12 @@ public:
 
     BaseHDF5(hid_t hid);
 
+    BaseHDF5(hid_t hid, bool is_copy) : hid(hid) {
+        if (is_copy) {
+            inc();
+        }
+    }
+
     BaseHDF5(const BaseHDF5 &other);
 
     BaseHDF5(BaseHDF5 &&other);

--- a/include/nix/hdf5/BaseHDF5.hpp
+++ b/include/nix/hdf5/BaseHDF5.hpp
@@ -97,7 +97,7 @@ public:
 
     BaseHDF5() : hid(H5I_INVALID_HID) { }
 
-    BaseHDF5(hid_t hid) : BaseHDF5(hid, true) { };
+    BaseHDF5(hid_t hid) : BaseHDF5(hid, false) { };
 
     BaseHDF5(hid_t hid, bool is_copy) : hid(hid) {
         if (is_copy) {

--- a/include/nix/hdf5/BaseHDF5.hpp
+++ b/include/nix/hdf5/BaseHDF5.hpp
@@ -95,9 +95,9 @@ protected:
 
 public:
 
-    BaseHDF5();
+    BaseHDF5() : hid(H5I_INVALID_HID) { }
 
-    BaseHDF5(hid_t hid);
+    BaseHDF5(hid_t hid) : BaseHDF5(hid, true) { };
 
     BaseHDF5(hid_t hid, bool is_copy) : hid(hid) {
         if (is_copy) {

--- a/include/nix/hdf5/BaseHDF5.hpp
+++ b/include/nix/hdf5/BaseHDF5.hpp
@@ -122,6 +122,14 @@ public:
 
     int refCount() const;
 
+    bool isValid() const;
+
+    void check(const std::string &msg_if_fail) {
+        if (!isValid()) {
+            throw H5Exception(msg_if_fail);
+        }
+    }
+
     std::string name() const;
 
     virtual void close();

--- a/include/nix/hdf5/DataSetHDF5.hpp
+++ b/include/nix/hdf5/DataSetHDF5.hpp
@@ -30,6 +30,8 @@ public:
 
     DataSet(hid_t hid);
 
+    DataSet(hid_t hid, bool is_copy) : LocID(hid, is_copy) { }
+
     DataSet(const DataSet &other);
 
     void read(hid_t memType, void *data) const;

--- a/include/nix/hdf5/Group.hpp
+++ b/include/nix/hdf5/Group.hpp
@@ -36,6 +36,8 @@ public:
 
     Group(hid_t hid);
 
+    Group(hid_t hid, bool is_copy) : LocID(hid, is_copy) { }
+
     Group(const Group &other);
 
     bool hasObject(const std::string &path) const;

--- a/include/nix/hdf5/LocID.hpp
+++ b/include/nix/hdf5/LocID.hpp
@@ -25,6 +25,8 @@ public:
 
     LocID(hid_t hid);
 
+    LocID(hid_t hid, bool is_copy) : BaseHDF5(hid, is_copy) { }
+
     LocID(const LocID &other);
 
     bool hasAttr(const std::string &name) const;

--- a/src/hdf5/Attribute.cpp
+++ b/src/hdf5/Attribute.cpp
@@ -46,15 +46,9 @@ void Attribute::write(H5::DataType mem_type, const NDSize &size, const std::stri
 
 DataSpace Attribute::getSpace() const {
 
-    hid_t space = H5Aget_space(hid);
-    if (space < 0) {
-        throw H5Exception("Attribute::getSpace(): Dould not get data space");
-    }
-
-    DataSpace ds(space);
-    H5Idec_ref(space);
-
-    return ds;
+    DataSpace space = H5Aget_space(hid);
+    space.check("Attribute::getSpace(): Dould not get data space");
+    return space;
 }
 
 NDSize Attribute::extent() const {

--- a/src/hdf5/BaseHDF5.cpp
+++ b/src/hdf5/BaseHDF5.cpp
@@ -71,6 +71,11 @@ int BaseHDF5::refCount() const {
     }
 }
 
+bool BaseHDF5::isValid() const {
+    HTri res = H5Iis_valid(hid);
+    res.check("BaseHDF5::isValid() failed");
+    return res.result();
+}
 
 std::string BaseHDF5::name() const {
     if (! H5Iis_valid(hid)) {

--- a/src/hdf5/BaseHDF5.cpp
+++ b/src/hdf5/BaseHDF5.cpp
@@ -16,18 +16,6 @@ namespace nix {
 namespace hdf5 {
 
 
-BaseHDF5::BaseHDF5()
-    : hid(H5I_INVALID_HID)
-{}
-
-
-BaseHDF5::BaseHDF5(hid_t id)
-    : hid(id)
-{
-    inc();
-}
-
-
 BaseHDF5::BaseHDF5(const BaseHDF5 &other)
     : hid(other.hid)
 {

--- a/src/hdf5/DataSetHDF5.cpp
+++ b/src/hdf5/DataSetHDF5.cpp
@@ -290,13 +290,9 @@ DataType DataSet::dataType(void) const
 }
 
 DataSpace DataSet::getSpace() const {
-    hid_t space = H5Dget_space(hid);
-    if (space < 0) {
-        throw new H5Exception("DataSet::getSpace(): Could not obtain dataspace");
-    }
-    DataSpace sp(space);
-    H5Idec_ref(space);
-    return sp;
+    DataSpace space = H5Dget_space(hid);
+    space.check("DataSet::getSpace(): Could not obtain dataspace");
+    return space;
 }
 
 /* Value related functions */

--- a/src/hdf5/DataSpace.cpp
+++ b/src/hdf5/DataSpace.cpp
@@ -33,13 +33,8 @@ DataSpace DataSpace::create(const NDSize &dims, const NDSize &maxdims)
         }
     }
 
-    if (spaceId < 0) {
-        H5Exception("Could not create data space");
-    }
-
     space = DataSpace(spaceId);
-    H5Idec_ref(spaceId);
-
+    space.check("Could not create data space");
     return space;
 }
 

--- a/src/hdf5/FileHDF5.cpp
+++ b/src/hdf5/FileHDF5.cpp
@@ -72,14 +72,8 @@ FileHDF5::FileHDF5(const string &name, FileMode mode)
         throw H5Exception("Could not open/create file");
     }
 
-    hid_t h5root = H5Gopen2(hid, "/", H5P_DEFAULT);
-
-    if (!H5Iis_valid(hid)) {
-        throw H5Exception("Could not root group");
-    }
-
-    root = Group(h5root);
-    H5Idec_ref(h5root);
+    root = Group(H5Gopen2(hid, "/", H5P_DEFAULT));
+    root.check("Could not root group");
 
     metadata = root.openGroup("metadata");
     data = root.openGroup("data");

--- a/src/hdf5/LocID.cpp
+++ b/src/hdf5/LocID.cpp
@@ -39,7 +39,7 @@ void LocID::removeAttr(const std::string &name) const {
 Attribute LocID::openAttr(const std::string &name) const {
     hid_t ha = H5Aopen(hid, name.c_str(), H5P_DEFAULT);
     Attribute attr = Attribute(ha);
-    H5Idec_ref(ha);
+    attr.check("LocID::openAttr: Could not open attribute " + name);
     return attr;
 }
 
@@ -47,7 +47,7 @@ Attribute LocID::openAttr(const std::string &name) const {
 Attribute LocID::createAttr(const std::string &name, H5::DataType fileType, const DataSpace &fileSpace) const {
     hid_t ha = H5Acreate(hid, name.c_str(), fileType.getId(), fileSpace.h5id(), H5P_DEFAULT, H5P_DEFAULT);
     Attribute attr = Attribute(ha);
-    H5Idec_ref(ha);
+    attr.check("LocID::openAttr: Could not create attribute " + name);
     return attr;
 }
 

--- a/test/RefTester.hpp
+++ b/test/RefTester.hpp
@@ -1,0 +1,97 @@
+// Copyright © 2015 German Neuroinformatics Node (G-Node)
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted under the terms of the BSD License. See
+// LICENSE file in the root of the Project.
+//
+// Author: Christian Kellner <kellner@bio.lmu.de>
+
+#include <nix/hdf5/BaseHDF5.hpp>
+
+struct RefTester {
+    RefTester(hid_t id) : obj(id) {
+        if (H5Iis_valid(id)) {
+            ref = H5Iget_ref(id);
+        } else {
+            ref = 0;
+        }
+    }
+
+    void inc_check(nix::hdf5::BaseHDF5* wrapped = nullptr) {
+        ref++;
+        check(wrapped);
+    }
+
+    void dec_check(nix::hdf5::BaseHDF5* wrapped = nullptr) {
+        ref--;
+        check(wrapped);
+    }
+
+    void check(nix::hdf5::BaseHDF5* wrapped = nullptr) {
+        CPPUNIT_ASSERT_EQUAL(H5Iget_ref(obj), ref);
+        if (wrapped) {
+            CPPUNIT_ASSERT_EQUAL(obj, wrapped->h5id());
+            CPPUNIT_ASSERT_EQUAL(ref, wrapped->refCount());
+        }
+    }
+
+    int   ref;
+    hid_t obj;
+};
+
+template<typename T>
+void test_refcounting(hid_t a_id, hid_t b_id) {
+
+    RefTester a_tst = a_id;
+    RefTester b_tst = b_id;
+
+    T obj_invalid{};
+    CPPUNIT_ASSERT_EQUAL(H5I_INVALID_HID, obj_invalid.h5id());
+
+    T wa_copy(a_id, true); // +1
+    a_tst.inc_check(&wa_copy);
+
+    //non-transfering ownership test
+    H5Iinc_ref(a_id); // +1, because if we transfer ownership, the need an extra one
+    a_tst.inc_check();
+    T wa_owner(a_id, false); // =, take ownership, no refcount change to a
+    a_tst.check(&wa_owner);
+
+    T wa_ic = a_id; // +1, currently makes a copy
+    a_tst.inc_check(&wa_ic);
+
+    {
+        T tmp = T(a_id, true); //+1
+        a_tst.inc_check(&tmp);
+    }
+    a_tst.dec_check();
+
+    {
+        T tmp = T(a_id, true); //+1
+        a_tst.inc_check(&tmp);
+        tmp.close();        //-1
+        a_tst.dec_check();
+    }
+
+    a_tst.check();  // =
+
+    wa_copy = wa_owner; //=, self assignment, i.e. no inc ref
+
+    a_tst.check(&wa_copy);
+    a_tst.check(&wa_owner);
+
+    //now with two objects ...
+
+    CPPUNIT_ASSERT(a_id != b_id);
+
+    T wb_copy(b_id, true); // + 1
+    b_tst.inc_check(&wb_copy);
+
+    // copy-assignment ctor
+    wa_copy = wb_copy; // + 1 b, - 1 a
+    a_tst.dec_check();
+    b_tst.inc_check(&wb_copy);
+    b_tst.check(&wa_copy);
+}

--- a/test/RefTester.hpp
+++ b/test/RefTester.hpp
@@ -59,8 +59,10 @@ void test_refcounting(hid_t a_id, hid_t b_id) {
     T wa_owner(a_id, false); // =, take ownership, no refcount change to a
     a_tst.check(&wa_owner);
 
-    T wa_ic = a_id; // +1, currently makes a copy
-    a_tst.inc_check(&wa_ic);
+    H5Iinc_ref(a_id);
+    a_tst.inc_check();
+    T wa_ic = a_id; // =, this transfers ownership
+    a_tst.check(&wa_ic);
 
     {
         T tmp = T(a_id, true); //+1

--- a/test/TestDataSet.cpp
+++ b/test/TestDataSet.cpp
@@ -13,6 +13,7 @@
 #include <nix/DataType.hpp>
 
 #include <string.h>
+#include "RefTester.hpp"
 
 using namespace nix; //quick fix for now
 
@@ -192,10 +193,12 @@ void TestDataSet::testDataType() {
 void TestDataSet::testBasic() {
     NDSize dims({4, 6});
 
-    hdf5::DataSet ds = h5group.createData("dsZero", DataType::Double, nix::NDSize({ 0, 0 }));
-    CPPUNIT_ASSERT_EQUAL(ds.size(), (NDSize{0, 0}));
+    hdf5::DataSet dsZero = h5group.createData("dsZero", DataType::Double, nix::NDSize({ 0, 0 }));
+    CPPUNIT_ASSERT_EQUAL(dsZero.size(), (NDSize{0, 0}));
 
-    ds = h5group.createData("dsDouble", DataType::Double, dims);
+    hdf5::DataSet ds = h5group.createData("dsDouble", DataType::Double, dims);
+
+    test_refcounting<hdf5::DataSet>(dsZero.h5id(), ds.h5id());
 
     typedef boost::multi_array<double, 2> array_type;
     typedef array_type::index index;

--- a/test/TestDataSet.cpp
+++ b/test/TestDataSet.cpp
@@ -45,7 +45,6 @@ void TestDataSet::setUp() {
 
     CPPUNIT_ASSERT(H5Iis_valid(g));
     h5group = nix::hdf5::Group(g);
-    H5Idec_ref(g);
 
     openMode = H5F_ACC_RDWR;
 }

--- a/test/TestGroup.cpp
+++ b/test/TestGroup.cpp
@@ -10,6 +10,7 @@
 
 #include <nix/hdf5/FileHDF5.hpp>
 #include "TestGroup.hpp"
+#include "RefTester.hpp"
 
 unsigned int & TestGroup::open_mode()
 {
@@ -202,55 +203,7 @@ void TestGroup::testOpen() {
 
 void TestGroup::testRefCount() {
 
-    nix::hdf5::Group wrapped(h5group);
-
-    CPPUNIT_ASSERT_EQUAL(2, H5Iget_ref(h5group));
-    CPPUNIT_ASSERT_EQUAL(h5group, wrapped.h5id());
-    CPPUNIT_ASSERT_EQUAL(2, H5Iget_ref(h5group));
-
-    nix::hdf5::Group g;
-    CPPUNIT_ASSERT_EQUAL(H5I_INVALID_HID, g.h5id());
-
-    g = nix::hdf5::Group(h5group);
-    CPPUNIT_ASSERT_EQUAL(h5group, g.h5id());
-    CPPUNIT_ASSERT_EQUAL(3, H5Iget_ref(h5group));
-    nix::hdf5::Group c = g;
-
-    CPPUNIT_ASSERT_EQUAL(h5group, c.h5id());
-    CPPUNIT_ASSERT_EQUAL(4, H5Iget_ref(h5group));
-
-    {
-        nix::hdf5::Group tmp = g;
-        CPPUNIT_ASSERT_EQUAL(h5group, tmp.h5id());
-        CPPUNIT_ASSERT_EQUAL(5, H5Iget_ref(h5group));
-    }
-
-    CPPUNIT_ASSERT_EQUAL(4, H5Iget_ref(h5group));
-
     hid_t ha = H5Gopen2(h5file, "/", H5P_DEFAULT);
-
-    CPPUNIT_ASSERT(ha != h5group);
-
-    CPPUNIT_ASSERT_EQUAL(1, H5Iget_ref(ha));
-    nix::hdf5::Group b(ha);
-    CPPUNIT_ASSERT_EQUAL(ha, b.h5id());
-    CPPUNIT_ASSERT_EQUAL(2, H5Iget_ref(ha));
-
-    wrapped = nix::hdf5::Group(h5group);  // test self assignment! no inc ref
-    CPPUNIT_ASSERT_EQUAL(h5group, wrapped.h5id());
-    CPPUNIT_ASSERT_EQUAL(4, H5Iget_ref(h5group));
-    CPPUNIT_ASSERT_EQUAL(2, H5Iget_ref(ha));
-
-    c = nix::hdf5::Group(b);
-    CPPUNIT_ASSERT_EQUAL(ha, c.h5id());
-    CPPUNIT_ASSERT_EQUAL(3, H5Iget_ref(h5group));
-    CPPUNIT_ASSERT_EQUAL(3, H5Iget_ref(ha));
-
-    wrapped = c;
-    CPPUNIT_ASSERT_EQUAL(2, H5Iget_ref(h5group));
-    CPPUNIT_ASSERT_EQUAL(4, H5Iget_ref(ha));
-
-    b = wrapped;
-    CPPUNIT_ASSERT_EQUAL(2, H5Iget_ref(h5group));
-    CPPUNIT_ASSERT_EQUAL(4, H5Iget_ref(ha));
+    test_refcounting<nix::hdf5::Group>(h5group, ha);
+    H5Gclose(ha);
 }

--- a/test/TestGroup.cpp
+++ b/test/TestGroup.cpp
@@ -44,7 +44,7 @@ void TestGroup::tearDown() {
 }
 
 void TestGroup::testBaseTypes() {
-    nix::hdf5::Group group(h5group);
+    nix::hdf5::Group group(h5group, true);
 
     //int
     //attr
@@ -73,7 +73,7 @@ void TestGroup::testBaseTypes() {
 }
 
 void TestGroup::testMultiArray() {
-    nix::hdf5::Group group(h5group);
+    nix::hdf5::Group group(h5group, true);
     //arrays
     typedef boost::multi_array<double, 3> array_type;
     typedef array_type::index index;
@@ -125,7 +125,7 @@ void TestGroup::testMultiArray() {
 }
 
 void TestGroup::testVector() {
-    nix::hdf5::Group group(h5group);
+    nix::hdf5::Group group(h5group, true);
 
     std::vector<int> iv;
     iv.push_back(7);
@@ -153,7 +153,7 @@ void TestGroup::testVector() {
 
 void TestGroup::testArray() {
 
-    nix::hdf5::Group group(h5group);
+    nix::hdf5::Group group(h5group, true);
     int ia1d[5] = {1, 2, 3, 4, 5};
 
     group.setAttr("t_intarray1d", ia1d);
@@ -177,7 +177,7 @@ void TestGroup::testArray() {
 }
 
 void TestGroup::testOpen() {
-    nix::hdf5::Group root(h5group);
+    nix::hdf5::Group root(h5group, true);
 
     nix::hdf5::Group g = root.openGroup("name_a", true);
     std::string uuid = nix::util::createId();

--- a/test/TestH5.cpp
+++ b/test/TestH5.cpp
@@ -41,7 +41,6 @@ void TestH5::setUp() {
 
     CPPUNIT_ASSERT(H5Iis_valid(g));
     h5group = nix::hdf5::Group(g);
-    H5Idec_ref(g);
 
     openMode = H5F_ACC_RDWR;
 }
@@ -102,8 +101,6 @@ void TestH5::testBase() {
     std::string name = h5group.name();
 
     CPPUNIT_ASSERT_EQUAL(std::string("/h5"), name);
-
-    nix::hdf5::Group g_invalid{};
     CPPUNIT_ASSERT_EQUAL(std::string{}, g_invalid.name());
 
 }
@@ -119,9 +116,6 @@ void TestH5::testDataSpace() {
     CPPUNIT_ASSERT_EQUAL(es[0], dims[0]);
     CPPUNIT_ASSERT_EQUAL(es[1], dims[1]);
 
-    space.close();
     CPPUNIT_ASSERT_EQUAL(1, H5Iget_ref(ds));
-
-    H5Sclose(ds);
-
+    space.close();
 }

--- a/test/TestH5.cpp
+++ b/test/TestH5.cpp
@@ -12,6 +12,8 @@
 #include <nix/hdf5/ExceptionHDF5.hpp>
 #include "TestH5.hpp"
 
+#include "RefTester.hpp"
+
 unsigned int & TestH5::open_mode()
 {
     static unsigned int openMode = H5F_ACC_TRUNC;
@@ -79,7 +81,16 @@ void TestH5::testBase() {
     CPPUNIT_ASSERT_THROW(htri_error.check("Error"), nix::hdf5::H5Exception);
 
     //check BaseHDF5
+    //ref counting
+    hid_t ga = H5Gopen(h5file, "/", H5P_DEFAULT);
+    hid_t gb = H5Gopen(h5file, "/h5", H5P_DEFAULT);
 
+    CPPUNIT_ASSERT(ga > 0);
+    CPPUNIT_ASSERT(gb > 0);
+
+    test_refcounting<nix::hdf5::BaseHDF5>(ga, gb);
+
+    //name()
     std::string name = h5group.name();
 
     CPPUNIT_ASSERT_EQUAL(std::string("/h5"), name);

--- a/test/TestH5.cpp
+++ b/test/TestH5.cpp
@@ -90,6 +90,8 @@ void TestH5::testBase() {
 
     test_refcounting<nix::hdf5::BaseHDF5>(ga, gb);
 
+    test_refcounting<nix::hdf5::LocID>(ga, gb);
+
     //name()
     std::string name = h5group.name();
 

--- a/test/TestH5.cpp
+++ b/test/TestH5.cpp
@@ -53,6 +53,11 @@ void TestH5::tearDown() {
 
 
 void TestH5::testBase() {
+    CPPUNIT_ASSERT(h5group.isValid());
+
+    nix::hdf5::Group g_invalid{};
+    CPPUNIT_ASSERT_EQUAL(false, g_invalid.isValid());
+    CPPUNIT_ASSERT_THROW(g_invalid.check("Error"), nix::hdf5::H5Exception);
 
     // check HTri
 
@@ -81,6 +86,7 @@ void TestH5::testBase() {
     CPPUNIT_ASSERT_THROW(htri_error.check("Error"), nix::hdf5::H5Exception);
 
     //check BaseHDF5
+
     //ref counting
     hid_t ga = H5Gopen(h5file, "/", H5P_DEFAULT);
     hid_t gb = H5Gopen(h5file, "/h5", H5P_DEFAULT);


### PR DESCRIPTION
`BaseHDF5::BaseHDF5(hid_t)` used to do a `inc()`, i.e making a
copy of the object. It now takes over ownership by not doing that
`inc()`. This allows code like `Group g = H5Gopen()` instead of
the longer version`hid_t o = H5Gopen(); Group g = o; H5Idec_ref(o);`.

