### PR TITLE
[m32] Fix warnings on win32

### DIFF
--- a/include/nix/NDSize.hpp
+++ b/include/nix/NDSize.hpp
@@ -269,7 +269,7 @@ public:
         std::for_each(begin(), end(), [&](T val) {
             product *= val;
         });
-        //FIXME: check overflow before casting
+        //FIXME: return-type should be T too, issue #473
         return static_cast<size_t>(product);
     }
 

--- a/include/nix/hydra/multiArray.hpp
+++ b/include/nix/hydra/multiArray.hpp
@@ -21,6 +21,8 @@
 
 #include <nix/Hydra.hpp>
 
+#include <type_traits>
+
 #ifndef HYDRA_MULTI_ARRAY_H
 #define HYDRA_MULTI_ARRAY_H
 
@@ -65,12 +67,23 @@ public:
     }
 
     static void resize(reference value, const NDSize &dims) {
-        if (dims.size() != N) {
-            throw InvalidRank("Cannot change rank of multiarray");
+        check_rank(dims.size());
+        //FIXME: not needed for ndsize_t == size_t case, optimize
+        std::vector<size_t> size(N);
+
+        for (size_t i = 0; i < N; i++) {
+            size[i] = check::fits_in_size_t(dims[i], "Cannot resize multiarray: too big for memroy");
         }
 
-        value.resize(dims);
+        value.resize(size);
     }
+
+    static void check_rank(size_t rank) {
+        if (rank != N) {
+            throw InvalidRank("Cannot change rank of multiarray");
+        }
+    }
+
 };
 
 } //nix::

--- a/src/NDArray.cpp
+++ b/src/NDArray.cpp
@@ -45,8 +45,9 @@ void NDArray::calc_strides() {
 
 
 size_t NDArray::sub2index(const NDSize &sub) const {
-    size_t index = strides.dot(sub);
-    return index;
+    ndsize_t pos = strides.dot(sub);
+    size_t idx = check::fits_in_size_t(pos, "index does not fit into memory");
+    return idx;
 }
 
 } // namespace nix

--- a/src/hdf5/DataSetHDF5.cpp
+++ b/src/hdf5/DataSetHDF5.cpp
@@ -469,7 +469,7 @@ void DataSet::read(std::vector<Value> &values) const
     }
 
     assert(shape.size() == 1);
-    size_t nvalues = shape[0];
+    size_t nvalues = nix::check::fits_in_size_t(shape[0], "Can't resize: data to big for memory");
 
     switch (dtype) {
     case DataType::Bool:   do_read_value<bool>(*this, nvalues, values);     break;

--- a/src/hdf5/Group.cpp
+++ b/src/hdf5/Group.cpp
@@ -71,7 +71,8 @@ size_t Group::objectCount() const {
     hsize_t n_objs;
     HErr res = H5Gget_num_objs(hid, &n_objs);
     res.check("Could not get object count");
-    return n_objs;
+    //FIXME: return type should be ndsize_t, #473
+    return static_cast<size_t>(n_objs);
 }
 
 

--- a/src/hdf5/PropertyHDF5.cpp
+++ b/src/hdf5/PropertyHDF5.cpp
@@ -215,7 +215,8 @@ void PropertyHDF5::deleteValues() {
 
 size_t PropertyHDF5::valueCount() const {
     NDSize size = dataset().size();
-    return size[0];
+    //FIXME: 32bit casting issue, cf issue #473
+    return static_cast<size_t>(size[0]);
 }
 
 

--- a/src/util/dataAccess.cpp
+++ b/src/util/dataAccess.cpp
@@ -105,7 +105,7 @@ void getOffsetAndCount(const Tag &tag, const DataArray &array, NDSize &offset, N
         Dimension dim = array.getDimension(i+1);
         temp_offset[i] = positionToIndex(position[i], i >= units.size() ? "none" : units[i], dim);
         if (i < extent.size()) {
-            size_t c = positionToIndex(position[i] + extent[i], i >= units.size() ? "none" : units[i], dim) - temp_offset[i];
+            ndsize_t c = positionToIndex(position[i] + extent[i], i >= units.size() ? "none" : units[i], dim) - temp_offset[i];
             temp_count[i] = (c > 1) ? c : 1;
         }
     }
@@ -178,7 +178,7 @@ void getOffsetAndCount(const MultiTag &tag, const DataArray &array, size_t index
             if (i <= units.size() && units.size() > 0) {
                 unit = units[i];
             }
-            size_t c = positionToIndex(offset[i] + extent[i], unit, dimension) - data_offset[i];
+            ndsize_t c = positionToIndex(offset[i] + extent[i], unit, dimension) - data_offset[i];
             data_count[i] = (c > 1) ? c : 1;
         }
     }

--- a/test/TestH5.cpp
+++ b/test/TestH5.cpp
@@ -133,6 +133,16 @@ void TestH5::testBase() {
 
     CPPUNIT_ASSERT_EQUAL(std::string("/h5"), name);
     CPPUNIT_ASSERT_EQUAL(std::string{}, g_invalid.name());
+
+    //FIXME: this should be somewhere lese
+
+    size_t sz_a = 10;
+    CPPUNIT_ASSERT_EQUAL(sz_a, nix::check::fits_in_size_t(sz_a, "OOB"));
+
+    //this is a bit of a hack to get a size that will be bigger then
+    //size_t's max value on 64bit systems
+    double sz_b = static_cast<double>(std::numeric_limits<size_t>::max()) * 2.0;
+    CPPUNIT_ASSERT_THROW(nix::check::fits_in_size_t(sz_b, "OOB"), nix::OutOfBounds);
 }
 
 void TestH5::testDataType() {


### PR DESCRIPTION
This should fix all build warnings on windows (32bit & 64bit),
i.e. close issue #447. Although not all are properly fixed since
that requires some refactoring (issue #473).