### PR TITLE
[<< operators] in Section and Source reverted back to pre pr #512 state

### DIFF
--- a/src/Section.cpp
+++ b/src/Section.cpp
@@ -273,7 +273,7 @@ vector<Section> Section::findSideways(const std::function<bool(Section)> &filter
 }
 
 
-std::ostream& operator<<(ostream &out, const Section &ent) {
+std::ostream& nix::operator<<(ostream &out, const Section &ent) {
     out << "Section: {name = " << ent.name();
     out << ", type = " << ent.type();
     out << ", id = " << ent.id() << "}";

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -108,7 +108,7 @@ std::vector<Source> Source::findSources(const util::Filter<Source>::type &filter
 //------------------------------------------------------
 
 
-std::ostream& operator<<(ostream &out, const Source &ent) {
+std::ostream& nix::operator<<(ostream &out, const Source &ent) {
     out << "Source: {name = " << ent.name();
     out << ", type = " << ent.type();
     out << ", id = " << ent.id() << "}";


### PR DESCRIPTION
with pr #512 I changed the << operators to the same version as in all other entities. With these changes, nixpy would compile but tests failed during nix import due to undefined symbols.
This commit reverts these changes. Still, I do not really understand but this may come later ...