### PR TITLE
Remove the const refs in check.cpp and some work on the validation

### DIFF
--- a/include/nix/valid/checks.hpp
+++ b/include/nix/valid/checks.hpp
@@ -330,7 +330,7 @@ namespace valid {
      * via "size" the method.
      */
     struct NIXAPI dimEquals {
-        const size_t &value;
+        size_t value;
         
         dimEquals(const size_t &value) : value(value) {}
         
@@ -354,7 +354,7 @@ namespace valid {
      * in given unit vector.
      */
     struct NIXAPI tagRefsHaveUnits {
-        const std::vector<std::string> &units;
+        std::vector<std::string> units;
         
         tagRefsHaveUnits(const std::vector<std::string> &units) : units(units) {}
         
@@ -378,7 +378,7 @@ namespace valid {
      * in a DataArray differs the number of units in the units vector.
      */
     struct NIXAPI tagUnitsMatchRefsUnits {
-        const std::vector<std::string> &units;
+        std::vector<std::string> units;
         
         tagUnitsMatchRefsUnits(const std::vector<std::string> &units) : units(units) {}
         
@@ -393,7 +393,7 @@ namespace valid {
      * which gets passed at construction time and which via operator().
      */
     struct NIXAPI extentsMatchPositions {
-        const boost::any extents;
+        boost::any extents;
         
         extentsMatchPositions(const DataArray &extents) : extents(extents) {}
         
@@ -412,7 +412,7 @@ namespace valid {
      * dimensionality in each of the given referenced DataArrays.
      */
     struct NIXAPI extentsMatchRefs {
-        const std::vector<DataArray> &refs;
+        std::vector<DataArray> refs;
         
         extentsMatchRefs(const std::vector<DataArray> &refs) : refs(refs) {}
 
@@ -431,7 +431,7 @@ namespace valid {
      * same thing.
      */
     struct NIXAPI positionsMatchRefs {
-        const std::vector<DataArray> &refs;
+        std::vector<DataArray> refs;
 
         positionsMatchRefs(const std::vector<DataArray> &refs) : refs(refs) {}
     

--- a/src/valid/checks.cpp
+++ b/src/valid/checks.cpp
@@ -103,12 +103,14 @@ bool dimTicksMatchData::operator()(const std::vector<Dimension> &dims) const {
     while (!mismatch && it != dims.end()) {
         if ((*it).dimensionType() == DimensionType::Range) {
             size_t dimIndex = (*it).index() - 1;
+            if (dimIndex >= data.dataExtent().size()) {
+                break;
+            }
             auto dim = (*it).asRangeDimension();
             mismatch = !(dim.ticks().size() == data.dataExtent()[dimIndex]);
         }
         ++it;
     }
-    
     return !mismatch;
 }
 
@@ -118,6 +120,9 @@ bool dimLabelsMatchData::operator()(const std::vector<Dimension> &dims) const {
     while (!mismatch && it != dims.end()) {
         if ((*it).dimensionType() == DimensionType::Set) {
             size_t dimIndex = (*it).index() - 1;
+            if (dimIndex >= data.dataExtent().size()) {
+                break;
+            }
             auto dim = (*it).asSetDimension();
             mismatch = dim.labels().size() > 0 && !(dim.labels().size() == data.dataExtent()[dimIndex]);
         }

--- a/src/valid/checks.cpp
+++ b/src/valid/checks.cpp
@@ -104,12 +104,12 @@ bool dimTicksMatchData::operator()(const std::vector<Dimension> &dims) const {
         if ((*it).dimensionType() == DimensionType::Range) {
             size_t dimIndex = (*it).index() - 1;
             auto dim = (*it).asRangeDimension();
-            mismatch = dim.ticks().size() == data.dataExtent()[dimIndex];
+            mismatch = !(dim.ticks().size() == data.dataExtent()[dimIndex]);
         }
         ++it;
     }
     
-    return mismatch;
+    return !mismatch;
 }
 
 bool dimLabelsMatchData::operator()(const std::vector<Dimension> &dims) const {
@@ -119,12 +119,12 @@ bool dimLabelsMatchData::operator()(const std::vector<Dimension> &dims) const {
         if ((*it).dimensionType() == DimensionType::Set) {
             size_t dimIndex = (*it).index() - 1;
             auto dim = (*it).asSetDimension();
-            mismatch = dim.labels().size() == data.dataExtent()[dimIndex];
+            mismatch = dim.labels().size() > 0 && !(dim.labels().size() == data.dataExtent()[dimIndex]);
         }
         ++it;
     }
     
-    return mismatch;
+    return !mismatch;
 }
 
 } // namespace valid

--- a/src/valid/validate.cpp
+++ b/src/valid/validate.cpp
@@ -103,7 +103,7 @@ Result validate(const DataArray &data_array) {
         must(data_array, &DataArray::dataType, notEqual<DataType>(DataType::Nothing), "data type is not set!"),
         must(data_array, &DataArray::dimensionCount, isEqual<size_t>(data_array.dataExtent().size()), "data dimensionality does not match number of defined dimensions!", {
             could(data_array, &DataArray::dimensions, notEmpty(), {
-                must(data_array, &DataArray::dimensions, dimTicksMatchData(data_array), "in some of the Range dimensions the number of ticks differs from the number of data entries along the corresponding data dimension!"),
+                should(data_array, &DataArray::dimensions, dimTicksMatchData(data_array), "in some of the Range dimensions the number of ticks differs from the number of data entries along the corresponding data dimension!"),
                 must(data_array, &DataArray::dimensions, dimLabelsMatchData(data_array), "in some of the Set dimensions the number of labels differs from the number of data entries along the corresponding data dimension!") }) }),
         could(data_array, &DataArray::unit, notFalse(), {
             must(data_array, &DataArray::unit, isValidUnit(), "Unit is not SI or composite of SI units.") }),

--- a/src/valid/validate.cpp
+++ b/src/valid/validate.cpp
@@ -167,8 +167,7 @@ Result validate(const MultiTag &multi_tag) {
         // check units for validity
         could(multi_tag, &MultiTag::units, notEmpty(), {
             must(multi_tag, &MultiTag::units, isValidUnit(), "Some of the units in tag are invalid: not an atomic SI. Note: So far composite SI units are not supported!"),
-            could(multi_tag, &MultiTag::references, tagRefsHaveUnits(multi_tag.units()), {
-                    must(multi_tag, &MultiTag::references, tagUnitsMatchRefsUnits(multi_tag.units()), "Some of the referenced DataArrays' dimensions have units that are not convertible to the units set in tag. Note: So far composite SI units are not supported!")})}),
+            must(multi_tag, &MultiTag::references, tagUnitsMatchRefsUnits(multi_tag.units()), "Some of the referenced DataArrays' dimensions have units that are not convertible to the units set in tag. Note: So far composite SI units are not supported!")}),
         // check positions & extents
         could(multi_tag, &MultiTag::extents, notFalse(), {
             must(multi_tag, &MultiTag::positions, extentsMatchPositions(multi_tag.extents()), "Number of entries in positions and extents do not match!") }),

--- a/src/valid/validate.cpp
+++ b/src/valid/validate.cpp
@@ -166,9 +166,9 @@ Result validate(const MultiTag &multi_tag) {
             must(multi_tag, &MultiTag::extents, dimEquals(2), "dimensionality of extents DataArray must be two!") }),
         // check units for validity
         could(multi_tag, &MultiTag::units, notEmpty(), {
-            must(multi_tag, &MultiTag::units, isValidUnit(), "Some of the units in tag are invalid: not an atomic SI. Note: So far composite SI units are not supported!") }),
-        must(multi_tag, &MultiTag::references, tagRefsHaveUnits(multi_tag.units()), "Some of the referenced DataArrays' dimensions don't have units where the tag has. Make sure that all references have the same number of dimensions as the tag has units and that each dimension has a unit set."),
-        must(multi_tag, &MultiTag::references, tagUnitsMatchRefsUnits(multi_tag.units()), "Some of the referenced DataArrays' dimensions have units that are not convertible to the units set in tag. Note: So far composite SI units are not supported!"),
+            must(multi_tag, &MultiTag::units, isValidUnit(), "Some of the units in tag are invalid: not an atomic SI. Note: So far composite SI units are not supported!"),
+            could(multi_tag, &MultiTag::references, tagRefsHaveUnits(multi_tag.units()), {
+                    must(multi_tag, &MultiTag::references, tagUnitsMatchRefsUnits(multi_tag.units()), "Some of the referenced DataArrays' dimensions have units that are not convertible to the units set in tag. Note: So far composite SI units are not supported!")})}),
         // check positions & extents
         could(multi_tag, &MultiTag::extents, notFalse(), {
             must(multi_tag, &MultiTag::positions, extentsMatchPositions(multi_tag.extents()), "Number of entries in positions and extents do not match!") }),

--- a/src/valid/validate.cpp
+++ b/src/valid/validate.cpp
@@ -103,7 +103,7 @@ Result validate(const DataArray &data_array) {
         must(data_array, &DataArray::dataType, notEqual<DataType>(DataType::Nothing), "data type is not set!"),
         must(data_array, &DataArray::dimensionCount, isEqual<size_t>(data_array.dataExtent().size()), "data dimensionality does not match number of defined dimensions!", {
             could(data_array, &DataArray::dimensions, notEmpty(), {
-                should(data_array, &DataArray::dimensions, dimTicksMatchData(data_array), "in some of the Range dimensions the number of ticks differs from the number of data entries along the corresponding data dimension!"),
+                must(data_array, &DataArray::dimensions, dimTicksMatchData(data_array), "in some of the Range dimensions the number of ticks differs from the number of data entries along the corresponding data dimension!"),
                 must(data_array, &DataArray::dimensions, dimLabelsMatchData(data_array), "in some of the Set dimensions the number of labels differs from the number of data entries along the corresponding data dimension!") }) }),
         could(data_array, &DataArray::unit, notFalse(), {
             must(data_array, &DataArray::unit, isValidUnit(), "Unit is not SI or composite of SI units.") }),

--- a/src/valid/validate.cpp
+++ b/src/valid/validate.cpp
@@ -101,7 +101,7 @@ Result validate(const DataArray &data_array) {
     Result result_base = validate_entity_with_sources(data_array);
     Result result = validator({
         must(data_array, &DataArray::dataType, notEqual<DataType>(DataType::Nothing), "data type is not set!"),
-        should(data_array, &DataArray::dimensionCount, isEqual<size_t>(data_array.dataExtent().size()), "data dimensionality does not match number of defined dimensions!", {
+        must(data_array, &DataArray::dimensionCount, isEqual<size_t>(data_array.dataExtent().size()), "data dimensionality does not match number of defined dimensions!", {
             could(data_array, &DataArray::dimensions, notEmpty(), {
                 must(data_array, &DataArray::dimensions, dimTicksMatchData(data_array), "in some of the Range dimensions the number of ticks differs from the number of data entries along the corresponding data dimension!"),
                 must(data_array, &DataArray::dimensions, dimLabelsMatchData(data_array), "in some of the Set dimensions the number of labels differs from the number of data entries along the corresponding data dimension!") }) }),

--- a/src/valid/validate.cpp
+++ b/src/valid/validate.cpp
@@ -121,9 +121,10 @@ Result validate(const Tag &tag) {
     Result result = validator({
         must(tag, &Tag::position, notEmpty(), "position is not set!"),
         could(tag, &Tag::references, notEmpty(), {
-            must(tag, &Tag::position, positionsMatchRefs(tag.references()), 
+            must(tag, &Tag::position, positionsMatchRefs(tag.references()),
                 "number of entries in position does not match number of dimensions in all referenced DataArrays!"),
             could(tag, &Tag::extent, notEmpty(), {
+                must(tag, &Tag::position, extentsMatchPositions(tag.extent()), "Number of entries in position and extent do not match!"),
                 must(tag, &Tag::extent, extentsMatchRefs(tag.references()),
                     "number of entries in extent does not match number of dimensions in all referenced DataArrays!") })
         }),
@@ -132,10 +133,6 @@ Result validate(const Tag &tag) {
             must(tag, &Tag::units, isValidUnit(), "Unit is invalid: not an atomic SI. Note: So far composite units are not supported!"),
             must(tag, &Tag::references, tagRefsHaveUnits(tag.units()), "Some of the referenced DataArrays' dimensions don't have units where the tag has. Make sure that all references have the same number of dimensions as the tag has units and that each dimension has a unit set."),
                 must(tag, &Tag::references, tagUnitsMatchRefsUnits(tag.units()), "Some of the referenced DataArrays' dimensions have units that are not convertible to the units set in tag. Note: So far composite SI units are not supported!")}),
-        // check positions & extents
-        could(tag, &Tag::extent, notEmpty(), {
-            must(tag, &Tag::position, extentsMatchPositions(tag.extent()), "Number of entries in position and extent do not match!"),
-            must(tag, &Tag::extent, extentsMatchRefs(tag.references()), "number of entries in extent does not match number of dimensions in all referenced DataArrays!") })
     });
 
     return result.concat(result_base);

--- a/src/valid/validate.cpp
+++ b/src/valid/validate.cpp
@@ -129,9 +129,9 @@ Result validate(const Tag &tag) {
         }),
         // check units for validity
         could(tag, &Tag::units, notEmpty(), {
-            must(tag, &Tag::units, isValidUnit(), "Unit is invalid: not an atomic SI. Note: So far composite units are not supported!") }),
-        must(tag, &Tag::references, tagRefsHaveUnits(tag.units()), "Some of the referenced DataArrays' dimensions don't have units where the tag has. Make sure that all references have the same number of dimensions as the tag has units and that each dimension has a unit set."),
-        must(tag, &Tag::references, tagUnitsMatchRefsUnits(tag.units()), "Some of the referenced DataArrays' dimensions have units that are not convertible to the units set in tag. Note: So far composite SI units are not supported!"),
+            must(tag, &Tag::units, isValidUnit(), "Unit is invalid: not an atomic SI. Note: So far composite units are not supported!"),
+            must(tag, &Tag::references, tagRefsHaveUnits(tag.units()), "Some of the referenced DataArrays' dimensions don't have units where the tag has. Make sure that all references have the same number of dimensions as the tag has units and that each dimension has a unit set."),
+                must(tag, &Tag::references, tagUnitsMatchRefsUnits(tag.units()), "Some of the referenced DataArrays' dimensions have units that are not convertible to the units set in tag. Note: So far composite SI units are not supported!")}),
         // check positions & extents
         could(tag, &Tag::extent, notEmpty(), {
             must(tag, &Tag::position, extentsMatchPositions(tag.extent()), "Number of entries in position and extent do not match!"),

--- a/src/valid/validator.cpp
+++ b/src/valid/validator.cpp
@@ -16,9 +16,7 @@ Result validator(const std::vector<condition> &li) {
     Result result = Result();
 
     for (auto &sub : li) {
-         result = result.concat(
-            sub()
-        );
+        result = result.concat(sub());
     }
 
     return result;

--- a/test/TestDataArray.cpp
+++ b/test/TestDataArray.cpp
@@ -43,8 +43,8 @@ void TestDataArray::tearDown()
 void TestDataArray::testValidate() {
     // dims are not equal data dims: 1 warning
     valid::Result result = validate(array1);
-    CPPUNIT_ASSERT(result.getErrors().size() == 0);
-    CPPUNIT_ASSERT(result.getWarnings().size() == 1);
+    CPPUNIT_ASSERT(result.getErrors().size() == 1);
+    CPPUNIT_ASSERT(result.getWarnings().size() == 0);
 }
 
 

--- a/test/TestValidate.cpp
+++ b/test/TestValidate.cpp
@@ -80,7 +80,7 @@ void TestValidate::setValid() {
         }
     }
     array4.setData(sin_array);
-    for (index i = 1; i <= array4.dimensionCount(); ++i) {
+    for (size_t i = 1; i <= array4.dimensionCount(); ++i) {
         array4.deleteDimension(i);
     }
     array4.appendSampledDimension(1.);
@@ -122,12 +122,12 @@ void TestValidate::setValid() {
     extents.setData(C);
     
     // ensure correct dimension descriptors for positions
-    for (index i = 1; i <= positions.dimensionCount(); ++i) {
+    for (size_t i = 1; i <= positions.dimensionCount(); ++i) {
         positions.deleteDimension(i);
     }
     positions.appendSetDimension();
     positions.appendSetDimension();
-    for (index i = 1; i <= extents.dimensionCount(); ++i) {
+    for (size_t i = 1; i <= extents.dimensionCount(); ++i) {
         extents.deleteDimension(i);
     }
     extents.appendSetDimension();
@@ -150,7 +150,7 @@ void TestValidate::setValid() {
     dim_sample1.unit(atomic_units[0]);
     dim_sample2.unit(atomic_units[1]);
     dim_sample3.unit(atomic_units[2]);
-    // fill tag_tmp    
+    // fill tag_tmp
     units_tmp = tag_tmp(compound_units);
     
     return;
@@ -210,16 +210,16 @@ void TestValidate::setInvalid() {
     dim_sample3.unit(atomic_units[0]);
     dim_sample1.unit(atomic_units[1]);
     dim_sample2.unit(atomic_units[2]);
-    // fill tag_tmp    
+    // fill tag_tmp
     units_tmp = tag_tmp(invalid_units);
     // remove dimension descriptors from array4, position and extents
-    for (index i = 1; i <= array4.dimensionCount(); ++i) {
+    for (size_t i = 1; i <= array4.dimensionCount(); ++i) {
         array4.deleteDimension(i);
     }
-    for (index i = 1; i <= positions.dimensionCount(); ++i) {
+    for (size_t i = 1; i <= positions.dimensionCount(); ++i) {
         positions.deleteDimension(i);
     }
-    for (index i = 1; i <= extents.dimensionCount(); ++i) {
+    for (size_t i = 1; i <= extents.dimensionCount(); ++i) {
         extents.deleteDimension(i);
     }
     return;

--- a/test/TestValidate.cpp
+++ b/test/TestValidate.cpp
@@ -80,7 +80,7 @@ void TestValidate::setValid() {
         }
     }
     array4.setData(sin_array);
-    for (size_t i = 1; i <= array4.dimensionCount(); ++i) {
+    for (size_t i = array4.dimensionCount(); i > 0 ; --i) {
         array4.deleteDimension(i);
     }
     array4.appendSampledDimension(1.);
@@ -96,6 +96,13 @@ void TestValidate::setValid() {
                 A[i][j][k] = values++;
     array1.setData(A);
     array2.setData(A);
+    for (size_t i = array2.dimensionCount(); i > 0; --i) {
+        array2.deleteDimension(i);
+    }
+    dim_range1 = array2.appendRangeDimension({1, 2, 3});
+    dim_range2 = array2.appendRangeDimension({1, 2, 3, 4});
+    dim_range3 = array2.appendRangeDimension({1, 2});
+
     array3.setData(A);
 
     // fill extent & position
@@ -122,12 +129,12 @@ void TestValidate::setValid() {
     extents.setData(C);
     
     // ensure correct dimension descriptors for positions
-    for (size_t i = 1; i <= positions.dimensionCount(); ++i) {
+    for (size_t i = positions.dimensionCount(); i > 0; --i) {
         positions.deleteDimension(i);
     }
     positions.appendSetDimension();
     positions.appendSetDimension();
-    for (size_t i = 1; i <= extents.dimensionCount(); ++i) {
+    for (size_t i = extents.dimensionCount(); i > 0; --i) {
         extents.deleteDimension(i);
     }
     extents.appendSetDimension();

--- a/test/TestValidate.cpp
+++ b/test/TestValidate.cpp
@@ -220,13 +220,13 @@ void TestValidate::setInvalid() {
     // fill tag_tmp
     units_tmp = tag_tmp(invalid_units);
     // remove dimension descriptors from array4, position and extents
-    for (size_t i = 1; i <= array4.dimensionCount(); ++i) {
+    for (size_t i = array4.dimensionCount(); i > 0; --i) {
         array4.deleteDimension(i);
     }
-    for (size_t i = 1; i <= positions.dimensionCount(); ++i) {
+    for (size_t i = positions.dimensionCount(); i > 0; --i) {
         positions.deleteDimension(i);
     }
-    for (size_t i = 1; i <= extents.dimensionCount(); ++i) {
+    for (size_t i = extents.dimensionCount(); i > 0; --i) {
         extents.deleteDimension(i);
     }
     return;

--- a/test/TestValidate.cpp
+++ b/test/TestValidate.cpp
@@ -69,7 +69,7 @@ void TestValidate::tearDown() {
 }
 
 void TestValidate::setValid() {
-    // fill sin data & leave it in file for plot testing
+    // fill sinus data & leave it in file for plot testing
     typedef boost::multi_array<double, 2> array2D_type;
     typedef array2D_type::index index;
     array2D_type sin_array(boost::extents[1000][1000]);
@@ -80,7 +80,11 @@ void TestValidate::setValid() {
         }
     }
     array4.setData(sin_array);
-    
+    for (index i = 1; i <= array4.dimensionCount(); ++i) {
+        array4.deleteDimension(i);
+    }
+    array4.appendSampledDimension(1.);
+    array4.appendSetDimension();
     // fill array1 & array2
     typedef boost::multi_array<double, 3> array_type;
     typedef array_type::index index;
@@ -108,6 +112,7 @@ void TestValidate::setValid() {
         }
     }
     positions.setData(B);
+   
     array2D_type C(boost::extents[5][3]);
     for (index i = 0; i < 5; ++i) {
         for (index j = 0; j < 3; ++j) {
@@ -115,6 +120,19 @@ void TestValidate::setValid() {
         }
     }
     extents.setData(C);
+    
+    // ensure correct dimension descriptors for positions
+    for (index i = 1; i <= positions.dimensionCount(); ++i) {
+        positions.deleteDimension(i);
+    }
+    positions.appendSetDimension();
+    positions.appendSetDimension();
+    for (index i = 1; i <= extents.dimensionCount(); ++i) {
+        extents.deleteDimension(i);
+    }
+    extents.appendSetDimension();
+    extents.appendSetDimension();
+
     // fill MultiTag
     refs = {array2, array3};
     mtag.units(atomic_units);
@@ -194,7 +212,16 @@ void TestValidate::setInvalid() {
     dim_sample2.unit(atomic_units[2]);
     // fill tag_tmp    
     units_tmp = tag_tmp(invalid_units);
-    
+    // remove dimension descriptors from array4, position and extents
+    for (index i = 1; i <= array4.dimensionCount(); ++i) {
+        array4.deleteDimension(i);
+    }
+    for (index i = 1; i <= positions.dimensionCount(); ++i) {
+        positions.deleteDimension(i);
+    }
+    for (index i = 1; i <= extents.dimensionCount(); ++i) {
+        extents.deleteDimension(i);
+    }
     return;
 }
 

--- a/test/TestValidate.cpp
+++ b/test/TestValidate.cpp
@@ -308,14 +308,13 @@ void TestValidate::test() {
         should(tag, &nix::Tag::references, tagUnitsMatchRefsUnits(atomic_units), "tagUnitsMatchRefsUnits(atomic_units); (tag)")
     });
     // have debug info
-    std::cout << myResult;
+    // std::cout << myResult;
     CPPUNIT_ASSERT(myResult.hasWarnings() == false);
     CPPUNIT_ASSERT(myResult.hasErrors() == false);
 
     myResult = file.validate();
-    CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(3), myResult.getWarnings().size()); //FIMXE: should be 0 ;-)
-    CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(4), myResult.getErrors().size());   //FIXME: should be 0 too
-
+    CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(0), myResult.getWarnings().size());
+    CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(0), myResult.getErrors().size());
     // entity failure cases---------------------------------------------
     // -----------------------------------------------------------------
     setInvalid();

--- a/test/TestValidate.cpp
+++ b/test/TestValidate.cpp
@@ -263,10 +263,10 @@ void TestValidate::test() {
         should(foobar, &fooC::getSorted, isSorted(), "isSorted()")
     });
     // have debug info
-    std::cout << myResult;
+    // std::cout << myResult;
     CPPUNIT_ASSERT(myResult.hasWarnings() == false);
     CPPUNIT_ASSERT(myResult.hasErrors() == false);
-    
+ 
     // failure cases----------------------------------------------------
     // -----------------------------------------------------------------
     myResult = validator({
@@ -302,7 +302,7 @@ void TestValidate::test() {
         must(  tag, &nix::Tag::extent, extentsMatchRefs(refs), "extentsMatchRefs(refs); (tag)"),
         should(mtag, &nix::MultiTag::extents,  extentsMatchRefs(refs), "extentsMatchRefs(refs); (mtag)"),
         must(  tag, &nix::Tag::position, positionsMatchRefs(refs), "positionsMatchRefs(refs); (tag)"),
-        should(mtag, &nix::MultiTag::positions,  positionsMatchRefs(refs), "positionsMatchRefs(refs); (mtag)"),
+        must(mtag, &nix::MultiTag::positions,  positionsMatchRefs(refs), "positionsMatchRefs(refs); (mtag)"),
         should(dim_range1, &nix::RangeDimension::unit, isAtomicUnit(), "isAtomicUnit(); (dim_range1)"),
         should(tag,       &nix::Tag::units,     isAtomicUnit(), "isAtomicUnit(); (tag)"),
         must(units_tmp, &tag_tmp::unit,  isCompoundUnit(), "isCompoundUnit(); (units_tmp.unit)"),
@@ -312,33 +312,33 @@ void TestValidate::test() {
         must(  units_tmp, &tag_tmp::units, isValidUnit(), "isValidUnit(); (units_tmp.units)"),
         should(units_tmp, &tag_tmp::unito, isValidUnit(), "isValidUnit(); (units_tmp.unito)"),
         must(  tag, &nix::Tag::references, tagRefsHaveUnits(atomic_units),       "tagRefsHaveUnits(atomic_units); (tag)"),
-        should(tag, &nix::Tag::references, tagUnitsMatchRefsUnits(atomic_units), "tagUnitsMatchRefsUnits(atomic_units); (tag)")
+        must(tag, &nix::Tag::references, tagUnitsMatchRefsUnits(atomic_units), "tagUnitsMatchRefsUnits(atomic_units); (tag)")
     });
     // have debug info
     // std::cout << myResult;
     CPPUNIT_ASSERT(myResult.hasWarnings() == false);
     CPPUNIT_ASSERT(myResult.hasErrors() == false);
-
+    
     myResult = file.validate();
     CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(0), myResult.getWarnings().size());
     CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(0), myResult.getErrors().size());
     // entity failure cases---------------------------------------------
     // -----------------------------------------------------------------
+    
     setInvalid();
     myResult = validator({
         could(mtag, &nix::MultiTag::positions, dimEquals(2), {
             must(mtag, &nix::MultiTag::extents, dimEquals(42), "dimEquals(42)") }),//
         must(  mtag,   &nix::MultiTag::extents, dimEquals(42), "dimEquals(42)"),//
         should(array1, &nix::DataArray::dimensions, dimLabelsMatchData(array1), "dimLabelsMatchData(array)"),
-        must(  array2, &nix::DataArray::dimensions, dimTicksMatchData(array2),  "dimTicksMatchData(array)"),//
-        should(tag, &nix::Tag::position, extentsMatchPositions(extent),  "extentsMatchPositions(extent)"),//
+        must(tag, &nix::Tag::position, extentsMatchPositions(extent),  "extentsMatchPositions(extent)"),//
         must(  mtag, &nix::MultiTag::positions,  extentsMatchPositions(extents), "extentsMatchPositions(extents)"),
         must(  tag, &nix::Tag::extent, extentsMatchRefs(refs), "extentsMatchRefs(refs); (tag)"),
-        should(mtag, &nix::MultiTag::extents,  extentsMatchRefs(refs), "extentsMatchRefs(refs); (mtag)"),
+        must(mtag, &nix::MultiTag::extents,  extentsMatchRefs(refs), "extentsMatchRefs(refs); (mtag)"),
         must(  tag, &nix::Tag::position, positionsMatchRefs(refs), "positionsMatchRefs(refs); (tag)"),
-        should(mtag, &nix::MultiTag::positions,  positionsMatchRefs(refs), "positionsMatchRefs(refs); (mtag)"),
-        should(units_tmp, &tag_tmp::unit,  isAtomicUnit(), "isAtomicUnit(); (units_tmp.unit)"),
-        should(units_tmp, &tag_tmp::units, isAtomicUnit(), "isAtomicUnit(); (units_tmp.units)"),
+        must(mtag, &nix::MultiTag::positions,  positionsMatchRefs(refs), "positionsMatchRefs(refs); (mtag)"),
+        must(units_tmp, &tag_tmp::unit,  isAtomicUnit(), "isAtomicUnit(); (units_tmp.unit)"),
+        must(units_tmp, &tag_tmp::units, isAtomicUnit(), "isAtomicUnit(); (units_tmp.units)"),
         must(units_tmp, &tag_tmp::unit,  isCompoundUnit(), "isCompoundUnit(); (units_tmp.unit)"),
         must(units_tmp, &tag_tmp::units, isCompoundUnit(), "isCompoundUnit(); (units_tmp.units)"),
         must(units_tmp, &tag_tmp::unito, isCompoundUnit(), "isCompoundUnit(); (units_tmp.unito)"),
@@ -346,20 +346,19 @@ void TestValidate::test() {
         must(  units_tmp, &tag_tmp::units, isValidUnit(), "isValidUnit(); (units_tmp.units)"),
         should(units_tmp, &tag_tmp::unito, isValidUnit(), "isValidUnit(); (units_tmp.unito)"),
         must(  tag, &nix::Tag::references, tagRefsHaveUnits(invalid_units),       "tagRefsHaveUnits(atomic_units); (tag)"),
-        should(tag, &nix::Tag::references, tagUnitsMatchRefsUnits(invalid_units), "tagUnitsMatchRefsUnits(atomic_units); (tag)")
+        must(tag, &nix::Tag::references, tagUnitsMatchRefsUnits(invalid_units), "tagUnitsMatchRefsUnits(atomic_units); (tag)")
     });
-
-    CPPUNIT_ASSERT(myResult.getWarnings().size() == 9);
-    CPPUNIT_ASSERT(myResult.getErrors().size() == 11);
+    // std::cout << myResult;
+    CPPUNIT_ASSERT(myResult.getWarnings().size() == 3);
+    CPPUNIT_ASSERT(myResult.getErrors().size() == 16);
 
     myResult = file.validate();
-
-    CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(3), myResult.getWarnings().size());
-    CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(13), myResult.getErrors().size());
-
+    // std::cout << myResult;
+    CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(0), myResult.getWarnings().size());
+    CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(11), myResult.getErrors().size());
+    
     // uncomment this to have debug info
     // std::cout << myResult;
     // lets leave the file clean & valid
     setValid();
-
 }


### PR DESCRIPTION
major changes to the validation:

mismatch in dimension count is an error
mismatch in tick count is an error
mismatch in label count is a warning (they are optional)

and several minors ...