### PR TITLE
Change the file opening...

### DIFF
--- a/backend/fs/Directory.cpp
+++ b/backend/fs/Directory.cpp
@@ -128,7 +128,7 @@ bool Directory::removeObjectByNameOrAttribute(const std::string &attribute, cons
                 }
             }
         }
-        uintmax_t ret = remove_all(*p);
+        uintmax_t ret = bfs::remove_all(*p);
         return ret > 0;
     }
     return false;

--- a/backend/fs/DirectoryWithAttributes.cpp
+++ b/backend/fs/DirectoryWithAttributes.cpp
@@ -20,6 +20,28 @@ DirectoryWithAttributes::DirectoryWithAttributes(const bfs::path &location, File
         std::cerr << "checkHeader" << std::endl;
         if (!bfs::exists(location / bfs::path("attributes"))) {
            throw nix::InvalidFile("DirectoryWithAttributes");
+        } else {
+            AttributesFS a(location, mode);
+            bool check = true;
+            std::vector<int> version;
+            std::string str;
+            if (a.has("format"))  {
+                getAttr("format", str);
+                if (str != FILE_FORMAT) {
+                    check = false;
+                }
+            } else {
+                check = false;
+            }
+            if (a.has("version")) {
+                getAttr("version", version);
+                if (version != FILE_VERSION) {
+                    check = false;
+                }
+            } else {
+                check = false;
+            }
+            throw nix::InvalidFile("DirectoryWithAttributes");
         }
     }
     attributes = AttributesFS(location, mode);

