### PR TITLE
Dimensions are no longer treated as stack...

### DIFF
--- a/backend/fs/DataArrayFS.cpp
+++ b/backend/fs/DataArrayFS.cpp
@@ -210,28 +210,15 @@ Group DataArrayFS::createDimensionGroup(size_t index) {
 }
 */
 
-bool DataArrayFS::deleteDimension(ndsize_t index) {
-    bool deleted = false;
-    if (fileMode() == FileMode::ReadOnly)
-        return deleted;
-    size_t dim_count = dimensionCount();
-    std::string str_id = util::numToStr(index);
-    if (dimensions.hasObject(str_id)) {
-            deleted = dimensions.removeObjectByNameOrAttribute("entity_id", str_id);
-        }
-        if (deleted && index < dim_count) {
-            for (size_t old_id = index + 1; old_id <= dim_count; old_id++) {
-                std::string str_old_id = util::numToStr(old_id);
-                std::string str_new_id = util::numToStr(old_id - 1);
-                std::string temp_path = this->location() + bfs::path::preferred_separator + "dimensions" +
-                    bfs::path::preferred_separator + str_old_id;
-                AttributesFS attr(temp_path, this->fileMode());
-                attr.set("index", old_id - 1);
-                dimensions.renameSubdir(str_old_id, str_new_id);
-            }
-        }
-    return deleted;
+bool DataArrayFS::deleteDimensions() {
+    if (fileMode() != FileMode::ReadOnly) {
+        this->dimensions.removeAll();
+        return true;
+    } else {
+        return false;
+    }
 }
+
 
 //--------------------------------------------------
 // Other methods and functions

--- a/backend/fs/DataArrayFS.hpp
+++ b/backend/fs/DataArrayFS.hpp
@@ -116,7 +116,7 @@ public:
     std::shared_ptr<base::ISampledDimension> createSampledDimension(ndsize_t id, double sampling_interval);
 
 
-    bool deleteDimension(ndsize_t id);
+    bool deleteDimensions();
 
     //--------------------------------------------------
     // Other methods and functions

--- a/backend/hdf5/DataArrayHDF5.cpp
+++ b/backend/hdf5/DataArrayHDF5.cpp
@@ -222,29 +222,18 @@ H5Group DataArrayHDF5::createDimensionGroup(ndsize_t index) {
 }
 
 
-bool DataArrayHDF5::deleteDimension(ndsize_t index) {
-    bool deleted = false;
-    ndsize_t dim_count = dimensionCount();
-    string str_id = util::numToStr(index);
+bool DataArrayHDF5::deleteDimensions() {
+    string dim_id;
     boost::optional<H5Group> g = dimension_group();
-
-    if (g) {
-        if (g->hasGroup(str_id)) {
-            g->removeGroup(str_id);
-            deleted = true;
-        }
-
-        if (deleted && index < dim_count) {
-            for (ndsize_t old_id = index + 1; old_id <= dim_count; old_id++) {
-                string str_old_id = util::numToStr(old_id);
-                string str_new_id = util::numToStr(old_id - 1);
-                g->renameGroup(str_old_id, str_new_id);
-            }
+    for (ndsize_t i = dimensionCount(); i > 0; --i) {
+        dim_id = util::numToStr(i);
+        if (g->hasGroup(dim_id)) {
+            g->removeGroup(dim_id);
         }
     }
-
-    return deleted;
+    return true;
 }
+
 
 //--------------------------------------------------
 // Other methods and functions

--- a/backend/hdf5/DataArrayHDF5.hpp
+++ b/backend/hdf5/DataArrayHDF5.hpp
@@ -114,7 +114,7 @@ public:
     std::shared_ptr<base::ISampledDimension> createSampledDimension(ndsize_t id, double sampling_interval);
 
 
-    bool deleteDimension(ndsize_t id);
+    bool deleteDimensions();
 
     //--------------------------------------------------
     // Other methods and functions

--- a/include/nix/DataArray.hpp
+++ b/include/nix/DataArray.hpp
@@ -405,12 +405,12 @@ public:
     }
 
     /**
-     * @brief Remove a dimension descriptor at a specified index.
+     * @brief Remove all dimension descriptors of the {@link nix::DataArray}.
      *
-     * @param id        The index of the dimension. Must be a value > 0 and < `dimensionCount + 1`.
+     * @return bool indicating if operation succeeded.
      */
-    bool deleteDimension(ndsize_t id) {
-        return backend()->deleteDimension(id);
+    bool deleteDimensions() {
+        return backend()->deleteDimensions();
     }
 
     //--------------------------------------------------

--- a/include/nix/DataArray.hpp
+++ b/include/nix/DataArray.hpp
@@ -320,7 +320,19 @@ public:
      * @return The created RangeDimension
      */
     RangeDimension appendAliasRangeDimension() {
-        return createAliasRangeDimension();
+        if (this->dataExtent().size() > 1) {
+            throw nix::InvalidDimension("AliasRangeDimensions only allowed for 1D numeric DataArrays!",
+                                        "DataArray::createAliasRangeDimension");
+        }
+        if (!nix::data_type_is_numeric(this->dataType())) {
+            throw nix::InvalidDimension("AliasRangeDimensions are only allowed for 1D numeric DataArrays!",
+                                        "DataArray::createAliasRangeDimension");
+        }
+        if (dimensionCount() > 0) {
+            throw nix::InvalidDimension("Cannot append additional alias dimension. There must only be one!",
+                                        "DataArray::createAliasRangeDimension");
+        }
+        return backend()->createAliasRangeDimension();
     }
 
 
@@ -344,9 +356,10 @@ public:
      * @param id        The index of the dimension. Must be a value > 0 and <= `dimensionCount + 1`.
      *
      * @return The created dimension descriptor.
+     * @deprecated This function is deprecated and ignores the id argument!
      */
     SetDimension createSetDimension(ndsize_t id) {
-        return backend()->createSetDimension(id);
+        return appendSetDimension();
     }
 
     /**
@@ -359,34 +372,20 @@ public:
      * @param ticks     Vector with {@link nix::RangeDimension::ticks}.
      *
      * @return The created dimension descriptor.
+     * @deprecated This function is deprecated and ignores the id argument!
      */
     RangeDimension createRangeDimension(ndsize_t id, const std::vector<double> &ticks) {
-        if (ticks.size() == 0) {
-            throw nix::InvalidDimension("The ticks of a range dimension must not be empty!", 
-                                        "DataArray::createRangeDimension");
-        }
-        return backend()->createRangeDimension(id, ticks);
+        return appendRangeDimension(ticks);
     }
 
     /**
      * @brief Create a new RangeDimension that uses the data stored in this DataArray as ticks.
      * 
      * @return The created dimension descriptor.
+     * @deprecated This function is deprecated and will be removed. Use appendAliasRangeDimension instead!
      */
     RangeDimension createAliasRangeDimension() {
-        if (this->dataExtent().size() > 1) {
-            throw nix::InvalidDimension("AliasRangeDimensions only allowed for 1D numeric DataArrays!",
-                                        "DataArray::createAliasRangeDimension");
-        }
-        if (!nix::data_type_is_numeric(this->dataType())) {
-            throw nix::InvalidDimension("AliasRangeDimensions are only allowed for 1D numeric DataArrays!",
-                                        "DataArray::createAliasRangeDimension");
-        }
-        if (dimensionCount() > 0) {
-            throw nix::InvalidDimension("Cannot append additional alias dimension. There must only be one!",
-                                        "DataArray::createAliasRangeDimension");
-        }
-        return backend()->createAliasRangeDimension();
+        return appendAliasRangeDimension();
     }
 
     /**
@@ -399,9 +398,10 @@ public:
      * @param sampling_interval  The sampling interval of the dimension.
      *
      * @return The created dimension descriptor.
+     * @deprecated This function is deprecated and ignores the id argument!
      */
     SampledDimension createSampledDimension(ndsize_t id, double sampling_interval) {
-        return backend()->createSampledDimension(id, sampling_interval);
+        return appendSampledDimension(sampling_interval);
     }
 
     /**

--- a/include/nix/base/IDataArray.hpp
+++ b/include/nix/base/IDataArray.hpp
@@ -94,8 +94,7 @@ public:
     virtual std::shared_ptr<base::ISampledDimension> createSampledDimension(ndsize_t id, double sampling_interval) = 0;
 
 
-    virtual bool deleteDimension(ndsize_t id) = 0;
-
+    virtual bool deleteDimensions() = 0;
 
     //--------------------------------------------------
     // Methods concerning data access.

--- a/test/BaseTestDataArray.cpp
+++ b/test/BaseTestDataArray.cpp
@@ -397,13 +397,10 @@ void BaseTestDataArray::testDimension() {
         ticks.push_back(i * boost::math::constants::pi<double>());
     }
     CPPUNIT_ASSERT_THROW(array2.appendRangeDimension(std::vector<double>{}), nix::InvalidDimension);
-    CPPUNIT_ASSERT_THROW(array2.createRangeDimension(1, std::vector<double>{}), nix::InvalidDimension);
-    dims.push_back(array2.createSampledDimension(1, samplingInterval));
-    dims.push_back(array2.createSetDimension(2));
-    dims.push_back(array2.createRangeDimension(3, ticks));
     dims.push_back(array2.appendSampledDimension(samplingInterval));
     dims.push_back(array2.appendSetDimension());
-    dims[3] = array2.createRangeDimension(4, ticks);
+    dims.push_back(array2.appendRangeDimension(ticks));
+    dims.push_back(array2.appendSetDimension());
 
     // have some explicit dimension types
     nix::RangeDimension dim_range = array1.appendRangeDimension(ticks);
@@ -412,11 +409,10 @@ void BaseTestDataArray::testDimension() {
     CPPUNIT_ASSERT(array2.getDimension(dims[0].index()).dimensionType() == nix::DimensionType::Sample);
     CPPUNIT_ASSERT(array2.getDimension(dims[1].index()).dimensionType() == nix::DimensionType::Set);
     CPPUNIT_ASSERT(array2.getDimension(dims[2].index()).dimensionType() == nix::DimensionType::Range);
-    CPPUNIT_ASSERT(array2.getDimension(dims[3].index()).dimensionType() == nix::DimensionType::Range);
-    CPPUNIT_ASSERT(array2.getDimension(dims[4].index()).dimensionType() == nix::DimensionType::Set);
+    CPPUNIT_ASSERT(array2.getDimension(dims[3].index()).dimensionType() == nix::DimensionType::Set);
     CPPUNIT_ASSERT(!dim_range.alias());
 
-    CPPUNIT_ASSERT(array2.dimensionCount() == 5);
+    CPPUNIT_ASSERT(array2.dimensionCount() == 4);
     dims = array2.dimensions([](nix::Dimension dim) { return dim.dimensionType() == nix::DimensionType::Sample; });
     CPPUNIT_ASSERT(dims.size() == 1);
     CPPUNIT_ASSERT(dims[0].dimensionType() == nix::DimensionType::Sample);
@@ -425,16 +421,14 @@ void BaseTestDataArray::testDimension() {
     CPPUNIT_ASSERT(dims[0].dimensionType() == nix::DimensionType::Set);
     CPPUNIT_ASSERT(dims[1].dimensionType() == nix::DimensionType::Set);
     dims = array2.dimensions([](nix::Dimension dim) { return dim.dimensionType() == nix::DimensionType::Range; });
-    CPPUNIT_ASSERT(dims.size() == 2);
+    CPPUNIT_ASSERT(dims.size() == 1);
     CPPUNIT_ASSERT(dims[0].dimensionType() == nix::DimensionType::Range);
-    CPPUNIT_ASSERT(dims[1].dimensionType() == nix::DimensionType::Range);
     dims = array2.dimensions();
-    CPPUNIT_ASSERT(dims.size() == 5);
+    CPPUNIT_ASSERT(dims.size() == 4);
     CPPUNIT_ASSERT(dims[0].dimensionType() == nix::DimensionType::Sample);
     CPPUNIT_ASSERT(dims[1].dimensionType() == nix::DimensionType::Set);
     CPPUNIT_ASSERT(dims[2].dimensionType() == nix::DimensionType::Range);
-    CPPUNIT_ASSERT(dims[3].dimensionType() == nix::DimensionType::Range);
-    CPPUNIT_ASSERT(dims[4].dimensionType() == nix::DimensionType::Set);
+    CPPUNIT_ASSERT(dims[3].dimensionType() == nix::DimensionType::Set);
     // since deleteDimension renumbers indices to be continuous we test that too
     array2.deleteDimensions();
     dims = array2.dimensions();
@@ -447,14 +441,14 @@ void BaseTestDataArray::testAliasRangeDimension() {
     nix::Dimension dim = array3.createAliasRangeDimension();
     CPPUNIT_ASSERT(array3.dimensionCount() == 1);
     CPPUNIT_ASSERT(dim.dimensionType() == nix::DimensionType::Range);
-    CPPUNIT_ASSERT_THROW(array2.createAliasRangeDimension(), nix::InvalidDimension);
-    CPPUNIT_ASSERT_THROW(array2.createAliasRangeDimension(), nix::InvalidDimension);
-    CPPUNIT_ASSERT_THROW(array3.createAliasRangeDimension(), nix::InvalidDimension);
+    CPPUNIT_ASSERT_THROW(array2.appendAliasRangeDimension(), nix::InvalidDimension);
+    CPPUNIT_ASSERT_THROW(array2.appendAliasRangeDimension(), nix::InvalidDimension);
+    CPPUNIT_ASSERT_THROW(array3.appendAliasRangeDimension(), nix::InvalidDimension);
     CPPUNIT_ASSERT_THROW(array3.appendAliasRangeDimension(), nix::InvalidDimension);
     DataArray bool_array = block.createDataArray("string array", "string_array",
                                                  nix::DataType::Bool,
                                                  nix::NDSize({20}));
-    CPPUNIT_ASSERT_THROW(bool_array.createAliasRangeDimension(), nix::InvalidDimension);
+    CPPUNIT_ASSERT_THROW(bool_array.appendAliasRangeDimension(), nix::InvalidDimension);
     nix::RangeDimension rd;
     rd = dim;
     CPPUNIT_ASSERT(rd.alias());

--- a/test/BaseTestDataArray.cpp
+++ b/test/BaseTestDataArray.cpp
@@ -436,11 +436,7 @@ void BaseTestDataArray::testDimension() {
     CPPUNIT_ASSERT(dims[3].dimensionType() == nix::DimensionType::Range);
     CPPUNIT_ASSERT(dims[4].dimensionType() == nix::DimensionType::Set);
     // since deleteDimension renumbers indices to be continuous we test that too
-    array2.deleteDimension(5);
-    array2.deleteDimension(4);
-    array2.deleteDimension(1);
-    array2.deleteDimension(1);
-    array2.deleteDimension(1);
+    array2.deleteDimensions();
     dims = array2.dimensions();
     CPPUNIT_ASSERT(array2.dimensionCount() == 0);
     CPPUNIT_ASSERT(dims.size() == 0);

--- a/test/BaseTestDimension.cpp
+++ b/test/BaseTestDimension.cpp
@@ -69,7 +69,7 @@ void BaseTestDimension::testSampleValidate() {
 void BaseTestDimension::testIndex() {
     Dimension sd = data_array.appendSetDimension();
     CPPUNIT_ASSERT(data_array.dimensionCount() == 1 && sd.index() == 1);
-    data_array.deleteDimension(sd.index());
+    data_array.deleteDimensions();
     CPPUNIT_ASSERT(data_array.dimensionCount() == 0);
 }
 
@@ -91,7 +91,7 @@ void BaseTestDimension::testSampledDimLabel() {
     CPPUNIT_ASSERT_NO_THROW(sd.label(none));
     CPPUNIT_ASSERT(sd.label() == none);
 
-    data_array.deleteDimension(d.index());
+    data_array.deleteDimensions();
 }
 
 
@@ -110,7 +110,7 @@ void BaseTestDimension::testSampledDimUnit() {
     CPPUNIT_ASSERT(*(sd.unit()) == validUnit);
     CPPUNIT_ASSERT_NO_THROW(sd.unit(boost::none));
     CPPUNIT_ASSERT(sd.unit() == boost::none);
-    data_array.deleteDimension(d.index());
+    data_array.deleteDimensions();
 }
 
 
@@ -130,7 +130,7 @@ void BaseTestDimension::testSampledDimSamplingInterval() {
     CPPUNIT_ASSERT_NO_THROW(sd.samplingInterval(samplingInterval));
     CPPUNIT_ASSERT(sd.samplingInterval() == samplingInterval);
 
-    data_array.deleteDimension(d.index());
+    data_array.deleteDimensions();
 }
 
 
@@ -148,7 +148,7 @@ void BaseTestDimension::testSampledDimOffset() {
     CPPUNIT_ASSERT_NO_THROW(sd.offset(boost::none));
     CPPUNIT_ASSERT(sd.offset() == boost::none);
 
-    data_array.deleteDimension(d.index());
+    data_array.deleteDimensions();
 }
 
 
@@ -177,7 +177,7 @@ void BaseTestDimension::testSampledDimIndexOf() {
     CPPUNIT_ASSERT(sd.indexOf(4.28) == 1);
     CPPUNIT_ASSERT(sd.indexOf(7.28) == 2);
 
-    data_array.deleteDimension(d.index());
+    data_array.deleteDimensions();
 }
 
 
@@ -203,7 +203,7 @@ void BaseTestDimension::testSampledDimPositionAt() {
         sd[200],
         std::numeric_limits<double>::round_error());
 
-    data_array.deleteDimension(d.index());
+    data_array.deleteDimensions();
 }
 
 
@@ -236,7 +236,7 @@ void BaseTestDimension::testSampledDimAxis() {
         axis.back(),
         std::numeric_limits<double>::round_error());
 
-    data_array.deleteDimension(d.index());
+    data_array.deleteDimensions();
 }
 
 
@@ -255,8 +255,7 @@ void BaseTestDimension::testSampledDimOperators() {
     CPPUNIT_ASSERT(sd1.index() == d.index() && sd2.index() == d2.index());
     CPPUNIT_ASSERT(sd1 != sd2);
     CPPUNIT_ASSERT(sd1 != sd3);
-    data_array.deleteDimension(d2.index());
-    data_array.deleteDimension(d.index());
+    data_array.deleteDimensions();
     Dimension dim = data_array.appendSetDimension();
     CPPUNIT_ASSERT_THROW(dim.asSampledDimension(), IncompatibleDimensions);
     SampledDimension sampled = data_array.appendSampledDimension(samplingInterval);
@@ -320,7 +319,7 @@ void BaseTestDimension::testSetDimLabels() {
     retrieved_labels = sd.labels();
     CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(0), retrieved_labels.size());
 
-    data_array.deleteDimension(d.index());
+    data_array.deleteDimensions();
 }
 
 
@@ -344,7 +343,7 @@ void BaseTestDimension::testRangeDimLabel() {
     rd.label(none);
     CPPUNIT_ASSERT(rd.label() == none);
 
-    data_array.deleteDimension(d.index());
+    data_array.deleteDimensions();
 }
 
 
@@ -367,7 +366,7 @@ void BaseTestDimension::testRangeDimUnit() {
     CPPUNIT_ASSERT_NO_THROW(rd.unit(none));
     CPPUNIT_ASSERT(rd.unit() == none);
 
-    data_array.deleteDimension(d.index());
+    data_array.deleteDimensions();
 }
 
 
@@ -399,7 +398,7 @@ void BaseTestDimension::testRangeTicks() {
         CPPUNIT_ASSERT(new_ticks[i] == retrieved_ticks[i]);
     }
 
-    data_array.deleteDimension(d.index());
+    data_array.deleteDimensions();
 }
 
 
@@ -418,7 +417,7 @@ void BaseTestDimension::testRangeDimIndexOf() {
     CPPUNIT_ASSERT(rd.indexOf(257.28) == 4);
     CPPUNIT_ASSERT(rd.indexOf(-257.28) == 0);
 
-    data_array.deleteDimension(d.index());
+    data_array.deleteDimensions();
 }
 
 
@@ -438,7 +437,7 @@ void BaseTestDimension::testRangeDimTickAt() {
     CPPUNIT_ASSERT(rd[4] == 100.);
     CPPUNIT_ASSERT_THROW(rd[10], OutOfBounds);
 
-    data_array.deleteDimension(d.index());
+    data_array.deleteDimensions();
 }
 
 
@@ -478,7 +477,7 @@ void BaseTestDimension::testAsDimensionMethods() {
     sa_str << x.dimensionType();
     CPPUNIT_ASSERT(sa_str.str() == "Range");
 
-    data_array.deleteDimension(1);
+    data_array.deleteDimensions();
     d = data_array.appendSampledDimension(0.1);
     CPPUNIT_ASSERT_THROW(d.asRangeDimension(), IncompatibleDimensions);
     CPPUNIT_ASSERT_THROW(d.asSetDimension(), IncompatibleDimensions);
@@ -488,7 +487,7 @@ void BaseTestDimension::testAsDimensionMethods() {
     range_str << x.dimensionType();
     CPPUNIT_ASSERT(range_str.str() == "Sample");
 
-    data_array.deleteDimension(1);
+    data_array.deleteDimensions();
     d = data_array.appendSetDimension();
     CPPUNIT_ASSERT_THROW(d.asRangeDimension(), IncompatibleDimensions);
     CPPUNIT_ASSERT_THROW(d.asSampledDimension(), IncompatibleDimensions);

--- a/test/TestValidate.cpp
+++ b/test/TestValidate.cpp
@@ -80,9 +80,7 @@ void TestValidate::setValid() {
         }
     }
     array4.setData(sin_array);
-    for (ndsize_t i = array4.dimensionCount(); i > 0 ; --i) {
-        array4.deleteDimension(i);
-    }
+    array4.deleteDimensions();
     array4.appendSampledDimension(1.);
     array4.appendSetDimension();
     // fill array1 & array2
@@ -96,9 +94,7 @@ void TestValidate::setValid() {
                 A[i][j][k] = values++;
     array1.setData(A);
     array2.setData(A);
-    for (ndsize_t i = array2.dimensionCount(); i > 0; --i) {
-        array2.deleteDimension(i);
-    }
+    array2.deleteDimensions();
     dim_range1 = array2.appendRangeDimension({1, 2, 3});
     dim_range2 = array2.appendRangeDimension({1, 2, 3, 4});
     dim_range3 = array2.appendRangeDimension({1, 2});
@@ -129,14 +125,10 @@ void TestValidate::setValid() {
     extents.setData(C);
     
     // ensure correct dimension descriptors for positions
-    for (ndsize_t i = positions.dimensionCount(); i > 0; --i) {
-        positions.deleteDimension(i);
-    }
+    positions.deleteDimensions();
     positions.appendSetDimension();
     positions.appendSetDimension();
-    for (ndsize_t i = extents.dimensionCount(); i > 0; --i) {
-        extents.deleteDimension(i);
-    }
+    extents.deleteDimensions();
     extents.appendSetDimension();
     extents.appendSetDimension();
 
@@ -220,15 +212,9 @@ void TestValidate::setInvalid() {
     // fill tag_tmp
     units_tmp = tag_tmp(invalid_units);
     // remove dimension descriptors from array4, position and extents
-    for (ndsize_t i = array4.dimensionCount(); i > 0; --i) {
-        array4.deleteDimension(i);
-    }
-    for (ndsize_t i = positions.dimensionCount(); i > 0; --i) {
-        positions.deleteDimension(i);
-    }
-    for (ndsize_t i = extents.dimensionCount(); i > 0; --i) {
-        extents.deleteDimension(i);
-    }
+    array4.deleteDimensions();
+    positions.deleteDimensions();
+    extents.deleteDimensions();
     return;
 }
 
@@ -348,6 +334,7 @@ void TestValidate::test() {
     CPPUNIT_ASSERT_EQUAL(false, myResult.hasErrors());
     
     myResult = file.validate();
+    std::cerr << myResult << std::endl;
     CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(0), myResult.getWarnings().size());
     CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(0), myResult.getErrors().size());
     // entity failure cases---------------------------------------------

--- a/test/TestValidate.cpp
+++ b/test/TestValidate.cpp
@@ -334,7 +334,6 @@ void TestValidate::test() {
     CPPUNIT_ASSERT_EQUAL(false, myResult.hasErrors());
     
     myResult = file.validate();
-    std::cerr << myResult << std::endl;
     CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(0), myResult.getWarnings().size());
     CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(0), myResult.getErrors().size());
     // entity failure cases---------------------------------------------

--- a/test/fs/TestDimensionFS.hpp
+++ b/test/fs/TestDimensionFS.hpp
@@ -35,6 +35,7 @@ class TestDimensionFS : public BaseTestDimension {
     // CPPUNIT_TEST(testRangeDimIndexOf);
     // CPPUNIT_TEST(testRangeDimTickAt);
     // CPPUNIT_TEST(testRangeDimAxis);
+    CPPUNIT_TEST(testAsDimensionMethods);
     CPPUNIT_TEST_SUITE_END ();
 
 public:

--- a/test/hdf5/TestDimensionHDF5.hpp
+++ b/test/hdf5/TestDimensionHDF5.hpp
@@ -35,6 +35,7 @@ class TestDimensionHDF5 : public BaseTestDimension {
     CPPUNIT_TEST(testRangeDimIndexOf);
     CPPUNIT_TEST(testRangeDimTickAt);
     CPPUNIT_TEST(testRangeDimAxis);
+    CPPUNIT_TEST(testAsDimensionMethods);
     CPPUNIT_TEST_SUITE_END ();
 
 public:


### PR DESCRIPTION
handling issue #593:

removing of individual dimensions is no longer possible, respective method is gone. new deleteDimensions() removes all at once. 

public createDimension methods on DataArray are deprecated (documentation) and ignore any passed id argument. 