### PR TITLE
add a way to check whether an Entity is valid in the backend

### DIFF
--- a/include/nix/base/Entity.hpp
+++ b/include/nix/base/Entity.hpp
@@ -122,6 +122,12 @@ public:
     }
 
     /**
+     *
+     */
+    bool isValidEntity() {
+        return ImplContainer<T>::backend()->isValidEntity();
+    }
+    /**
      * @brief Destructor
      */
     virtual ~Entity() {}

--- a/include/nix/base/IEntity.hpp
+++ b/include/nix/base/IEntity.hpp
@@ -46,6 +46,7 @@ public:
 
     virtual void forceCreatedAt(time_t t) = 0;
 
+    virtual  bool isValidEntity() = 0;
 
     virtual ~IEntity() {}
 };

--- a/include/nix/hdf5/BlockHDF5.hpp
+++ b/include/nix/hdf5/BlockHDF5.hpp
@@ -178,7 +178,7 @@ public:
     virtual ~BlockHDF5();
 
 
-    std::shared_ptr<IBlock> block() const;
+    std::shared_ptr<base::IBlock> block() const;
 
 };
 

--- a/include/nix/hdf5/DataSetHDF5.hpp
+++ b/include/nix/hdf5/DataSetHDF5.hpp
@@ -69,6 +69,8 @@ public:
     DataType dataType(void) const;
 
     DataSpace getSpace() const;
+
+    bool isReferenced() const;
 };
 
 

--- a/include/nix/hdf5/EntityHDF5.hpp
+++ b/include/nix/hdf5/EntityHDF5.hpp
@@ -60,6 +60,9 @@ public:
     void forceCreatedAt(time_t t);
 
 
+    bool isValidEntity();
+
+
     bool operator==(const EntityHDF5 &other) const;
 
 

--- a/include/nix/hdf5/H5Group.hpp
+++ b/include/nix/hdf5/H5Group.hpp
@@ -172,6 +172,8 @@ public:
      */
     bool removeAllLinks(const std::string &name);
 
+    bool isReferenced() const;
+
     virtual ~H5Group();
 
 

--- a/include/nix/hdf5/PropertyHDF5.hpp
+++ b/include/nix/hdf5/PropertyHDF5.hpp
@@ -115,7 +115,10 @@ public:
 
 
     void values(const boost::none_t t);
-    
+
+
+    bool isValidEntity();
+
 
     bool operator==(const PropertyHDF5 &other) const; //FIXME: not implemented
 

--- a/src/hdf5/DataSetHDF5.cpp
+++ b/src/hdf5/DataSetHDF5.cpp
@@ -523,5 +523,11 @@ void DataSet::write(const std::vector<Value> &values)
 
 }
 
+bool DataSet::isReferenced() const {
+    H5O_info_t oInfo;
+    H5Oget_info(hid, &oInfo);
+    return oInfo.rc > 0;
+}
+
 } // namespace hdf5
 } // namespace nix

--- a/src/hdf5/EntityHDF5.cpp
+++ b/src/hdf5/EntityHDF5.cpp
@@ -91,6 +91,11 @@ void EntityHDF5::forceCreatedAt(time_t t) {
 }
 
 
+bool EntityHDF5::isValidEntity() {
+    return group().isReferenced();
+}
+
+
 H5Group EntityHDF5::group() const {
     return entity_group;
 }

--- a/src/hdf5/H5Group.cpp
+++ b/src/hdf5/H5Group.cpp
@@ -368,6 +368,12 @@ boost::optional<DataSet> H5Group::findDataByNameOrAttribute(std::string const &a
     }
 }
 
+bool H5Group::isReferenced() const {
+    H5O_info_t oinfo;
+    H5Oget_info(hid, &oinfo);
+    return oinfo.rc > 0;
+}
+
 
 H5Group::~H5Group()
 {}

--- a/src/hdf5/PropertyHDF5.cpp
+++ b/src/hdf5/PropertyHDF5.cpp
@@ -233,6 +233,11 @@ void PropertyHDF5::values(const nix::none_t t) {
 }
 
 
+bool PropertyHDF5::isValidEntity() {
+    return dataset().isReferenced();
+}
+
+
 PropertyHDF5::~PropertyHDF5() {}
 
 } // ns nix::hdf5

--- a/test/BaseTestEntity.cpp
+++ b/test/BaseTestEntity.cpp
@@ -66,5 +66,12 @@ void BaseTestEntity::testUpdatedAt() {
 }
 
 
+void BaseTestEntity::testIsValidEntity() {
+    CPPUNIT_ASSERT(block.isValidEntity());
+    Source s  = block.createSource("test", "test");
+    CPPUNIT_ASSERT(s.isValidEntity());
+    block.deleteSource(s.name());
+    CPPUNIT_ASSERT(!s.isValidEntity());
+}
 
 

--- a/test/BaseTestEntity.hpp
+++ b/test/BaseTestEntity.hpp
@@ -28,6 +28,8 @@ public:
     void testDefinition();
     void testUpdatedAt();
     void testCreatedAt();
+    void testIsValidEntity();
+
 };
 
 #endif // NIX_BASETESTENTITY_HPP

--- a/test/BaseTestProperty.cpp
+++ b/test/BaseTestProperty.cpp
@@ -189,3 +189,9 @@ void BaseTestProperty::testUpdatedAt() {
     CPPUNIT_ASSERT(property.updatedAt() >= startup_time);
 }
 
+void BaseTestProperty::testIsValidEntity() {
+    Property p = section.createProperty("testProperty", DataType::Double);
+    CPPUNIT_ASSERT(p.isValidEntity());
+    section.deleteProperty(p.name());
+    CPPUNIT_ASSERT(!p.isValidEntity());
+}

--- a/test/BaseTestProperty.hpp
+++ b/test/BaseTestProperty.hpp
@@ -34,6 +34,7 @@ public:
     void testDataType();
     void testValues();
     void testUnit();
+    void testIsValidEntity();
 
     void testOperators();
     void testUpdatedAt();

--- a/test/TestEntityHDF5.hpp
+++ b/test/TestEntityHDF5.hpp
@@ -23,6 +23,8 @@ class TestEntityHDF5 : public BaseTestEntity {
     CPPUNIT_TEST(testUpdatedAt);
     CPPUNIT_TEST(testCreatedAt);
 
+    CPPUNIT_TEST(testIsValidEntity);
+
     CPPUNIT_TEST_SUITE_END ();
 
 public:

--- a/test/TestPropertyHDF5.hpp
+++ b/test/TestPropertyHDF5.hpp
@@ -28,7 +28,7 @@ class TestPropertyHDF5 : public BaseTestProperty {
     CPPUNIT_TEST(testOperators);
     CPPUNIT_TEST(testUpdatedAt);
     CPPUNIT_TEST(testCreatedAt);
-
+    CPPUNIT_TEST(testIsValidEntity);
     CPPUNIT_TEST_SUITE_END();
 
 public:


### PR DESCRIPTION
In hdf5 an hid identifier can be valid even if the object is unlinked from everything else in the file, the object's name, btw., does no longer exist at that point. According to the valid hid, there may still be a reference count from this object to attributes and datasets. These can still be accessed.

This pr is related to issue #565 