### PR TITLE
[Property] move compare method to the front-end

### DIFF
--- a/include/nix/Property.hpp
+++ b/include/nix/Property.hpp
@@ -260,9 +260,7 @@ public:
      * @return > 0 if the property is larger that other, 0 if both are
      * equal, and < 0 otherwise.
      */
-    int compare(const Property &other) const {
-        return backend()->compare(other.impl());
-    }
+    int compare(const Property &other) const;
 
     /**
      * @brief Assignment operator for none.

--- a/include/nix/base/IProperty.hpp
+++ b/include/nix/base/IProperty.hpp
@@ -78,9 +78,6 @@ public:
     virtual void values(const boost::none_t t) = 0;
 
 
-    virtual int compare(const std::shared_ptr<IProperty> &other) const = 0;
-
-
     virtual ~IProperty() {}
 };
 

--- a/include/nix/hdf5/PropertyHDF5.hpp
+++ b/include/nix/hdf5/PropertyHDF5.hpp
@@ -115,10 +115,7 @@ public:
 
 
     void values(const boost::none_t t);
-
-
-    int compare(const std::shared_ptr<IProperty> &other) const;
-
+    
 
     bool operator==(const PropertyHDF5 &other) const; //FIXME: not implemented
 

--- a/src/Property.cpp
+++ b/src/Property.cpp
@@ -25,5 +25,16 @@ std::ostream& operator<<(std::ostream &out, const Property &ent) {
     return out;
 }
 
+int Property::compare(const Property &other) const {
+    int cmp = 0;
+    if (!name().empty() && !other.name().empty()) {
+        cmp = (name()).compare(other.name());
+    }
+    if (cmp == 0) {
+        cmp = id().compare(other.id());
+    }
+    return cmp;
+}
+
 } // namespace nix
 

--- a/src/hdf5/PropertyHDF5.cpp
+++ b/src/hdf5/PropertyHDF5.cpp
@@ -243,18 +243,6 @@ void PropertyHDF5::values(const nix::none_t t) {
 }
 
 
-int PropertyHDF5::compare(const std::shared_ptr<IProperty> &other) const {
-    int cmp = 0;
-    if (!name().empty() && !other->name().empty()) {
-        cmp = (name()).compare(other->name());
-    }
-    if (cmp == 0) {
-        cmp = id().compare(other->id());
-    }
-    return cmp;
-}
-
-
 PropertyHDF5::~PropertyHDF5() {}
 
 } // ns nix::hdf5


### PR DESCRIPTION
this pr solves issue #525.  Actually, this is the only method that can be meaningfully moved. The == and != have to stay with the back end as long as we check for equality by being stored at the same location in the hdf5 file.