### PR TITLE
[File] throw nix::outOfBounds exception if invalid index is used

### DIFF
--- a/include/nix/File.hpp
+++ b/include/nix/File.hpp
@@ -139,6 +139,9 @@ public:
      * @return The block at the given index.
      */
     Block getBlock(size_t index) const {
+        if (index >= blockCount()) {
+            throw nix::OutOfBounds("Index is out of bounds when calling File::getBlock(index)!");
+        }
         return backend()->getBlock(index);
     }
 
@@ -242,6 +245,9 @@ public:
      * @return The section with the specified index.
      */
     Section getSection(size_t index) const {
+        if (index >= sectionCount()) {
+            throw nix::OutOfBounds("Index is out of bounds when calling File::getSection(index)!");
+        }
         return backend()->getSection(index);
     }
 

--- a/test/TestFile.cpp
+++ b/test/TestFile.cpp
@@ -112,6 +112,8 @@ void TestFile::testBlockAccess() {
     }
     CPPUNIT_ASSERT_THROW(file_open.deleteBlock(b), std::runtime_error);
     b = file_open.createBlock("test","test");
+    CPPUNIT_ASSERT_NO_THROW(file_open.getBlock(0));
+    CPPUNIT_ASSERT_THROW(file_open.getBlock(file_open.blockCount()), nix::OutOfBounds);
     CPPUNIT_ASSERT(file_open.deleteBlock(b));
     CPPUNIT_ASSERT(file_open.blockCount() == 0);
     CPPUNIT_ASSERT(file_open.blocks().size() == 0);
@@ -149,6 +151,8 @@ void TestFile::testSectionAccess() {
     }
     CPPUNIT_ASSERT_THROW(file_open.deleteSection(s), std::runtime_error);
     s = file_open.createSection("test","test");
+    CPPUNIT_ASSERT_NO_THROW(file_open.getSection(0));
+    CPPUNIT_ASSERT_THROW(file_open.getSection(file_open.sectionCount()), nix::OutOfBounds);
     CPPUNIT_ASSERT(file_open.hasSection(s));
     CPPUNIT_ASSERT(file_open.deleteSection(s));
     CPPUNIT_ASSERT(file_open.sectionCount() == 0);


### PR DESCRIPTION
solves issue #506 

actually I introduce  a slight inconsistency here. So far the getXYZ(index) methods return none (e.g. in Block) when an invalid index is given. I do not really like this and would prefer the exception. If you disagree I am happy to change the behaviour in File to match the Block-like behaviour and remove the exception. 