### PR TITLE
h5x::DataSet::dataType() returns a h5x::DataType

### DIFF
--- a/backend/hdf5/DataArrayHDF5.cpp
+++ b/backend/hdf5/DataArrayHDF5.cpp
@@ -334,7 +334,8 @@ DataType DataArrayHDF5::dataType(void) const {
     }
 
     DataSet ds = group().openData("data");
-    return ds.dataType();
+    const h5x::DataType dtype = ds.dataType();
+    return data_type_from_h5(dtype);
 }
 
 } // ns nix::hdf5

--- a/backend/hdf5/PropertyHDF5.cpp
+++ b/backend/hdf5/PropertyHDF5.cpp
@@ -161,7 +161,8 @@ void PropertyHDF5::definition(const nix::none_t t) {
 
 
 DataType PropertyHDF5::dataType() const {
-    return this->dataset().dataType();
+    const h5x::DataType dtype = dataset().dataType();
+    return data_type_from_h5(dtype);
 }
 
 
@@ -410,7 +411,7 @@ std::vector<Value> PropertyHDF5::values(void) const
     std::vector<Value> values;
 
     DataSet dset = dataset();
-    DataType dtype = dset.dataType();
+    DataType dtype = data_type_from_h5(dset.dataType());
     NDSize shape = dset.size();
 
     if (shape.size() < 1 || shape[0] < 1) {

--- a/backend/hdf5/h5x/H5DataSet.cpp
+++ b/backend/hdf5/h5x/H5DataSet.cpp
@@ -231,32 +231,8 @@ DataType DataSet::dataType(void) const
 {
     h5x::DataType ftype = H5Dget_type(hid);
     ftype.check("DataSet::dataType(): H5Dget_type failed");
-
-    H5T_class_t ftclass = ftype.class_t();
-
-    size_t     size;
-    H5T_sign_t sign;
-
-    if (ftclass == H5T_COMPOUND) {
-        //if it is a compound data type then it must be a
-        //a property dataset, we can handle that
-        int nmems = ftype.member_count();
-        assert(nmems == 6);
-        h5x::DataType vtype = ftype.member_type(0);
-
-        ftclass = vtype.class_t();
-        size = vtype.size();
-        sign = vtype.sign();
-
-    } else if (ftclass == H5T_OPAQUE) {
-        return DataType::Opaque;
-    } else {
-        size = ftype.size();
-        sign = ftype.sign();
-    }
-
-    DataType dtype = nix::hdf5::data_type_from_h5(ftclass, size, sign);
-    return dtype;
+    
+    return data_type_from_h5(ftype);
 }
 
 DataSpace DataSet::getSpace() const {

--- a/backend/hdf5/h5x/H5DataSet.cpp
+++ b/backend/hdf5/h5x/H5DataSet.cpp
@@ -227,12 +227,11 @@ void DataSet::vlenReclaim(h5x::DataType mem_type, void *data, DataSpace *dspace)
 }
 
 
-DataType DataSet::dataType(void) const
+h5x::DataType DataSet::dataType(void) const
 {
     h5x::DataType ftype = H5Dget_type(hid);
     ftype.check("DataSet::dataType(): H5Dget_type failed");
-    
-    return data_type_from_h5(ftype);
+    return ftype;
 }
 
 DataSpace DataSet::getSpace() const {

--- a/backend/hdf5/h5x/H5DataSet.hpp
+++ b/backend/hdf5/h5x/H5DataSet.hpp
@@ -60,7 +60,7 @@ public:
 
     void vlenReclaim(h5x::DataType mem_type, void *data, DataSpace *dspace = nullptr) const;
 
-    DataType dataType(void) const;
+    h5x::DataType dataType(void) const;
 
     DataSpace getSpace() const;
 

--- a/backend/hdf5/h5x/H5DataType.cpp
+++ b/backend/hdf5/h5x/H5DataType.cpp
@@ -211,5 +211,34 @@ data_type_from_h5(H5T_class_t vclass, size_t vsize, H5T_sign_t vsign)
     return DataType::Nothing;
 }
 
-} // namespace hdf4
+
+DataType data_type_from_h5(const h5x::DataType &dtype) {
+
+    H5T_class_t ftclass = dtype.class_t();
+
+    size_t     size;
+    H5T_sign_t sign;
+
+    if (ftclass == H5T_COMPOUND) {
+        //if it is a compound data type then it must be a
+        //a property dataset, we can handle that
+        int nmems = dtype.member_count();
+        assert(nmems == 6);
+        h5x::DataType vtype = dtype.member_type(0);
+
+        ftclass = vtype.class_t();
+        size = vtype.size();
+        sign = vtype.sign();
+
+    } else if (ftclass == H5T_OPAQUE) {
+        return DataType::Opaque;
+    } else {
+        size = dtype.size();
+        sign = dtype.sign();
+    }
+
+    return data_type_from_h5(ftclass, size, sign);
+}
+
+} // namespace hdf5
 } // namespace nix

--- a/backend/hdf5/h5x/H5DataType.hpp
+++ b/backend/hdf5/h5x/H5DataType.hpp
@@ -66,6 +66,7 @@ NIXAPI h5x::DataType data_type_to_h5(DataType dtype, bool for_memory);
 
 
 NIXAPI DataType data_type_from_h5(H5T_class_t vclass, size_t vsize, H5T_sign_t vsign);
+NIXAPI DataType data_type_from_h5(const h5x::DataType &dtype);
 
 } // namespace hdf5
 } // namespace nix

--- a/test/hdf5/TestDataSet.cpp
+++ b/test/hdf5/TestDataSet.cpp
@@ -91,7 +91,9 @@ void TestDataSet::testDataType() {
 
     for (size_t i = 0; i < (sizeof(_types)/sizeof(_type_info)); i++) {
         hdf5::DataSet ds = h5group.createData(_types[i].name, _types[i].dtype, dims);
-        CPPUNIT_ASSERT_EQUAL(ds.dataType(), _types[i].dtype);
+        nix::hdf5::h5x::DataType h5dtype = ds.dataType();
+        nix::DataType nixdtype = nix::hdf5::data_type_from_h5(h5dtype);
+        CPPUNIT_ASSERT_EQUAL(_types[i].dtype, nixdtype);
     }
 
 }


### PR DESCRIPTION
Part of the ongoing effort to separate the hdf5 backend code
from our hdf5 abstraction layer.