### PR TITLE
DataType: remove Date, DateTime

### DIFF
--- a/include/nix/DataType.hpp
+++ b/include/nix/DataType.hpp
@@ -38,8 +38,6 @@ NIXAPI enum class DataType {
     UInt32,
     UInt64,
     String,
-    Date,
-    DateTime,
     Opaque,
 
     Nothing = -1

--- a/src/DataType.cpp
+++ b/src/DataType.cpp
@@ -36,8 +36,6 @@ std::string data_type_to_string(DataType dtype) {
     case DataType::UInt64:   str = "UInt64";   break;
     case DataType::String:   str = "String";   break;
     case DataType::Nothing:  str = "Nothing";  break;
-    case DataType::Date:     str = "Date";     break;
-    case DataType::DateTime: str = "Datetime"; break;
     case DataType::Opaque:   str = "Opaque";   break;
     }
 
@@ -61,8 +59,6 @@ DataType string_to_data_type(const std::string& dtype) {
         {"uint32", DataType::UInt32},
         {"uint64", DataType::UInt64},
         {"string", DataType::String},
-        {"date", DataType::Date},
-        {"datetime", DataType::DateTime},
         {"opaque", DataType::Opaque},
         {"nothing", DataType::Nothing}
     };

--- a/src/hdf5/DataTypeHDF5.cpp
+++ b/src/hdf5/DataTypeHDF5.cpp
@@ -79,8 +79,6 @@ h5x::DataType data_type_to_h5_filetype(DataType dtype) {
 
         case DataType::Char: break; //FIXME
         case DataType::Nothing: break;
-        case DataType::Date: break;
-        case DataType::DateTime: break;
     }
 
     throw std::invalid_argument("Unkown DataType"); //FIXME
@@ -112,8 +110,6 @@ h5x::DataType data_type_to_h5_memtype(DataType dtype) {
 
         case DataType::Char: break; //FIXME
         case DataType::Nothing: break;
-        case DataType::Date: break;
-        case DataType::DateTime: break;
     }
 
     throw std::invalid_argument("DataType not handled!"); //FIXME

--- a/test/TestDataSet.cpp
+++ b/test/TestDataSet.cpp
@@ -248,8 +248,6 @@ void TestDataSet::testDataTypeIsNumeric() {
             {true, nix::DataType::Double},
             {false, nix::DataType::String},
             {false, nix::DataType::Nothing},
-            {false, nix::DataType::Date},
-            {false, nix::DataType::DateTime},
             {false, nix::DataType::Opaque}
     };
 

--- a/test/TestValue.cpp
+++ b/test/TestValue.cpp
@@ -69,7 +69,7 @@ void TestValue::testObject() {
     CPPUNIT_ASSERT_EQUAL(v1.type(), nix::DataType::Nothing);
 
     //the rest of the supports_type test are in ValTester::check_basic, below
-    CPPUNIT_ASSERT_EQUAL(false, nix::Value::supports_type(nix::DataType::DateTime));
+    CPPUNIT_ASSERT_EQUAL(false, nix::Value::supports_type(nix::DataType::Opaque));
 }
 
 struct ValTester {


### PR DESCRIPTION
Not supported anyway. Fix all locations that mention it.
NB: This will break nixpy and nix-java bindings.