### PR TITLE
[fs] File: don't mark close() with 'override'

### DIFF
--- a/backend/fs/BlockFS.hpp
+++ b/backend/fs/BlockFS.hpp
@@ -104,7 +104,7 @@ public:
 
 
     std::shared_ptr<base::IDataArray> createDataArray(const std::string &name, const std::string &type,
-                                                      nix::DataType data_type, const NDSize &shape) override;
+                                                      nix::DataType data_type, const NDSize &shape);
 
 
     bool deleteDataArray(const std::string &name_or_id);

--- a/backend/fs/FileFS.hpp
+++ b/backend/fs/FileFS.hpp
@@ -101,7 +101,7 @@ public:
     void forceCreatedAt(time_t t);
 
 
-    void close() override;
+    void close();
 
 
     bool isOpen() const;


### PR DESCRIPTION
This will otherwise trigger clang's inconsistent-missing-override
warning.