### PR TITLE
DataType: check for _WIN32 instead of WIN32

### DIFF
--- a/include/nix/DataType.hpp
+++ b/include/nix/DataType.hpp
@@ -17,7 +17,7 @@
 #include <ostream>
 
 namespace std {
-#if !defined(WIN32) && __cplusplus < 201300L
+#if !defined(_WIN32) && __cplusplus < 201300L
 template<bool B, class T = void>
 using enable_if_t = typename std::enable_if<B, T>::type;
 #endif


### PR DESCRIPTION
* For consistency reasons
* And lets hope this causes less troubles with nix-java