--- a/backend/fs/DirectoryWithAttributes.cpp
+++ b/backend/fs/DirectoryWithAttributes.cpp
@@ -14,13 +14,19 @@ namespace bfs = boost::filesystem;
 namespace nix {
 namespace file {
 
-DirectoryWithAttributes::DirectoryWithAttributes(const bfs::path &location, FileMode mode)
+DirectoryWithAttributes::DirectoryWithAttributes(const bfs::path &location, FileMode mode, bool checkHeader)
     : Directory(location, mode) {
+    if (checkHeader && mode < FileMode::ReadWrite) {
+        std::cerr << "checkHeader" << std::endl;
+        if (!bfs::exists(location / bfs::path("attributes"))) {
+           throw nix::InvalidFile("DirectoryWithAttributes");
+        }
+    }
     attributes = AttributesFS(location, mode);
 }
 
-DirectoryWithAttributes::DirectoryWithAttributes(const std::string &location, FileMode mode)
-    : DirectoryWithAttributes(bfs::path(location.c_str()), mode)
+DirectoryWithAttributes::DirectoryWithAttributes(const std::string &location, FileMode mode, bool checkHeader)
+    : DirectoryWithAttributes(bfs::path(location.c_str()), mode, checkHeader)
 {
 }
 

--- a/backend/fs/DirectoryWithAttributes.cpp
+++ b/backend/fs/DirectoryWithAttributes.cpp
@@ -17,7 +17,6 @@ namespace file {
 DirectoryWithAttributes::DirectoryWithAttributes(const bfs::path &location, FileMode mode, bool checkHeader)
     : Directory(location, mode) {
     if (checkHeader && mode < FileMode::ReadWrite) {
-        std::cerr << "checkHeader" << std::endl;
         if (!bfs::exists(location / bfs::path("attributes"))) {
            throw nix::InvalidFile("DirectoryWithAttributes");
         } else {
@@ -41,7 +40,8 @@ DirectoryWithAttributes::DirectoryWithAttributes(const bfs::path &location, File
             } else {
                 check = false;
             }
-            throw nix::InvalidFile("DirectoryWithAttributes");
+            if (!check)
+                throw nix::InvalidFile("DirectoryWithAttributes");
         }
     }
     attributes = AttributesFS(location, mode);

--- a/backend/fs/DirectoryWithAttributes.hpp
+++ b/backend/fs/DirectoryWithAttributes.hpp
@@ -25,9 +25,10 @@ private:
     mutable AttributesFS attributes;
 
 public:
-    DirectoryWithAttributes (const boost::filesystem::path &location, FileMode mode = FileMode::ReadOnly);
+    DirectoryWithAttributes (const boost::filesystem::path &location, FileMode mode = FileMode::ReadOnly,
+                             bool checkHeader = false);
 
-    DirectoryWithAttributes (const std::string &location, FileMode mode = FileMode::ReadOnly);
+    DirectoryWithAttributes (const std::string &location, FileMode mode = FileMode::ReadOnly, bool checkHeader = false);
 
     template <typename T> void setAttr(const std::string &name, const T &value);
 

--- a/backend/fs/FileFS.cpp
+++ b/backend/fs/FileFS.cpp
@@ -20,7 +20,7 @@ namespace file {
 #define FILE_FORMAT  std::string("nix")
 
 FileFS::FileFS(const std::string &name, FileMode mode)
-    : DirectoryWithAttributes(name, mode){
+    : DirectoryWithAttributes(name, mode, true){
     this->mode = mode;
     if (mode == FileMode::Overwrite) {
         removeAll();

--- a/backend/fs/FileFS.cpp
+++ b/backend/fs/FileFS.cpp
@@ -15,9 +15,6 @@ namespace bfs = boost::filesystem;
 namespace nix {
 namespace file {
 
-// Format definition
-#define FILE_VERSION std::vector<int>{1, 0, 0}
-#define FILE_FORMAT  std::string("nix")
 
 FileFS::FileFS(const std::string &name, FileMode mode)
     : DirectoryWithAttributes(name, mode, true){

--- a/backend/hdf5/FileHDF5.cpp
+++ b/backend/hdf5/FileHDF5.cpp
@@ -316,7 +316,6 @@ bool FileHDF5::checkHeader() const {
     bool check = true;
     vector<int> version;
     string str;
-    // check format
     if (root.hasAttr("format")) {
         if (!root.getAttr("format", str) || str != FILE_FORMAT) {
             check = false;
@@ -324,7 +323,6 @@ bool FileHDF5::checkHeader() const {
     } else {
         check = false;
     }
-    // check version
     if (root.hasAttr("version")) {
         if (!root.getAttr("version", version) || version != FILE_VERSION) {
             check = false;
@@ -336,14 +334,13 @@ bool FileHDF5::checkHeader() const {
 }
 
 
-bool FileHDF5::createHeader() const {
+void FileHDF5::createHeader() const {
     try {
         root.setAttr("format", FILE_FORMAT);
         root.setAttr("version", FILE_VERSION);
-    } catch ( ... ){
-        return false;
+    } catch ( ... ) {
+        throw H5Exception("Could not open/create file");
     }
-    return true;
 }
 
 

--- a/backend/hdf5/FileHDF5.cpp
+++ b/backend/hdf5/FileHDF5.cpp
@@ -340,7 +340,7 @@ bool FileHDF5::createHeader() const {
     try {
         root.setAttr("format", FILE_FORMAT);
         root.setAttr("version", FILE_VERSION);
-    } catch (int e){
+    } catch ( ... ){
         return false;
     }
     return true;

--- a/backend/hdf5/FileHDF5.cpp
+++ b/backend/hdf5/FileHDF5.cpp
@@ -336,7 +336,7 @@ bool FileHDF5::checkHeader() const {
             check = false;
         }
     } else {
-        root.setAttr("format", FILE_FORMAT);
+        check = false;
     }
     // check version
     if (root.hasAttr("version")) {
@@ -344,12 +344,21 @@ bool FileHDF5::checkHeader() const {
             check = false;
         }
     } else {
-        root.setAttr("version", FILE_VERSION);
+        check = false;
     }
     return check;
 }
 
 
+bool FileHDF5::createHeader() const {
+    try {
+        root.setAttr("format", FILE_FORMAT);
+        root.setAttr("version", FILE_VERSION);
+    } catch (int e){
+        return false;
+    }
+    return true;
+}
 bool FileHDF5::fileExists(const string &name) const {
     ifstream f(name.c_str());
     if (f) {

--- a/backend/hdf5/FileHDF5.cpp
+++ b/backend/hdf5/FileHDF5.cpp
@@ -23,11 +23,6 @@ namespace nix {
 namespace hdf5 {
 
 
-// Format definition
-#define FILE_VERSION std::vector<int>{1, 0, 0}
-#define FILE_FORMAT  std::string("nix")
-
-
 static unsigned int map_file_mode(FileMode mode) {
     switch (mode) {
         case FileMode::ReadWrite:

--- a/backend/hdf5/FileHDF5.hpp
+++ b/backend/hdf5/FileHDF5.hpp
@@ -143,6 +143,8 @@ private:
     // check if the header of the file is valid
     bool checkHeader() const;
 
+
+    bool createHeader() const;
 };
 
 

--- a/backend/hdf5/FileHDF5.hpp
+++ b/backend/hdf5/FileHDF5.hpp
@@ -140,7 +140,16 @@ private:
     // check for existence
     bool fileExists(const std::string &name) const;
 
-    // check if the header of the file is valid
+
+    void createNew(const std::string &name, unsigned int h5mode, const H5Object &fcpl);
+
+
+    void openExisting(const std::string &name, unsigned int h5mode, const H5Object &fcpl);
+
+
+    void openRoot();
+
+
     bool checkHeader() const;
 
 

--- a/backend/hdf5/FileHDF5.hpp
+++ b/backend/hdf5/FileHDF5.hpp
@@ -153,7 +153,7 @@ private:
     bool checkHeader() const;
 
 
-    bool createHeader() const;
+    void createHeader() const;
 };
 
 

--- a/include/nix/Exception.hpp
+++ b/include/nix/Exception.hpp
@@ -87,6 +87,13 @@ public:
 };
 
 
+class InvalidFile: public std::invalid_argument {
+public:
+    InvalidFile(const std::string &caller):
+        std::invalid_argument("Invalid file - file is not a nix file. (" + caller + ")") { }
+};
+
+
 class UnsortedTicks: public std::invalid_argument {
 public:
     UnsortedTicks(const std::string &caller):

--- a/include/nix/base/IFile.hpp
+++ b/include/nix/base/IFile.hpp
@@ -28,6 +28,10 @@ NIXAPI enum class FileMode {
     Overwrite
 };
 
+
+#define FILE_VERSION std::vector<int>{1, 0, 0}
+#define FILE_FORMAT  std::string("nix")
+
 namespace base {
 
 

--- a/test/fs/TestFileFS.hpp
+++ b/test/fs/TestFileFS.hpp
@@ -25,6 +25,7 @@ class TestFileFS: public BaseTestFile {
     CPPUNIT_TEST(testOperators);
     CPPUNIT_TEST(testReopen);
     CPPUNIT_TEST(testCheckHeader);
+    CPPUNIT_TEST(testNonNix);
 
     CPPUNIT_TEST_SUITE_END ();
 
@@ -63,6 +64,20 @@ public:
         std::vector<int> version{2, 0, 0};
         attr.set("version", version);
         CPPUNIT_ASSERT_THROW(nix::File::open("test_file", nix::FileMode::ReadWrite, "file"), std::runtime_error);
+    }
+
+    void testNonNix() {
+        bfs::path p("non-nix");
+        bfs::path pa("non-nix_with_wrong_attributes");
+        bfs::create_directory(p);
+        bfs::create_directory(pa);
+        std::ofstream ofs;
+        ofs.open("non-nix_with_wrong_attributes/attributes", std::ofstream::out | std::ofstream::app);
+        ofs.close();
+        CPPUNIT_ASSERT_THROW(nix::File::open(p.string(), nix::FileMode::ReadOnly, "file"), nix::InvalidFile);
+        CPPUNIT_ASSERT_THROW(nix::File::open(pa.string(), nix::FileMode::ReadOnly, "file"), nix::InvalidFile);
+        bfs::remove_all(p);
+        bfs::remove_all(pa);
     }
 };
 


### PR DESCRIPTION
... so far, we just opened any h5 file and in the case of a non-nix h5 file opened in read-only mode we ran into runtime exceptions when trying to create data and metadata groups. Basically the same things happened in the file-backend.
In read-write and read-only modes we now check if we are going to work with a nix file otherwise an InvalidFile exception is thrown.