### PR TITLE
h5x: Group::objectCount: change return type to ndsize_t

### DIFF
--- a/include/nix/Block.hpp
+++ b/include/nix/Block.hpp
@@ -468,7 +468,7 @@ public:
      *
      * @return The number of tags.
      */
-    size_t tagCount() const {
+    ndsize_t tagCount() const {
         return backend()->tagCount();
     }
 

--- a/include/nix/Block.hpp
+++ b/include/nix/Block.hpp
@@ -321,7 +321,7 @@ public:
      *
      * @return The number of data arrays of the block.
      */
-    size_t dataArrayCount() const {
+    ndsize_t dataArrayCount() const {
         return backend()->dataArrayCount();
     }
 

--- a/include/nix/Block.hpp
+++ b/include/nix/Block.hpp
@@ -185,7 +185,7 @@ public:
      *
      * @return The number of root sources.
      */
-    size_t sourceCount() const {
+    ndsize_t sourceCount() const {
         return backend()->sourceCount();
     }
 

--- a/include/nix/Block.hpp
+++ b/include/nix/Block.hpp
@@ -577,7 +577,7 @@ public:
      *
      * @return The number of multi tags.
      */
-    size_t multiTagCount() const {
+    ndsize_t multiTagCount() const {
         return backend()->multiTagCount();
     }
 

--- a/include/nix/Exception.hpp
+++ b/include/nix/Exception.hpp
@@ -116,6 +116,27 @@ public:
             std::runtime_error("MissingAttribute: Obligatory attribute " + name + " is not set!") { }
 };
 
+
+namespace check {
+
+template<typename T>
+inline typename std::enable_if<! std::is_same<T, size_t>::value, size_t>::type
+fits_in_size_t(T size, const std::string &msg_if_fail) {
+    if (size > std::numeric_limits<size_t>::max()) {
+        throw OutOfBounds(msg_if_fail);
+    }
+    return static_cast<size_t>(size);
+}
+
+template<typename T>
+inline typename std::enable_if<std::is_same<T, size_t>::value, size_t>::type
+fits_in_size_t(T size, const std::string &msg_if_fail) {
+    return size;
+}
+
+} // nix::check::
+
+
 }
 
 #endif

--- a/include/nix/Exception.hpp
+++ b/include/nix/Exception.hpp
@@ -13,6 +13,10 @@
 
 #include <nix/Platform.hpp>
 
+#include <limits>
+#include <type_traits>
+#include <cstddef>
+
 #include <stdexcept>
 #include <sstream>
 

--- a/include/nix/File.hpp
+++ b/include/nix/File.hpp
@@ -250,7 +250,7 @@ public:
      *
      * @return size_t   The number of sections.
      */
-    size_t sectionCount() const {
+    ndsize_t sectionCount() const {
         return backend()->sectionCount();
     }
 

--- a/include/nix/File.hpp
+++ b/include/nix/File.hpp
@@ -96,7 +96,7 @@ public:
      *
      * @return The number of blocks.
      */
-    size_t blockCount() const {
+    ndsize_t blockCount() const {
         return backend()->blockCount();
     }
 

--- a/include/nix/Hydra.hpp
+++ b/include/nix/Hydra.hpp
@@ -21,25 +21,6 @@
 
 namespace nix {
 
-namespace check {
-
-template<typename T>
-inline typename std::enable_if<! std::is_same<T, size_t>::value, size_t>::type
-fits_in_size_t(T size, const std::string &msg_if_fail) {
-    if (size > std::numeric_limits<size_t>::max()) {
-        throw OutOfBounds(msg_if_fail);
-    }
-    return static_cast<size_t>(size);
-}
-
-template<typename T>
-inline typename std::enable_if<std::is_same<T, size_t>::value, size_t>::type
-fits_in_size_t(T size, const std::string &msg_if_fail) {
-    return size;
-}
-
-} // nix::check::
-
 template<typename T>
 struct data_traits {
 

--- a/include/nix/MultiTag.hpp
+++ b/include/nix/MultiTag.hpp
@@ -380,7 +380,7 @@ public:
      *
      * @return The number of features.
      */
-    size_t featureCount() const {
+    ndsize_t featureCount() const {
         return backend()->featureCount();
     }
 

--- a/include/nix/MultiTag.hpp
+++ b/include/nix/MultiTag.hpp
@@ -236,7 +236,7 @@ public:
      *
      * @return The number of referenced data arrays.
      */
-    size_t referenceCount() const {
+    ndsize_t referenceCount() const {
         return backend()->referenceCount();
     }
 

--- a/include/nix/Property.hpp
+++ b/include/nix/Property.hpp
@@ -219,7 +219,7 @@ public:
      *
      * @return The number of values.
      */
-    size_t valueCount() const {
+    ndsize_t valueCount() const {
         return backend()->valueCount();
     }
 

--- a/include/nix/Section.hpp
+++ b/include/nix/Section.hpp
@@ -333,7 +333,7 @@ public:
      *
      * @return The number of Properties
      */
-    size_t propertyCount() const {
+    ndsize_t propertyCount() const {
         return backend()->propertyCount();
     }
 

--- a/include/nix/Section.hpp
+++ b/include/nix/Section.hpp
@@ -208,7 +208,7 @@ public:
      *
      * @return The number of child sections.
      */
-    size_t sectionCount() const {
+    ndsize_t sectionCount() const {
         return backend()->sectionCount();
     }
 

--- a/include/nix/Source.hpp
+++ b/include/nix/Source.hpp
@@ -131,7 +131,7 @@ public:
      *
      * @return The number of direct child sources.
      */
-    size_t sourceCount() const {
+    ndsize_t sourceCount() const {
         return backend()->sourceCount();
     }
 

--- a/include/nix/Tag.hpp
+++ b/include/nix/Tag.hpp
@@ -349,7 +349,7 @@ public:
      *
      * @return The number of features.
      */
-    size_t featureCount() const {
+    ndsize_t featureCount() const {
         return backend()->featureCount();
     }
 

--- a/include/nix/Tag.hpp
+++ b/include/nix/Tag.hpp
@@ -216,7 +216,7 @@ public:
      *
      * @return The number of referenced data arrays.
      */
-    size_t referenceCount() const {
+    ndsize_t referenceCount() const {
         return backend()->referenceCount();
     }
 

--- a/include/nix/base/EntityWithSources.hpp
+++ b/include/nix/base/EntityWithSources.hpp
@@ -59,7 +59,7 @@ public:
      *
      * @return The number sources.
      */
-    size_t sourceCount() const {
+    ndsize_t sourceCount() const {
         return EntityWithMetadata<T>::backend()->sourceCount();
     }
 

--- a/include/nix/base/IBaseTag.hpp
+++ b/include/nix/base/IBaseTag.hpp
@@ -36,7 +36,7 @@ public:
     virtual bool hasReference(const std::string &id) const = 0;
 
 
-    virtual size_t referenceCount() const = 0;
+    virtual ndsize_t referenceCount() const = 0;
 
 
     virtual std::shared_ptr<IDataArray> getReference(const std::string &id) const = 0;

--- a/include/nix/base/IBaseTag.hpp
+++ b/include/nix/base/IBaseTag.hpp
@@ -59,7 +59,7 @@ public:
     virtual bool hasFeature(const std::string &id) const = 0;
 
 
-    virtual size_t featureCount() const = 0;
+    virtual ndsize_t featureCount() const = 0;
 
 
     virtual std::shared_ptr<IFeature> getFeature(const std::string &id) const = 0;

--- a/include/nix/base/IBlock.hpp
+++ b/include/nix/base/IBlock.hpp
@@ -42,7 +42,7 @@ public:
     virtual std::shared_ptr<base::ISource> getSource(size_t index) const = 0;
 
 
-    virtual size_t sourceCount() const = 0;
+    virtual ndsize_t sourceCount() const = 0;
 
 
     virtual std::shared_ptr<base::ISource> createSource(const std::string &name, const std::string &type) = 0;

--- a/include/nix/base/IBlock.hpp
+++ b/include/nix/base/IBlock.hpp
@@ -85,7 +85,7 @@ public:
     virtual std::shared_ptr<base::ITag> getTag(size_t index) const = 0;
 
 
-    virtual size_t tagCount() const = 0;
+    virtual ndsize_t tagCount() const = 0;
 
 
     virtual std::shared_ptr<base::ITag> createTag(const std::string &name, const std::string &type,

--- a/include/nix/base/IBlock.hpp
+++ b/include/nix/base/IBlock.hpp
@@ -107,7 +107,7 @@ public:
     virtual std::shared_ptr<base::IMultiTag> getMultiTag(size_t index) const = 0;
 
 
-    virtual size_t multiTagCount() const = 0;
+    virtual ndsize_t multiTagCount() const = 0;
 
 
     // TODO evaluate if DataArray can be replaced by shared_ptr<IDataArray>

--- a/include/nix/base/IBlock.hpp
+++ b/include/nix/base/IBlock.hpp
@@ -63,7 +63,7 @@ public:
     virtual std::shared_ptr<base::IDataArray> getDataArray(size_t index) const = 0;
 
 
-    virtual size_t dataArrayCount() const = 0;
+    virtual ndsize_t dataArrayCount() const = 0;
 
 
     virtual std::shared_ptr<base::IDataArray> createDataArray(const std::string &name, const std::string &type,

--- a/include/nix/base/IEntityWithSources.hpp
+++ b/include/nix/base/IEntityWithSources.hpp
@@ -9,6 +9,8 @@
 #ifndef NIX_I_ENTITY_WITH_SOURCES_H
 #define NIX_I_ENTITY_WITH_SOURCES_H
 
+#include <nix/NDSize.hpp>
+
 #include <nix/base/ISource.hpp>
 #include <nix/base/IEntityWithMetadata.hpp>
 
@@ -31,7 +33,7 @@ class NIXAPI IEntityWithSources : virtual public IEntityWithMetadata {
 
 public:
 
-    virtual size_t sourceCount() const = 0;
+    virtual ndsize_t sourceCount() const = 0;
 
 
     virtual void addSource(const std::string &id) = 0;

--- a/include/nix/base/IFile.hpp
+++ b/include/nix/base/IFile.hpp
@@ -48,7 +48,7 @@ class NIXAPI IFile {
 
 public:
 
-    virtual size_t blockCount() const = 0;
+    virtual ndsize_t blockCount() const = 0;
 
 
     virtual bool hasBlock(const std::string &name_or_id) const = 0;

--- a/include/nix/base/IFile.hpp
+++ b/include/nix/base/IFile.hpp
@@ -78,7 +78,7 @@ public:
     virtual std::shared_ptr<ISection> getSection(size_t index) const = 0;
 
 
-    virtual size_t sectionCount() const = 0;
+    virtual ndsize_t sectionCount() const = 0;
 
 
     virtual std::shared_ptr<ISection> createSection(const std::string &name, const std::string &type) = 0;

--- a/include/nix/base/IProperty.hpp
+++ b/include/nix/base/IProperty.hpp
@@ -12,6 +12,8 @@
 #include <nix/Value.hpp>
 #include <nix/base/INamedEntity.hpp>
 
+#include <nix/NDSize.hpp>
+
 #include <string>
 #include <vector>
 #include <cstdlib>
@@ -64,7 +66,7 @@ public:
     virtual void deleteValues() = 0;
 
 
-    virtual size_t valueCount() const = 0;
+    virtual ndsize_t valueCount() const = 0;
 
 
     virtual void values(const std::vector<Value> &values) = 0;

--- a/include/nix/base/ISection.hpp
+++ b/include/nix/base/ISection.hpp
@@ -93,7 +93,7 @@ public:
     // Methods for property access
     //--------------------------------------------------
 
-    virtual size_t propertyCount() const = 0;
+    virtual ndsize_t propertyCount() const = 0;
 
 
     virtual bool hasProperty(const std::string &name_or_id) const = 0;

--- a/include/nix/base/ISection.hpp
+++ b/include/nix/base/ISection.hpp
@@ -9,11 +9,13 @@
 #ifndef NIX_I_SECTION_H
 #define NIX_I_SECTION_H
 
+
 #include <nix/base/IEntity.hpp>
 #include <nix/base/INamedEntity.hpp>
 #include <nix/base/IProperty.hpp>
 #include <nix/DataType.hpp>
 #include <nix/Value.hpp>
+#include <nix/NDSize.hpp>
 
 #include <string>
 #include <vector>
@@ -70,7 +72,7 @@ public:
     // Methods for child section access
     //--------------------------------------------------
 
-    virtual size_t sectionCount() const = 0;
+    virtual ndsize_t sectionCount() const = 0;
 
 
     virtual bool hasSection(const std::string &name_or_id) const = 0;

--- a/include/nix/base/ISource.hpp
+++ b/include/nix/base/ISource.hpp
@@ -37,7 +37,7 @@ public:
     virtual std::shared_ptr<ISource> getSource(size_t index) const = 0;
 
 
-    virtual size_t sourceCount() const = 0;
+    virtual ndsize_t sourceCount() const = 0;
 
 
     virtual std::shared_ptr<ISource> createSource(const std::string &name, const std::string &type) = 0;

--- a/include/nix/base/ImplContainer.hpp
+++ b/include/nix/base/ImplContainer.hpp
@@ -12,6 +12,7 @@
 #include <nix/Platform.hpp> //for pragma warnings on windows
 #include <nix/None.hpp>
 #include <nix/Exception.hpp>
+#include <nix/NDSize.hpp>
 
 #include <memory>
 #include <vector>
@@ -53,7 +54,7 @@ protected:
     template<typename TENT, typename TFUNC>
     std::vector<TENT> getEntities(
         TFUNC const &getEntity,
-        size_t n,
+        ndsize_t n,
         std::function<bool(TENT)> filter) const
     {
         std::vector<TENT> entities;
@@ -63,7 +64,9 @@ protected:
             return entities;
         }
 
-        for (size_t i = 0; i < n; i++) {
+		const size_t n_max = nix::check::fits_in_size_t(n, "n > sizeof(size_t)");
+
+        for (size_t i = 0; i < n_max; i++) {
             candidate = getEntity(i);
             if (candidate && filter(candidate)) {
                 entities.push_back(candidate);

--- a/include/nix/hdf5/BaseTagHDF5.hpp
+++ b/include/nix/hdf5/BaseTagHDF5.hpp
@@ -77,7 +77,7 @@ public:
     virtual bool hasFeature(const std::string &name_or_id) const;
 
 
-    virtual size_t featureCount() const;
+    virtual ndsize_t featureCount() const;
 
 
     virtual std::shared_ptr<base::IFeature> getFeature(const std::string &name_or_id) const;

--- a/include/nix/hdf5/BaseTagHDF5.hpp
+++ b/include/nix/hdf5/BaseTagHDF5.hpp
@@ -53,7 +53,7 @@ public:
     virtual bool hasReference(const std::string &name_or_id) const;
 
 
-    virtual size_t referenceCount() const;
+    virtual ndsize_t referenceCount() const;
 
 
     virtual std::shared_ptr<base::IDataArray> getReference(const std::string &name_or_id) const;

--- a/include/nix/hdf5/BlockHDF5.hpp
+++ b/include/nix/hdf5/BlockHDF5.hpp
@@ -118,7 +118,7 @@ public:
     std::shared_ptr<base::ITag> getTag(size_t index) const;
 
 
-    size_t tagCount() const;
+    ndsize_t tagCount() const;
 
 
     std::shared_ptr<base::ITag> createTag(const std::string &name, const std::string &type,

--- a/include/nix/hdf5/BlockHDF5.hpp
+++ b/include/nix/hdf5/BlockHDF5.hpp
@@ -140,7 +140,7 @@ public:
     std::shared_ptr<base::IMultiTag> getMultiTag(size_t index) const;
 
 
-    size_t multiTagCount() const;
+    ndsize_t multiTagCount() const;
 
 
     std::shared_ptr<base::IMultiTag> createMultiTag(const std::string &name, const std::string &type,

--- a/include/nix/hdf5/BlockHDF5.hpp
+++ b/include/nix/hdf5/BlockHDF5.hpp
@@ -96,7 +96,7 @@ public:
     std::shared_ptr<base::IDataArray> getDataArray(size_t index) const;
 
 
-    size_t dataArrayCount() const;
+    ndsize_t dataArrayCount() const;
 
 
     std::shared_ptr<base::IDataArray> createDataArray(const std::string &name, const std::string &type,

--- a/include/nix/hdf5/BlockHDF5.hpp
+++ b/include/nix/hdf5/BlockHDF5.hpp
@@ -75,7 +75,7 @@ public:
     std::shared_ptr<base::ISource> getSource(size_t index) const;
 
 
-    size_t sourceCount() const;
+    ndsize_t sourceCount() const;
 
 
     std::shared_ptr<base::ISource> createSource(const std::string &name, const std::string &type);

--- a/include/nix/hdf5/EntityWithSourcesHDF5.hpp
+++ b/include/nix/hdf5/EntityWithSourcesHDF5.hpp
@@ -47,7 +47,7 @@ public:
     EntityWithSourcesHDF5(const std::shared_ptr<base::IFile> &file, const std::shared_ptr<base::IBlock> &block, const Group &group,
                           const std::string &id, const std::string &type, const std::string &name, time_t time);
 
-    size_t sourceCount() const;
+    ndsize_t sourceCount() const;
 
 
     bool hasSource(const std::string &id) const;

--- a/include/nix/hdf5/FileHDF5.hpp
+++ b/include/nix/hdf5/FileHDF5.hpp
@@ -76,7 +76,7 @@ public:
     std::shared_ptr<base::ISection> getSection(size_t index) const;
 
 
-    size_t sectionCount() const;
+    ndsize_t sectionCount() const;
 
 
     std::shared_ptr<base::ISection> createSection(const std::string &name, const std::string &type);

--- a/include/nix/hdf5/FileHDF5.hpp
+++ b/include/nix/hdf5/FileHDF5.hpp
@@ -46,7 +46,7 @@ public:
     //--------------------------------------------------
 
 
-    size_t blockCount() const;
+    ndsize_t blockCount() const;
 
 
     bool hasBlock(const std::string &name_or_id) const;

--- a/include/nix/hdf5/Group.hpp
+++ b/include/nix/hdf5/Group.hpp
@@ -42,7 +42,7 @@ public:
 
     bool hasObject(const std::string &path) const;
     ndsize_t objectCount() const;
-    std::string objectName(size_t index) const;
+    std::string objectName(ndsize_t index) const;
 
     bool hasData(const std::string &name) const;
 

--- a/include/nix/hdf5/Group.hpp
+++ b/include/nix/hdf5/Group.hpp
@@ -41,7 +41,7 @@ public:
     Group(const Group &other);
 
     bool hasObject(const std::string &path) const;
-    size_t objectCount() const;
+    ndsize_t objectCount() const;
     std::string objectName(size_t index) const;
 
     bool hasData(const std::string &name) const;

--- a/include/nix/hdf5/PropertyHDF5.hpp
+++ b/include/nix/hdf5/PropertyHDF5.hpp
@@ -105,7 +105,7 @@ public:
     void deleteValues();
 
 
-    size_t valueCount() const;
+    ndsize_t valueCount() const;
 
 
     void values(const std::vector<Value> &values);

--- a/include/nix/hdf5/SectionHDF5.hpp
+++ b/include/nix/hdf5/SectionHDF5.hpp
@@ -131,7 +131,7 @@ public:
     //--------------------------------------------------
 
 
-    size_t propertyCount() const;
+    ndsize_t propertyCount() const;
 
 
     bool hasProperty(const std::string &name_or_id) const;

--- a/include/nix/hdf5/SectionHDF5.hpp
+++ b/include/nix/hdf5/SectionHDF5.hpp
@@ -109,7 +109,7 @@ public:
     //--------------------------------------------------
 
 
-    size_t sectionCount() const;
+    ndsize_t sectionCount() const;
 
 
     bool hasSection(const std::string &name_or_id) const;

--- a/include/nix/hdf5/SourceHDF5.hpp
+++ b/include/nix/hdf5/SourceHDF5.hpp
@@ -62,7 +62,7 @@ public:
     std::shared_ptr<base::ISource> getSource(size_t index) const;
 
 
-    size_t sourceCount() const;
+    ndsize_t sourceCount() const;
 
 
     std::shared_ptr<base::ISource> createSource(const std::string &name, const std::string &type);

--- a/src/hdf5/BaseTagHDF5.cpp
+++ b/src/hdf5/BaseTagHDF5.cpp
@@ -63,7 +63,7 @@ bool BaseTagHDF5::hasReference(const std::string &name_or_id) const {
 }
 
 
-size_t BaseTagHDF5::referenceCount() const {
+ndsize_t BaseTagHDF5::referenceCount() const {
     boost::optional<Group> g = refs_group();
     return g ? g->objectCount() : size_t(0);
 }

--- a/src/hdf5/BaseTagHDF5.cpp
+++ b/src/hdf5/BaseTagHDF5.cpp
@@ -172,7 +172,7 @@ bool BaseTagHDF5::hasFeature(const string &name_or_id) const {
 }
 
 
-size_t BaseTagHDF5::featureCount() const {
+ndsize_t BaseTagHDF5::featureCount() const {
     boost::optional<Group> g = feature_group();
     return g ? g->objectCount() : size_t(0);
 }

--- a/src/hdf5/BaseTagHDF5.cpp
+++ b/src/hdf5/BaseTagHDF5.cpp
@@ -132,7 +132,8 @@ void BaseTagHDF5::references(const std::vector<DataArray> &refs_new) {
     // extract vectors of names from vectors of new & old references
     std::vector<std::string> names_new(refs_new.size());
     transform(refs_new.begin(), refs_new.end(), names_new.begin(), util::toName<DataArray>);
-    std::vector<DataArray> refs_old(referenceCount());
+	//FIXME: issue 473
+    std::vector<DataArray> refs_old(static_cast<size_t>(referenceCount()));
     for (size_t i = 0; i < refs_old.size(); i++) refs_old[i] = getReference(i);
     std::vector<std::string> names_old(refs_old.size());
     transform(refs_old.begin(), refs_old.end(), names_old.begin(), util::toName<DataArray>);

--- a/src/hdf5/BlockHDF5.cpp
+++ b/src/hdf5/BlockHDF5.cpp
@@ -77,7 +77,7 @@ shared_ptr<ISource> BlockHDF5::getSource(size_t index) const {
 }
 
 
-size_t BlockHDF5::sourceCount() const {
+ndsize_t BlockHDF5::sourceCount() const {
     boost::optional<Group> g = source_group();
     return g ? g->objectCount() : size_t(0);
 }

--- a/src/hdf5/BlockHDF5.cpp
+++ b/src/hdf5/BlockHDF5.cpp
@@ -214,7 +214,7 @@ shared_ptr<IDataArray> BlockHDF5::getDataArray(size_t index) const {
 }
 
 
-size_t BlockHDF5::dataArrayCount() const {
+ndsize_t BlockHDF5::dataArrayCount() const {
     boost::optional<Group> g = data_array_group();
     return g ? g->objectCount() : size_t(0);
 }

--- a/src/hdf5/BlockHDF5.cpp
+++ b/src/hdf5/BlockHDF5.cpp
@@ -164,7 +164,7 @@ shared_ptr<ITag> BlockHDF5::getTag(size_t index) const {
 }
 
 
-size_t BlockHDF5::tagCount() const {
+ndsize_t BlockHDF5::tagCount() const {
     boost::optional<Group> g = tag_group();
     return g ? g->objectCount() : size_t(0);
 }

--- a/src/hdf5/BlockHDF5.cpp
+++ b/src/hdf5/BlockHDF5.cpp
@@ -297,7 +297,7 @@ shared_ptr<IMultiTag> BlockHDF5::getMultiTag(size_t index) const {
 }
 
 
-size_t BlockHDF5::multiTagCount() const {
+ndsize_t BlockHDF5::multiTagCount() const {
     boost::optional<Group> g = multi_tag_group();
     return g ? g->objectCount() : size_t(0);
 }

--- a/src/hdf5/DataArrayHDF5.cpp
+++ b/src/hdf5/DataArrayHDF5.cpp
@@ -168,7 +168,13 @@ void DataArrayHDF5::polynomCoefficients(const none_t t) {
 
 size_t DataArrayHDF5::dimensionCount() const {
     boost::optional<Group> g = dimension_group();
-    return g ? g->objectCount() : size_t(0);
+	size_t count = 0;
+	if (g) {
+		ndsize_t objs = g->objectCount();
+		//FIXME: issue 473
+		count = static_cast<size_t>(objs);
+	}
+    return count;
 }
 
 

--- a/src/hdf5/EntityWithSourcesHDF5.cpp
+++ b/src/hdf5/EntityWithSourcesHDF5.cpp
@@ -42,7 +42,7 @@ EntityWithSourcesHDF5::EntityWithSourcesHDF5 (const shared_ptr<IFile> &file, con
 }
 
 
-size_t EntityWithSourcesHDF5::sourceCount() const {
+ndsize_t EntityWithSourcesHDF5::sourceCount() const {
     boost::optional<Group> g = sources_refs();
     return g ? g->objectCount() : size_t(0);
 }

--- a/src/hdf5/EntityWithSourcesHDF5.cpp
+++ b/src/hdf5/EntityWithSourcesHDF5.cpp
@@ -85,7 +85,8 @@ void EntityWithSourcesHDF5::sources(const std::vector<Source> &sources) {
     // extract vectors of ids from vectors of new & old sources
     std::vector<std::string> ids_new(sources.size());
     transform(sources.begin(), sources.end(), ids_new.begin(), util::toId<Source>);
-    std::vector<Source> sources_old(sourceCount());
+    //FIXME: issue #473
+    std::vector<Source> sources_old(static_cast<size_t>(sourceCount()));
     for (size_t i = 0; i < sources_old.size(); i++) sources_old[i] = getSource(i);
     std::vector<std::string> ids_old(sources_old.size());
     transform(sources_old.begin(), sources_old.end(), ids_old.begin(), util::toId<Source>);

--- a/src/hdf5/FileHDF5.cpp
+++ b/src/hdf5/FileHDF5.cpp
@@ -197,7 +197,7 @@ bool FileHDF5::deleteSection(const std::string &name_or_id) {
 }
 
 
-size_t FileHDF5::sectionCount() const {
+ndsize_t FileHDF5::sectionCount() const {
     return metadata.objectCount();
 }
 

--- a/src/hdf5/FileHDF5.cpp
+++ b/src/hdf5/FileHDF5.cpp
@@ -135,7 +135,7 @@ bool FileHDF5::deleteBlock(const std::string &name_or_id) {
 }
 
 
-size_t FileHDF5::blockCount() const {
+ndsize_t FileHDF5::blockCount() const {
     return data.objectCount();
 }
 

--- a/src/hdf5/Group.cpp
+++ b/src/hdf5/Group.cpp
@@ -79,7 +79,7 @@ boost::optional<Group> Group::findGroupByAttribute(const std::string &attribute,
     boost::optional<Group> ret;
 
     // look up first direct sub-group that has given attribute with given value
-    for (size_t index = 0; index < objectCount(); index++) {
+    for (ndsize_t index = 0; index < objectCount(); index++) {
         std::string obj_name = objectName(index);
         if(hasGroup(obj_name)) {
             Group group = openGroup(obj_name, false);
@@ -103,7 +103,7 @@ boost::optional<DataSet> Group::findDataByAttribute(const std::string &attribute
     boost::optional<DataSet> ret;
 
     // look up all direct sub-datasets that have the given attribute
-    for (size_t index = 0; index < objectCount(); index++) {
+    for (ndsize_t index = 0; index < objectCount(); index++) {
         std::string obj_name = objectName(index);
         if(hasData(obj_name)) {
             DataSet ds = openData(obj_name);

--- a/src/hdf5/Group.cpp
+++ b/src/hdf5/Group.cpp
@@ -128,7 +128,9 @@ boost::optional<DataSet> Group::findDataByAttribute(const std::string &attribute
 std::string Group::objectName(ndsize_t index) const {
     // check if index valid
     if(index > objectCount()) {
-        throw OutOfBounds("No object at given index", index);
+		//FIXME: issue #473
+        throw OutOfBounds("No object at given index",
+			              static_cast<size_t>(index));
     }
 
     std::string str_name;

--- a/src/hdf5/Group.cpp
+++ b/src/hdf5/Group.cpp
@@ -125,7 +125,7 @@ boost::optional<DataSet> Group::findDataByAttribute(const std::string &attribute
 }
 
 
-std::string Group::objectName(size_t index) const {
+std::string Group::objectName(ndsize_t index) const {
     // check if index valid
     if(index > objectCount()) {
         throw OutOfBounds("No object at given index", index);

--- a/src/hdf5/Group.cpp
+++ b/src/hdf5/Group.cpp
@@ -67,12 +67,11 @@ bool Group::objectOfType(const std::string &name, H5O_type_t type) const {
     return res;
 }
 
-size_t Group::objectCount() const {
+ndsize_t Group::objectCount() const {
     hsize_t n_objs;
     HErr res = H5Gget_num_objs(hid, &n_objs);
     res.check("Could not get object count");
-    //FIXME: return type should be ndsize_t, #473
-    return static_cast<size_t>(n_objs);
+    return n_objs;
 }
 
 

--- a/src/hdf5/PropertyHDF5.cpp
+++ b/src/hdf5/PropertyHDF5.cpp
@@ -213,10 +213,9 @@ void PropertyHDF5::deleteValues() {
 }
 
 
-size_t PropertyHDF5::valueCount() const {
+ndsize_t PropertyHDF5::valueCount() const {
     NDSize size = dataset().size();
-    //FIXME: 32bit casting issue, cf issue #473
-    return static_cast<size_t>(size[0]);
+    return size[0];
 }
 
 

--- a/src/hdf5/SectionHDF5.cpp
+++ b/src/hdf5/SectionHDF5.cpp
@@ -256,7 +256,7 @@ bool SectionHDF5::deleteSection(const string &name_or_id) {
 //--------------------------------------------------
 
 
-size_t SectionHDF5::propertyCount() const {
+ndsize_t SectionHDF5::propertyCount() const {
     boost::optional<Group> g = property_group();
     return g ? g->objectCount() : size_t(0);
 }

--- a/src/hdf5/SectionHDF5.cpp
+++ b/src/hdf5/SectionHDF5.cpp
@@ -182,7 +182,7 @@ shared_ptr<ISection> SectionHDF5::parent() const {
 //--------------------------------------------------
 
 
-size_t SectionHDF5::sectionCount() const {
+ndsize_t SectionHDF5::sectionCount() const {
     boost::optional<Group> g = section_group();
     return g ? g->objectCount() : size_t(0);
 }

--- a/src/hdf5/SourceHDF5.cpp
+++ b/src/hdf5/SourceHDF5.cpp
@@ -63,7 +63,7 @@ shared_ptr<ISource> SourceHDF5::getSource(size_t index) const {
 }
 
 
-size_t SourceHDF5::sourceCount() const {
+ndsize_t SourceHDF5::sourceCount() const {
     boost::optional<Group> g = source_group(false);
     return g ? g->objectCount() : size_t(0);
 }

--- a/test/TestBlock.cpp
+++ b/test/TestBlock.cpp
@@ -93,11 +93,15 @@ void TestBlock::testSourceAccess() {
     CPPUNIT_ASSERT(block.sourceCount() == 0);
     CPPUNIT_ASSERT(block.sources().size() == 0);
     CPPUNIT_ASSERT(block.getSource("invalid_id") == false);
+    CPPUNIT_ASSERT(!block.hasSource("invalid_id"));
+
 
     vector<string> ids;
-    for (auto it = names.begin(); it != names.end(); it++) {
-        Source src = block.createSource(*it, "channel");
-        CPPUNIT_ASSERT(src.name() == *it);
+    for (const auto &name : names) {
+        Source src = block.createSource(name, "channel");
+        CPPUNIT_ASSERT(src.name() == name);
+        CPPUNIT_ASSERT(block.hasSource(name));
+        CPPUNIT_ASSERT(block.hasSource(src));
 
         ids.push_back(src.id());
     }
@@ -108,12 +112,12 @@ void TestBlock::testSourceAccess() {
     CPPUNIT_ASSERT(block.sources().size() == names.size());
 
 
-    for (auto it = ids.begin(); it != ids.end(); it++) {
-        Source src = block.getSource(*it);
-        CPPUNIT_ASSERT(block.hasSource(*it) == true);
-        CPPUNIT_ASSERT(src.id() == *it);
+    for (const auto &id : ids) {
+        Source src = block.getSource(id);
+        CPPUNIT_ASSERT(block.hasSource(id) == true);
+        CPPUNIT_ASSERT(src.id() == id);
 
-        block.deleteSource(*it);
+        block.deleteSource(id);
     }
 
     CPPUNIT_ASSERT(block.sourceCount() == 0);

--- a/test/TestFile.cpp
+++ b/test/TestFile.cpp
@@ -76,11 +76,14 @@ void TestFile::testBlockAccess() {
     CPPUNIT_ASSERT(file_open.blockCount() == 0);
     CPPUNIT_ASSERT(file_open.blocks().size() == 0);
     CPPUNIT_ASSERT(file_open.getBlock("invalid_id") == false);
+    CPPUNIT_ASSERT_EQUAL(false, file_open.hasBlock("invalid_id"));
 
     vector<string> ids;
-    for (auto it = names.begin(); it != names.end(); it++) {
-        Block bl = file_open.createBlock(*it, "dataset");
-        CPPUNIT_ASSERT(bl.name() == *it);
+    for (const auto &name : names) {
+        Block bl = file_open.createBlock(name, "dataset");
+        CPPUNIT_ASSERT(bl.name() == name);
+        CPPUNIT_ASSERT(file_open.hasBlock(bl));
+        CPPUNIT_ASSERT(file_open.hasBlock(name));
 
         ids.push_back(bl.id());
     }
@@ -99,12 +102,12 @@ void TestFile::testBlockAccess() {
         CPPUNIT_ASSERT_EQUAL(bl_name.name(), bl_id.name());
     }
     
-    for (auto it = ids.begin(); it != ids.end(); it++) {
-        Block bl = file_open.getBlock(*it);
-        CPPUNIT_ASSERT(file_open.hasBlock(*it) == true);
-        CPPUNIT_ASSERT(bl.id() == *it);
+    for (const auto &id: ids) {
+        Block bl = file_open.getBlock(id);
+        CPPUNIT_ASSERT(file_open.hasBlock(id) == true);
+        CPPUNIT_ASSERT(bl.id() == id);
 
-        file_open.deleteBlock(*it);
+        file_open.deleteBlock(id);
     }
 
     CPPUNIT_ASSERT(file_open.blockCount() == 0);

--- a/test/TestMultiTag.cpp
+++ b/test/TestMultiTag.cpp
@@ -96,7 +96,8 @@ void TestMultiTag::testDefinition() {
 
 void TestMultiTag::testCreateRemove() {
     std::vector<std::string> ids;
-    size_t count = block.multiTagCount();
+	//issue #473
+	ndsize_t count = static_cast<size_t>(block.multiTagCount());
     const char *names[5] = { "tag_a", "tag_b", "tag_c", "tag_d", "tag_e" };
     for (int i = 0; i < 5; i++) {
         std::string type = "Event";

--- a/test/TestProperty.cpp
+++ b/test/TestProperty.cpp
@@ -85,7 +85,7 @@ void TestProperty::testValues()
                                           nix::Value("schoener"),
                                           nix::Value("Goetterfunken") };
     p1.values(strValues);
-    CPPUNIT_ASSERT_EQUAL(p1.valueCount(), strValues.size());
+    CPPUNIT_ASSERT_EQUAL(p1.valueCount(), static_cast<ndsize_t>(strValues.size()));
 
     std::vector<nix::Value> ctrlValues = p1.values();
     for(size_t i = 0; i < ctrlValues.size(); ++i) {
@@ -98,11 +98,11 @@ void TestProperty::testValues()
     strValues.emplace_back("Wir betreten feuertrunken");
 
     p1.values(strValues);
-    CPPUNIT_ASSERT_EQUAL(p1.valueCount(), strValues.size());
+    CPPUNIT_ASSERT_EQUAL(p1.valueCount(), static_cast<ndsize_t>(strValues.size()));
 
     strValues.erase(strValues.begin()+6);
     p1.values(strValues);
-    CPPUNIT_ASSERT_EQUAL(p1.valueCount(), strValues.size());
+    CPPUNIT_ASSERT_EQUAL(p1.valueCount(), static_cast<ndsize_t>(strValues.size()));
 
     nix::Property p2 = section.createProperty("toDelete", str_dummy);
     CPPUNIT_ASSERT(p2.valueCount() == 1);
@@ -110,7 +110,7 @@ void TestProperty::testValues()
 
     strValues.clear();
     p2.values(strValues);
-    CPPUNIT_ASSERT_EQUAL(p2.valueCount(), strValues.size());
+    CPPUNIT_ASSERT_EQUAL(p2.valueCount(), static_cast<ndsize_t>(strValues.size()));
     p2.deleteValues();
     CPPUNIT_ASSERT(p2.values().empty() == true);
     p2.values(strValues);

--- a/test/TestSection.cpp
+++ b/test/TestSection.cpp
@@ -122,11 +122,13 @@ void TestSection::testSectionAccess() {
     CPPUNIT_ASSERT(section.sectionCount() == 0);
     CPPUNIT_ASSERT(section.sections().size() == 0);
     CPPUNIT_ASSERT(section.getSection("invalid_id") == false);
+    CPPUNIT_ASSERT_EQUAL(false, section.hasSection("invalid_id"));
 
     vector<string> ids;
     for (auto name : names) {
         Section child_section = section.createSection(name, "metadata");
         CPPUNIT_ASSERT(child_section.name() == name);
+        CPPUNIT_ASSERT_EQUAL(true, section.hasSection(name));
 
         ids.push_back(child_section.id());
     }
@@ -138,10 +140,11 @@ void TestSection::testSectionAccess() {
 
     for (auto id : ids) {
         Section child_section = section.getSection(id);
-        CPPUNIT_ASSERT(section.hasSection(id) == true);
-        CPPUNIT_ASSERT(child_section.id() == id);
+        CPPUNIT_ASSERT(section.hasSection(id));
+        CPPUNIT_ASSERT_EQUAL(id, child_section.id());
 
         section.deleteSection(id);
+
     }
 
     CPPUNIT_ASSERT(section.sectionCount() == 0);
@@ -272,9 +275,12 @@ void TestSection::testPropertyAccess() {
     CPPUNIT_ASSERT(section.propertyCount() == 0);
     CPPUNIT_ASSERT(section.properties().size() == 0);
     CPPUNIT_ASSERT(section.getProperty("invalid_id") == false);
+    CPPUNIT_ASSERT_EQUAL(false, section.hasProperty("invalid_id"));
 
     Property p = section.createProperty("empty_prop", DataType::Double);
     CPPUNIT_ASSERT(section.propertyCount() == 1);
+    CPPUNIT_ASSERT(section.hasProperty(p));
+    CPPUNIT_ASSERT(section.hasProperty("empty_prop"));
     Property prop = section.getProperty("empty_prop");
     CPPUNIT_ASSERT(prop.valueCount() == 0);
     CPPUNIT_ASSERT(prop.dataType() == nix::DataType::Double);

--- a/test/TestSource.cpp
+++ b/test/TestSource.cpp
@@ -105,11 +105,14 @@ void TestSource::testSourceAccess() {
     CPPUNIT_ASSERT(source.sourceCount() == 0);
     CPPUNIT_ASSERT(source.sources().size() == 0);
     CPPUNIT_ASSERT(source.getSource("invalid_id") == false);
+    CPPUNIT_ASSERT_EQUAL(false, source.hasSource("invalid_id"));
 
     vector<string> ids;
-    for (auto it = names.begin(); it != names.end(); it++) {
-        Source child_source = source.createSource(*it, "channel");
-        CPPUNIT_ASSERT(child_source.name() == *it);
+    for (const auto &name : names) {
+        Source child_source = source.createSource(name, "channel");
+        CPPUNIT_ASSERT(child_source.name() == name);
+        CPPUNIT_ASSERT(source.hasSource(child_source));
+        CPPUNIT_ASSERT(source.hasSource(name));
 
         ids.push_back(child_source.id());
     }
@@ -119,12 +122,12 @@ void TestSource::testSourceAccess() {
     CPPUNIT_ASSERT(source.sourceCount() == names.size());
     CPPUNIT_ASSERT(source.sources().size() == names.size());
 
-    for (auto it = ids.begin(); it != ids.end(); it++) {
-        Source child_source = source.getSource(*it);
-        CPPUNIT_ASSERT(source.hasSource(*it) == true);
-        CPPUNIT_ASSERT(child_source.id() == *it);
+    for (const auto &id : ids) {
+        Source child_source = source.getSource(id);
+        CPPUNIT_ASSERT(source.hasSource(id));
+        CPPUNIT_ASSERT(child_source.id() == id);
 
-        source.deleteSource(*it);
+        source.deleteSource(id);
     }
 
     CPPUNIT_ASSERT(source.sourceCount() == 0);

--- a/test/TestTag.cpp
+++ b/test/TestTag.cpp
@@ -84,7 +84,7 @@ void TestTag::testDefinition() {
 
 void TestTag::testCreateRemove() {
     std::vector<std::string> ids;
-    size_t count = block.tagCount();
+    size_t count = static_cast<size_t>(block.tagCount());
     const char *names[5] = { "tag_a", "tag_b", "tag_c", "tag_d", "tag_e" };
 
     for (int i = 0; i < 5; i++) {


### PR DESCRIPTION
Fix all affected components that use `objectCount`.
Part of issue #473