### PR TITLE
Variant: properly specialise get<none_t>

### DIFF
--- a/include/nix/Variant.hpp
+++ b/include/nix/Variant.hpp
@@ -139,7 +139,7 @@ inline const char *Variant::get<const char *>() const {
 }
 
 template<>
-inline const none_t Variant::get<>() const {
+inline none_t Variant::get<none_t>() const {
     return nix::none;
 }
 


### PR DESCRIPTION
And fix issue #578 (resp. #570, for good, hopefully).