### PR TITLE
[travis] cleanup travis file

### DIFF
--- a/.travis.ctest
+++ b/.travis.ctest
@@ -1,7 +1,7 @@
 
 string(SUBSTRING "$ENV{TRAVIS_COMMIT}" 0 7 COMMIT_ID)
 set(CTEST_SITE "travis")
-set(CTEST_BUILD_NAME "$ENV{TRAVIS_BUILD_NUMBER}-${COMMIT_ID}-$ENV{COMPILER}")
+set(CTEST_BUILD_NAME "$ENV{TRAVIS_BUILD_NUMBER}-${COMMIT_ID}-$ENV{CXX}")
 
 set(CTEST_SOURCE_DIRECTORY "$ENV{TRAVIS_BUILD_DIR}")
 set(CTEST_BINARY_DIRECTORY "${CTEST_SOURCE_DIRECTORY}/build")
@@ -28,17 +28,17 @@ ctest_start(Continuous)
 ctest_configure()
 ctest_build()
 
-if(CLANG_CHECK AND $ENV{COMPILER} MATCHES "clang")
+if(CLANG_CHECK AND $ENV{CXX} MATCHES "clang")
   ctest_build(TARGET check)
 endif()
 
 ctest_test()
 
-if(VALGRIND AND $ENV{COMPILER} MATCHES "clang")
+if(VALGRIND AND $ENV{CXX} MATCHES "clang")
   ctest_memcheck()
 endif()
 
-if(GCOV AND $ENV{COMPILER} MATCHES "g\\+\\+")
+if(GCOV AND $ENV{CXX} MATCHES "g\\+\\+")
   ctest_coverage()
 endif()
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ script:
 
 after_success:
   - if [[ "$CXX" == "g++" ]]; then
-      coveralls -b build --exclude test --exclude tmp --gcov gcov-4.8 --gcov-options '\-lp' > /dev/null ;
+      coveralls -b build -E ".*CMakeFiles.*" -e cli -e test -e tmp --gcov gcov-4.8 --gcov-options '\-lp' > /dev/null ;
     fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,42 @@
 language: cpp
-env:
-  matrix:
-    - COMPILER=g++-4.8 CTEST_ARGS=-V
-    - COMPILER=clang CXXFLAGS="-stdlib=libstdc++ -Qunused-arguments" CTEST_ARGS=-VV
 
-script:
-- CXX=${COMPILER} ctest ${CTEST_ARGS} --output-on-failure -S .travis.ctest
+compiler:
+  - gcc
+  - clang
 
 before_install:
-  - if [[ "$COMPILER" == "g++-4.8" ]]; then sudo pip install cpp-coveralls; fi
+  - if [[ "$CXX" == "g++" ]]; then
+      export CTEST_ARGS=-V;
+      sudo pip install cpp-coveralls;
+    else
+      export CTEST_ARGS=-VV;
+    fi
 
 install:
-- sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-- sudo add-apt-repository ppa:boost-latest/ppa -y
-- sudo add-apt-repository ppa:gnode/pandora -y
-- sudo apt-get update -qq -y
-- sudo apt-get install -q gcc-4.8 g++-4.8 libstdc++-4.8-dev libcppunit-dev libboost1.54-all-dev libhdf5-serial-dev libhdf5-dev libhdf5-7 valgrind cmake
+  - sudo add-apt-repository ppa:boost-latest/ppa -y
+  - sudo add-apt-repository ppa:gnode/pandora -y
+  - sudo apt-get update -qq -y
+  - sudo apt-get install -q libcppunit-dev libboost1.54-all-dev libhdf5-serial-dev libhdf5-dev libhdf5-7 valgrind cmake
+  - if [[ "$CXX" == "g++" ]]; then
+      sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y;
+      sudo apt-get update -qq -y;
+      sudo apt-get install -q gcc-4.8 g++-4.8 libstdc++-4.8-dev;
+      sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100;
+      sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 100;
+      sudo update-alternatives --config gcc;
+      sudo update-alternatives --config g++;
+      g++ --version;
+    else
+      clang --version;
+    fi
+
+script:
+  - ctest ${CTEST_ARGS} --output-on-failure -S .travis.ctest
 
 after_success:
-  - if [[ "$COMPILER" == "g++-4.8" ]]; then coveralls -b build --exclude test --exclude tmp --gcov gcov-4.8 --gcov-options '\-lp' > /dev/null ; fi
+  - if [[ "$CXX" == "g++" ]]; then
+      coveralls -b build --exclude test --exclude tmp --gcov gcov-4.8 --gcov-options '\-lp' > /dev/null ;
+    fi
 
 notifications:
   irc: "chat.freenode.net#gnode"


### PR DESCRIPTION
- Use `compiler` directive instead of custom matrix+env variables
- Only install g++-4.8 for g++ builds
- Use `update-alternatives` to select g++-4.8