### PR TITLE
Variant: Rework assignment, move ctor and swap

### DIFF
--- a/include/nix/Variant.hpp
+++ b/include/nix/Variant.hpp
@@ -64,11 +64,18 @@ public:
     }
 
     Variant(Variant &&other) NOEXCEPT : Variant() {
-        swap(other);
+        if (other.dtype == DataType::String) {
+            v_string = other.v_string;
+            dtype = DataType::String;
+            other.dtype = DataType::Nothing;
+            other.v_string = nullptr;
+        } else {
+            assign_variant_from(other);
+        }
     }
 
     Variant &operator=(Variant other) {
-        swap(other);
+        assign_variant_from(other);
         return *this;
     }
 

--- a/include/nix/Variant.hpp
+++ b/include/nix/Variant.hpp
@@ -120,13 +120,6 @@ public:
 
 private:
 
-    template<typename T>
-    void swap_helper(Variant &other) {
-        T temp = get<T>();
-        assign_variant_from(other);
-        other.set(temp);
-    }
-
     void assign_variant_from(const Variant &other);
 
     void maybe_deallocte_string();
@@ -150,11 +143,6 @@ inline const none_t Variant::get<>() const {
     return nix::none;
 }
 
-template<>
-inline void Variant::swap_helper<none_t>(Variant &other) {
-    assign_variant_from(other);
-    other.set(nix::none);
-}
 
 NIXAPI std::ostream &operator<<(std::ostream &out, const Variant &value);
 NIXAPI bool operator==(const Variant &a, const Variant &b);

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -153,42 +153,9 @@ void Variant::get(std::string &value) const {
 #define DATATYPE_SUPPORT_NOT_IMPLEMENTED false
 
 void Variant::swap(Variant &other) {
-    using std::swap;
-
-    //now for the variant members
-    if (dtype == other.dtype) {
-        switch(dtype) {
-            case DataType::Nothing: /* nothing to do, literally */ break;
-            case DataType::Bool:   swap(v_bool, other.v_bool);     break;
-            case DataType::Int32:  swap(v_int32, other.v_int32);   break;
-            case DataType::UInt32: swap(v_uint32, other.v_uint32); break;
-            case DataType::Int64:  swap(v_int64, other.v_int64);   break;
-            case DataType::UInt64: swap(v_uint64, other.v_uint64); break;
-            case DataType::Double: swap(v_double, other.v_double); break;
-            case DataType::String: swap(v_string, other.v_string); break;
-#ifndef CHECK_SUPPORTED_VALUES
-            default: assert(DATATYPE_SUPPORT_NOT_IMPLEMENTED);
-#endif
-        }
-
-        swap(dtype, other.dtype);
-
-    } else {
-
-        switch(dtype) {
-            case DataType::Nothing: swap_helper<none_t>(other);     break;
-            case DataType::Bool:    swap_helper<bool>(other);        break;
-            case DataType::Int32:   swap_helper<int32_t>(other);     break;
-            case DataType::UInt32:  swap_helper<uint32_t>(other);    break;
-            case DataType::Int64:   swap_helper<int64_t>(other);     break;
-            case DataType::UInt64:  swap_helper<uint64_t>(other);    break;
-            case DataType::Double:  swap_helper<double>(other);      break;
-            case DataType::String:  swap_helper<std::string>(other); break;
-#ifndef CHECK_SUPPORTED_VALUES
-            default: assert(DATATYPE_SUPPORT_NOT_IMPLEMENTED);
-#endif
-        }
-    }
+    Variant tmp(std::move(*this));
+    assign_variant_from(other);
+    other = std::move(tmp);
 }
 
 void Variant::assign_variant_from(const Variant &other) {


### PR DESCRIPTION
Implement swap in terms of assignment not the other way around.
Simplifies the code a bit.