### PR TITLE
Ctor vs init

### DIFF
--- a/include/nix/File.hpp
+++ b/include/nix/File.hpp
@@ -154,6 +154,15 @@ public:
      * @return The created block.
      */
     Block createBlock(const std::string &name, const std::string &type) {
+        if (name.empty()) {
+            throw EmptyString("Trying to create Block with empty name!");
+        }
+        if (type.empty()) {
+            throw EmptyString("Trying to create Block with empty type!");
+        }
+        if (hasBlock(name)) {
+            throw DuplicateName("Block with the given name already exists!");
+        }
         return backend()->createBlock(name, type);
     }
 

--- a/include/nix/hdf5/BlockHDF5.hpp
+++ b/include/nix/hdf5/BlockHDF5.hpp
@@ -39,29 +39,6 @@ public:
      */
     BlockHDF5(const std::shared_ptr<base::IFile> &file, const Group &group);
 
-    /**
-     * Standard constructor for a new Block.
-     *
-     * @param file      The file which contains this block.
-     * @param group     The group that represents the block inside the file.
-     * @param id        The id of this block.
-     * @param type      The type of this block.
-     * @param name      The name of this block.
-     */
-    BlockHDF5(const std::shared_ptr<base::IFile> &file, const Group &group, const std::string &id, const std::string &type, const std::string &name);
-
-    /**
-     * Standard constructor for a new Block.
-     *
-     * @param file      The file which contains this block.
-     * @param group     The group that represents the block inside the file.
-     * @param id        The id of this block.
-     * @param type      The type of this block.
-     * @param name      The name of this block.
-     * @param time      The creation time of this block.
-     */
-    BlockHDF5(const std::shared_ptr<base::IFile> &file, const Group &group, const std::string &id, const std::string &type, const std::string &name, time_t time);
-
     //--------------------------------------------------
     // Methods concerning sources
     //--------------------------------------------------

--- a/include/nix/hdf5/EntityHDF5.hpp
+++ b/include/nix/hdf5/EntityHDF5.hpp
@@ -68,6 +68,7 @@ public:
 
     Group group() const;
 
+    static void init(const Group &group, const std::string &id);
 
     virtual ~EntityHDF5();
 

--- a/include/nix/hdf5/NamedEntityHDF5.hpp
+++ b/include/nix/hdf5/NamedEntityHDF5.hpp
@@ -64,6 +64,8 @@ public:
 
     int compare(const std::shared_ptr<INamedEntity> &other) const;
 
+    static void init(const Group &group, const std::string &id, const std::string &type,
+                     const std::string &name);
 
     ~NamedEntityHDF5();
 

--- a/src/hdf5/BlockHDF5.cpp
+++ b/src/hdf5/BlockHDF5.cpp
@@ -32,20 +32,6 @@ BlockHDF5::BlockHDF5(const std::shared_ptr<base::IFile> &file, const Group &grou
     source_group = this->group().openOptGroup("sources");
 }
 
-BlockHDF5::BlockHDF5(const shared_ptr<IFile> &file, const Group &group, const string &id, const string &type, const string &name)
-        : BlockHDF5(file, group, id, type, name, util::getTime()) {
-}
-
-
-BlockHDF5::BlockHDF5(const shared_ptr<IFile> &file, const Group &group, const string &id, const string &type, const string &name, time_t time)
-        : EntityWithMetadataHDF5(file, group, id, type, name, time) {
-    data_array_group = this->group().openOptGroup("data_arrays");
-    tag_group = this->group().openOptGroup("tags");
-    multi_tag_group = this->group().openOptGroup("multi_tags");
-    source_group = this->group().openOptGroup("sources");
-}
-
-
 //--------------------------------------------------
 // Methods concerning sources
 //--------------------------------------------------

--- a/src/hdf5/EntityHDF5.cpp
+++ b/src/hdf5/EntityHDF5.cpp
@@ -111,6 +111,11 @@ bool EntityHDF5::operator!=(const EntityHDF5 &other) const {
 }
 
 
+void EntityHDF5::init(const Group &group, const std::string &id) {
+    group.setAttr("entity_id", id);
+}
+
+
 EntityHDF5::~EntityHDF5() {}
 
 } // ns nix::hdf5

--- a/src/hdf5/FileHDF5.cpp
+++ b/src/hdf5/FileHDF5.cpp
@@ -113,16 +113,15 @@ shared_ptr<base::IBlock> FileHDF5::getBlock(ndsize_t index) const {
 
 
 shared_ptr<base::IBlock> FileHDF5::createBlock(const string &name, const string &type) {
-    if (name.empty()) {
-        throw EmptyString("Trying to create Block with empty name!");
-    }
-    if (hasBlock(name)) {
-        throw DuplicateName("Block with the given name already exists!");
-    }
-    string id = util::createId();
-
     Group group = data.openGroup(name, true);
-    return make_shared<BlockHDF5>(file(), group, id, type, name);
+
+    try {
+        BlockHDF5::init(group, util::createId(), name, type);
+        return make_shared<BlockHDF5>(file(), group);
+    } catch (exception &e) {
+        data.removeGroup(name);
+        throw e;
+    }
 }
 
 

--- a/src/hdf5/NamedEntityHDF5.cpp
+++ b/src/hdf5/NamedEntityHDF5.cpp
@@ -122,6 +122,15 @@ int NamedEntityHDF5::compare(const std::shared_ptr<INamedEntity> &other) const {
 }
 
 
+void NamedEntityHDF5::init(const Group &group, const std::string &id, const std::string &name,
+                           const std::string &type) {
+    EntityHDF5::init(group, id);
+
+    group.setAttr("type", type);
+    group.setAttr("name", name);
+}
+
+
 NamedEntityHDF5::~NamedEntityHDF5() {}
 
 } // ns nix::hdf5


### PR DESCRIPTION
This pr serves the purpose of discussing the changes related to #523 and is not necessarily meant to be merged.

As an example I implemented `init` as static member function for some base classes and used them to implement `FileHDF5::createBlock` as discussed in #523. But there are certain things that need to be discussed:

* So far we have a rather stupid front-end and the majority of front-end methods just call `backend()->something()` and that's it. But with #529 and this pr we are changing the paradigm a bit since we do more checks in the front-end and rely in the back-end on more or less sane parameters. Is this the direction we want to go?
* Using a static member functions for `init` has one disadvantage. Since `init` methods have different signatures it is possible to call different `init` methods from `BlockHDF5`: the one defined by `EntityHDF5` and the one on `NamedEntityHDF5`, but only the latter is the correct one. This is not very nice.