### PR TITLE
[RangeDimension] change behavior of indexOf to return first index tha…

### DIFF
--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -629,7 +629,7 @@ public:
     /**
      * @brief Returns the index of the given position
      *
-     * Method will return the index closest to the given position  
+     * Method will return the index equal or larger than position
      * 
      * @param position    The position.
      *

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -333,7 +333,6 @@ double RangeDimension::tickAt(const size_t index) const {
 
 
 size_t RangeDimension::indexOf(const double position) const {
-    size_t index;
     vector<double> ticks = this->ticks();
     if (position < *ticks.begin()) {
         return 0;
@@ -341,22 +340,7 @@ size_t RangeDimension::indexOf(const double position) const {
         return prev(ticks.end()) - ticks.begin();
     }
     vector<double>::iterator low = std::lower_bound (ticks.begin(), ticks.end(), position);
-    if (*low == position) {
-        return low - ticks.begin();
-    }
-    if (low != ticks.begin() && *low != position) {
-        double diff_low, diff_before;
-        diff_low = fabs(*low - position);
-        diff_before = fabs(*(std::prev(low)) - position);
-        if (diff_low < diff_before) {
-            index = low - ticks.begin();
-        } else {
-            index = low - ticks.begin() - 1;
-        }
-        return index;
-    } else {
-        return low - ticks.begin();
-    }
+    return low - ticks.begin();
 }
 
 

--- a/test/TestDataAccess.cpp
+++ b/test/TestDataAccess.cpp
@@ -142,9 +142,9 @@ void TestDataAccess::testPositionToIndexRangeDimension() {
     CPPUNIT_ASSERT(util::positionToIndex(0.001, scaled_unit, rangeDim) == 0);
     CPPUNIT_ASSERT(util::positionToIndex(0.008, scaled_unit, rangeDim) == 4);
     CPPUNIT_ASSERT(util::positionToIndex(3.4, unit, rangeDim) == 2);
-    CPPUNIT_ASSERT(util::positionToIndex(3.6, unit, rangeDim) == 2);
+    CPPUNIT_ASSERT(util::positionToIndex(3.6, unit, rangeDim) == 3);
     CPPUNIT_ASSERT(util::positionToIndex(4.0, unit, rangeDim) == 3);
-    CPPUNIT_ASSERT(util::positionToIndex(0.0036, scaled_unit, rangeDim) == 2);
+    CPPUNIT_ASSERT(util::positionToIndex(0.0036, scaled_unit, rangeDim) == 3);
 }
 
 

--- a/test/TestDimension.cpp
+++ b/test/TestDimension.cpp
@@ -413,8 +413,8 @@ void TestDimension::testRangeDimIndexOf() {
     rd = d;
     CPPUNIT_ASSERT(rd.indexOf(-100.) == 0);
     CPPUNIT_ASSERT(rd.indexOf(-50.) == 1);
-    CPPUNIT_ASSERT(rd.indexOf(-70.) == 0);
-    CPPUNIT_ASSERT(rd.indexOf(5.0) == 2);
+    CPPUNIT_ASSERT(rd.indexOf(-70.) == 1);
+    CPPUNIT_ASSERT(rd.indexOf(5.0) == 3);
     CPPUNIT_ASSERT(rd.indexOf(257.28) == 4);
     CPPUNIT_ASSERT(rd.indexOf(-257.28) == 0);
 


### PR DESCRIPTION
…t is not less than position

In the former versions it appeared a good idea to give the index of the tick that is closest to the provided position. In the context of defining a range in the ticks this is at least awkward if not outright wrong.

I changed the behavior accordingly to return the first not-less index