### PR TITLE
Use order tracking for H5Group::objectName

### DIFF
--- a/backend/hdf5/h5x/H5Group.cpp
+++ b/backend/hdf5/h5x/H5Group.cpp
@@ -134,8 +134,8 @@ std::string H5Group::objectName(ndsize_t index) const {
     // check whether name is found by index
     ssize_t name_len = H5Lget_name_by_idx(hid,
                                           ".",
-                                          H5_INDEX_NAME,
-                                          H5_ITER_NATIVE,
+                                          H5_INDEX_CRT_ORDER,
+                                          H5_ITER_INC,
                                           (hsize_t) index,
                                           NULL,
                                           0,
@@ -144,8 +144,8 @@ std::string H5Group::objectName(ndsize_t index) const {
         char* name = new char[name_len+1];
         name_len = H5Lget_name_by_idx(hid,
                                       ".",
-                                      H5_INDEX_NAME,
-                                      H5_ITER_NATIVE,
+                                      H5_INDEX_CRT_ORDER,
+                                      H5_ITER_INC,
                                       (hsize_t) index,
                                       name,
                                       name_len+1,

--- a/backend/hdf5/h5x/H5Group.cpp
+++ b/backend/hdf5/h5x/H5Group.cpp
@@ -132,20 +132,34 @@ std::string H5Group::objectName(ndsize_t index) const {
 
     std::string str_name;
     // check whether name is found by index
+    H5_index_t index_type = H5_INDEX_CRT_ORDER;
+    H5_iter_order_t order = H5_ITER_INC;
     ssize_t name_len = H5Lget_name_by_idx(hid,
                                           ".",
-                                          H5_INDEX_CRT_ORDER,
-                                          H5_ITER_INC,
+                                          index_type,
+                                          order,
                                           (hsize_t) index,
                                           NULL,
                                           0,
                                           H5P_DEFAULT);
+    if (name_len < 0) {
+        index_type = H5_INDEX_NAME;
+        order = H5_ITER_NATIVE;
+        name_len = H5Lget_name_by_idx(hid,
+                                      ".",
+                                      index_type,
+                                      order,
+                                      (hsize_t) index,
+                                      NULL,
+                                      0,
+                                      H5P_DEFAULT);
+    }
     if (name_len > 0) {
         char* name = new char[name_len+1];
         name_len = H5Lget_name_by_idx(hid,
                                       ".",
-                                      H5_INDEX_CRT_ORDER,
-                                      H5_ITER_INC,
+                                      index_type,
+                                      order,
                                       (hsize_t) index,
                                       name,
                                       name_len+1,

--- a/test/hdf5/TestH5Group.cpp
+++ b/test/hdf5/TestH5Group.cpp
@@ -22,17 +22,23 @@ unsigned int &TestH5Group::open_mode()
 
 void TestH5Group::setUp() {
     unsigned int &openMode = open_mode();
+    nix::hdf5::H5Object fcpl = H5Pcreate(H5P_FILE_CREATE);
+    nix::hdf5::HErr fres = H5Pset_link_creation_order(fcpl.h5id(), H5P_CRT_ORDER_TRACKED|H5P_CRT_ORDER_INDEXED);
+    fres.check("Unable to create file in H5Group test (H5Pset_link_creation_order failed.)");
 
     if (openMode == H5F_ACC_TRUNC) {
-        h5file = H5Fcreate("test_group.h5", openMode, H5P_DEFAULT, H5P_DEFAULT);
+        h5file = H5Fcreate("test_group.h5", openMode, fcpl.h5id(), H5P_DEFAULT);
     } else {
         h5file = H5Fopen("test_group.h5", openMode, H5P_DEFAULT);
     }
 
     CPPUNIT_ASSERT(H5Iis_valid(h5file));
 
+    nix::hdf5::H5Object gcpl = H5Pcreate(H5P_GROUP_CREATE);
+    nix::hdf5::HErr gres = H5Pset_link_creation_order(gcpl.h5id(), H5P_CRT_ORDER_TRACKED|H5P_CRT_ORDER_INDEXED);
+    gres.check("Unable to create group in H5Group test (H5Pset_link_creation_order failed).");
     if (openMode == H5F_ACC_TRUNC) {
-        h5group = H5Gcreate2(h5file, "tstGroup", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+        h5group = H5Gcreate2(h5file, "tstGroup", H5P_DEFAULT, gcpl.h5id(), H5P_DEFAULT);
     } else {
         h5group = H5Gopen2(h5file, "tstGroup", H5P_DEFAULT);
     }

--- a/test/hdf5/TestH5Group.cpp
+++ b/test/hdf5/TestH5Group.cpp
@@ -215,3 +215,19 @@ void TestH5Group::testRefCount() {
     test_refcounting<nix::hdf5::H5Group>(h5group, ha);
     H5Gclose(ha);
 }
+
+void TestH5Group::testIterOrder() {
+    nix::ndsize_t N = 12;
+    nix::hdf5::H5Group root(h5group, true);
+    nix::hdf5::H5Group itergroup = root.openGroup("itertest", true);
+
+    for (nix::ndsize_t idx = 0; idx < N; idx++) {
+        itergroup.openGroup(std::to_string(idx), true);
+    }
+
+    std::string name;
+    for (nix::ndsize_t idx = 0; idx < N; idx++) {
+        name = itergroup.objectName(idx);
+        CPPUNIT_ASSERT_EQUAL(name, std::to_string(idx));
+    }
+}

--- a/test/hdf5/TestH5Group.hpp
+++ b/test/hdf5/TestH5Group.hpp
@@ -48,6 +48,8 @@ public:
 
     void testOpen();
 
+    void testIterOrder();
+
     template<typename T>
     static void assert_vectors_equal(std::vector<T> &a, std::vector<T> &b) {
 
@@ -77,5 +79,6 @@ private:
     CPPUNIT_TEST(testVector);
     CPPUNIT_TEST(testMultiArray);
     CPPUNIT_TEST(testArray);
+    CPPUNIT_TEST(testIterOrder);
     CPPUNIT_TEST_SUITE_END ();
 };


### PR DESCRIPTION
Use correct index type and order in `H5Lget_name_by_idx`: `H5_INDEX_CRT_ORDER` and `H5_ITER_INC` respectively.

File and Group in TestH5Group updated to enable order tracking and a new test has been added that checks whether retrieval order follows creation order.

Resolves #617.
