### PR TITLE
README.md: fix pkg name (nixlib-dev → libnix-dev)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ by executing
 ```
 sudo add-apt-repository ppa:gnode/nix
 sudo apt-get update
-sudo apt-get install nixlib-dev
+sudo apt-get install libnix-dev
 ```
 
 **Build NIX under Ubuntu 14.04**


### PR DESCRIPTION
```
E: Unable to locate package nixlib-dev
```