### PR TITLE
Be consistent with 'override'

### DIFF
--- a/include/nix/DataArray.hpp
+++ b/include/nix/DataArray.hpp
@@ -485,12 +485,12 @@ protected:
     void ioRead(DataType dtype,
                 void *data,
                 const NDSize &count,
-                const NDSize &offset) const override;
+                const NDSize &offset) const;
 
     void ioWrite(DataType dtype,
                  const void *data,
                  const NDSize &count,
-                 const NDSize &offset) override;
+                 const NDSize &offset);
 };
 
 } // namespace nix

--- a/include/nix/DataView.hpp
+++ b/include/nix/DataView.hpp
@@ -28,18 +28,18 @@ public:
     // the DataIO interface implementation
     virtual void dataExtent(const NDSize &extent);
     virtual NDSize dataExtent() const;
-    virtual DataType dataType() const override;
+    virtual DataType dataType() const;
 
 protected:
     void ioRead(DataType dtype,
                 void *data,
                 const NDSize &count,
-                const NDSize &offset) const override;
+                const NDSize &offset) const;
 
     void ioWrite(DataType dtype,
                  const void *data,
                  const NDSize &count,
-                 const NDSize &offset) override;
+                 const NDSize &offset);
 
 private:
     NDSize transform_coordinates(const NDSize &c, const NDSize &o) const;

--- a/include/nix/hdf5/BlockHDF5.hpp
+++ b/include/nix/hdf5/BlockHDF5.hpp
@@ -100,7 +100,7 @@ public:
 
 
     std::shared_ptr<base::IDataArray> createDataArray(const std::string &name, const std::string &type,
-                                                      nix::DataType data_type, const NDSize &shape) override;
+                                                      nix::DataType data_type, const NDSize &shape);
 
 
     bool deleteDataArray(const std::string &name_or_id);

--- a/include/nix/hdf5/FileHDF5.hpp
+++ b/include/nix/hdf5/FileHDF5.hpp
@@ -117,7 +117,7 @@ public:
     void forceCreatedAt(time_t t);
 
 
-    void close() override;
+    void close();
 
 
     bool isOpen() const;


### PR DESCRIPTION
This is a band aid for gh issue #537 by removing
the minority of override. Since clang complains
about inconsistent use, this will fix the warning.

Better would be to use override everywhere, after
the 1.1. release.