### PR TITLE
Inverse search of DataArrays, Tags, etc.. from a section

### DIFF
--- a/backend/fs/SectionFS.cpp
+++ b/backend/fs/SectionFS.cpp
@@ -311,6 +311,9 @@ bool SectionFS::deleteProperty(const std::string &name_or_id) {
     return property_dir.removeObjectByNameOrAttribute("entity_id", name_or_id);
 }
 
+std::shared_ptr<base::IFile> SectionFS::parentFile() const {
+    return file();
+}
 
 SectionFS::~SectionFS() {}
 

--- a/backend/fs/SectionFS.hpp
+++ b/backend/fs/SectionFS.hpp
@@ -160,6 +160,9 @@ public:
     // Ohter methods and operators
     //--------------------------------------------------
 
+    std::shared_ptr<base::IFile> parentFile() const;
+
+
     virtual ~SectionFS();
 
 };

--- a/backend/hdf5/SectionHDF5.cpp
+++ b/backend/hdf5/SectionHDF5.cpp
@@ -312,6 +312,10 @@ bool SectionHDF5::deleteProperty(const string &name_or_id) {
 }
 
 
+shared_ptr<IFile> SectionHDF5::parentFile() const {
+    return file();
+}
+
 SectionHDF5::~SectionHDF5() {}
 
 } // ns nix::hdf5

--- a/backend/hdf5/SectionHDF5.hpp
+++ b/backend/hdf5/SectionHDF5.hpp
@@ -158,6 +158,9 @@ public:
     // Ohter methods and operators
     //--------------------------------------------------
 
+    std::shared_ptr<base::IFile> parentFile() const;
+
+
     virtual ~SectionHDF5();
 
 };

--- a/include/nix/Section.hpp
+++ b/include/nix/Section.hpp
@@ -443,30 +443,81 @@ public:
     // Other methods and functions
     //--------------------------------------------------
 
+    /**
+     * @brief Find the DataArrays that refer to this Section in the metadata field.
+     *
+     * @param b The Block in which the search should be performed.
+     * @return Vector of DataArrays.
+     */
     std::vector<nix::DataArray> referringDataArrays(const nix::Block &b) const;
 
-
+    /**
+     * @brief Find the DataArrays that refer to this Section in the metadata field.
+     * Search is performed in the whole file.
+     *
+     * @return Vector of DataArrays.
+     */
     std::vector<nix::DataArray> referringDataArrays() const;
 
 
+    /**
+     * @brief Find the Tags that refer to this Section in the metadata field.
+     * Search is performed in the whole file.
+     *
+     * @return std::vector of Tags.
+     */
     std::vector<nix::Tag> referringTags() const;
 
 
+    /**
+     * @brief Find the Tags that refer to this Section in the metadata field.
+     *
+     * @param b The Block in which the search should be performed.
+     * @return std::vector of Tags.
+     */
     std::vector<nix::Tag> referringTags(const nix::Block &b) const;
 
 
+    /**
+     * @brief Find the DataArrays that refer to this Section in the metadata field.
+     * Search is performed in the whole file.
+     *
+     * @return std::vector of MultiTags.
+     */
     std::vector<nix::MultiTag> referringMultiTags() const;
 
 
+    /**
+     * @brief Find the MultiTags that refer to this Section in the metadata field.
+     *
+     * @param b The Block in which the search should be performed.
+     * @return std::vector of MultiTags.
+     */
     std::vector<nix::MultiTag> referringMultiTags(const nix::Block &b) const;
 
 
+    /**
+     * @brief Find the Sources that refer to this Section in the metadata field.
+     *
+     * @param b The Block in which the search should be performed.
+     * @return std::vector of Sources.
+     */
     std::vector<nix::Source> referringSources() const;
 
 
+    /**
+     * @brief Find the Sources that refer to this Section in the metadata field.
+     * Search is performed in the whole file.
+     *
+     * @return std::vector of Sources.
+     */
     std::vector<nix::Source> referringSources(const nix::Block &b) const;
 
-
+    /**
+     * @brief Find the Blocks that refer to this Section in the metadata field.
+     *
+     * @return std::vector of Blocks.
+     */
     std::vector<nix::Block> referringBlocks() const;
 
     /**

--- a/include/nix/Section.hpp
+++ b/include/nix/Section.hpp
@@ -443,8 +443,9 @@ public:
     // Other methods and functions
     //--------------------------------------------------
 
-    std::vector<nix::DataArray> referringDataArrays() const;
+    std::vector<nix::DataArray> referringDataArrays(const nix::Block &b) const;
 
+    std::vector<nix::DataArray> referringDataArrays() const;
     /**
      * @brief Assignment operator for none.
      */

--- a/include/nix/Section.hpp
+++ b/include/nix/Section.hpp
@@ -443,7 +443,7 @@ public:
     // Other methods and functions
     //--------------------------------------------------
 
-    std::vector<nix::DataArray> referringDataArrays(const nix::Block & block) const;
+    std::vector<nix::DataArray> referringDataArrays() const;
 
     /**
      * @brief Assignment operator for none.

--- a/include/nix/Section.hpp
+++ b/include/nix/Section.hpp
@@ -466,6 +466,9 @@ public:
 
     std::vector<nix::Source> referringSources(const nix::Block &b) const;
 
+
+    std::vector<nix::Block> referringBlocks() const;
+
     /**
      * @brief Assignment operator for none.
      */

--- a/include/nix/Section.hpp
+++ b/include/nix/Section.hpp
@@ -455,6 +455,12 @@ public:
     std::vector<nix::Tag> referringTags(const nix::Block &b) const;
 
 
+    std::vector<nix::MultiTag> referringMultiTags() const;
+
+
+    std::vector<nix::MultiTag> referringMultiTags(const nix::Block &b) const;
+
+
     /**
      * @brief Assignment operator for none.
      */

--- a/include/nix/Section.hpp
+++ b/include/nix/Section.hpp
@@ -445,7 +445,16 @@ public:
 
     std::vector<nix::DataArray> referringDataArrays(const nix::Block &b) const;
 
+
     std::vector<nix::DataArray> referringDataArrays() const;
+
+
+    std::vector<nix::Tag> referringTags() const;
+
+
+    std::vector<nix::Tag> referringTags(const nix::Block &b) const;
+
+
     /**
      * @brief Assignment operator for none.
      */

--- a/include/nix/Section.hpp
+++ b/include/nix/Section.hpp
@@ -15,7 +15,7 @@
 #include <nix/Property.hpp>
 #include <nix/DataType.hpp>
 #include <nix/Platform.hpp>
-
+#include <nix/types.hpp>
 #include <memory>
 #include <functional>
 #include <string>
@@ -23,8 +23,6 @@
 
 namespace nix {
 
-class Block;
-class DataArray;
 
 class NIXAPI Section : public base::NamedEntity<base::ISection> {
 

--- a/include/nix/Section.hpp
+++ b/include/nix/Section.hpp
@@ -23,6 +23,8 @@
 
 namespace nix {
 
+class Block;
+class DataArray;
 
 class NIXAPI Section : public base::NamedEntity<base::ISection> {
 
@@ -442,6 +444,8 @@ public:
     //--------------------------------------------------
     // Other methods and functions
     //--------------------------------------------------
+
+    std::vector<nix::DataArray> referringDataArrays(const nix::Block & block) const;
 
     /**
      * @brief Assignment operator for none.

--- a/include/nix/Section.hpp
+++ b/include/nix/Section.hpp
@@ -461,6 +461,11 @@ public:
     std::vector<nix::MultiTag> referringMultiTags(const nix::Block &b) const;
 
 
+    std::vector<nix::Source> referringSources() const;
+
+
+    std::vector<nix::Source> referringSources(const nix::Block &b) const;
+
     /**
      * @brief Assignment operator for none.
      */

--- a/include/nix/base/ISection.hpp
+++ b/include/nix/base/ISection.hpp
@@ -23,6 +23,7 @@
 namespace nix {
 namespace base {
 
+class NIXAPI IFile;
 /**
  * @brief Interface for implementations of the Section entity.
  *
@@ -115,6 +116,9 @@ public:
 
 
     virtual bool deleteProperty(const std::string &name_or_id) = 0;
+
+
+    virtual std::shared_ptr<IFile> parentFile() const = 0;
 
 
     virtual ~ISection() {}

--- a/include/nix/util/filter.hpp
+++ b/include/nix/util/filter.hpp
@@ -131,7 +131,12 @@ struct MetadataFilter : public Filter<T> {
     {}
 
     virtual bool operator()(const T &e) {
-        return e.metadata().id() == sec_id;
+        if (e.metadata()) {
+            return e.metadata().id() == sec_id;
+        } else {
+            return false;
+        }
+
     }
 };
 

--- a/include/nix/util/filter.hpp
+++ b/include/nix/util/filter.hpp
@@ -121,6 +121,20 @@ struct NameFilter : public Filter<T> {
 
 };
 
+template<typename T>
+struct MetadataFilter : public Filter<T> {
+
+    const std::string sec_id;
+
+    MetadataFilter(const std::string &section_id)
+        : sec_id(section_id)
+    {}
+
+    virtual bool operator()(const T &e) {
+        return e.metadata().id() == sec_id;
+    }
+};
+
 
 } // namespace util
 } // namespace nix

--- a/src/Section.cpp
+++ b/src/Section.cpp
@@ -341,8 +341,17 @@ std::vector<nix::DataArray> Section::referringDataArrays() const {
     std::vector<nix::DataArray> arrays;
     nix::File f = backend()->parentFile();
     for (auto b : f.blocks()) {
-        std::vector<nix::DataArray> temp = b.dataArrays(nix::util::MetadataFilter<nix::DataArray>(id()));
+        std::vector<nix::DataArray> temp = referringDataArrays(b);
         arrays.insert(arrays.end(), temp.begin(), temp.end());
+    }
+    return arrays;
+}
+
+
+std::vector<nix::DataArray> Section::referringDataArrays(const Block &b) const {
+    std::vector<nix::DataArray> arrays;
+    if (b) {
+        arrays = b.dataArrays(nix::util::MetadataFilter<nix::DataArray>(id()));
     }
     return arrays;
 }

--- a/src/Section.cpp
+++ b/src/Section.cpp
@@ -415,3 +415,9 @@ std::vector<nix::Source> Section::referringSources(const Block &b) const {
     }
     return srcs;
 }
+
+
+std::vector<nix::Block> Section::   referringBlocks() const {
+    nix::File f = backend()->parentFile();
+    return f.blocks(nix::util::MetadataFilter<nix::Block>(id()));
+}

--- a/src/Section.cpp
+++ b/src/Section.cpp
@@ -395,3 +395,23 @@ std::vector<nix::MultiTag> Section::referringMultiTags(const Block &b) const {
     }
     return tags;
 }
+
+
+std::vector<nix::Source> Section::referringSources() const {
+    std::vector<nix::Source> srcs;
+    nix::File f = backend()->parentFile();
+    for (auto b : f.blocks()) {
+        std::vector<nix::Source> temp = referringSources(b);
+        srcs.insert(srcs.end(), temp.begin(), temp.end());
+    }
+    return srcs;
+}
+
+
+std::vector<nix::Source> Section::referringSources(const Block &b) const {
+    std::vector<nix::Source> srcs;
+    if (b) {
+        srcs = b.findSources(nix::util::MetadataFilter<nix::Source>(id()));
+    }
+    return srcs;
+}

--- a/src/Section.cpp
+++ b/src/Section.cpp
@@ -375,3 +375,23 @@ std::vector<nix::Tag> Section::referringTags(const Block &b) const {
     }
     return tags;
 }
+
+
+std::vector<nix::MultiTag> Section::referringMultiTags() const {
+    std::vector<nix::MultiTag> tags;
+    nix::File f = backend()->parentFile();
+    for (auto b : f.blocks()) {
+        std::vector<nix::MultiTag> temp = referringMultiTags(b);
+        tags.insert(tags.end(), temp.begin(), temp.end());
+    }
+    return tags;
+}
+
+
+std::vector<nix::MultiTag> Section::referringMultiTags(const Block &b) const {
+    std::vector<nix::MultiTag> tags;
+    if (b) {
+        tags = b.multiTags(nix::util::MetadataFilter<nix::MultiTag>(id()));
+    }
+    return tags;
+}

--- a/src/Section.cpp
+++ b/src/Section.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <iterator>
 #include <nix/Block.hpp>
+#include <nix/File.hpp>
 #include <nix/DataArray.hpp>
 #include <nix/util/util.hpp>
 
@@ -336,10 +337,12 @@ Section Section::getSection(ndsize_t index) const {
 }
 
 
-std::vector<nix::DataArray> Section::referringDataArrays(const nix::Block & block) const {
+std::vector<nix::DataArray> Section::referringDataArrays() const {
     std::vector<nix::DataArray> arrays;
-    if (block) {
-        arrays = block.dataArrays(nix::util::MetadataFilter<nix::DataArray>(id()));
+    nix::File f = backend()->parentFile();
+    for (auto b : f.blocks()) {
+        std::vector<nix::DataArray> temp = b.dataArrays(nix::util::MetadataFilter<nix::DataArray>(id()));
+        arrays.insert(arrays.end(), temp.begin(), temp.end());
     }
     return arrays;
 }

--- a/src/Section.cpp
+++ b/src/Section.cpp
@@ -11,6 +11,8 @@
 #include <list>
 #include <algorithm>
 #include <iterator>
+#include <nix/Block.hpp>
+#include <nix/DataArray.hpp>
 #include <nix/util/util.hpp>
 
 using namespace nix;
@@ -331,4 +333,13 @@ Section Section::getSection(ndsize_t index) const {
         throw OutOfBounds("Section::getSection: index is out of bounds!");
     }
     return backend()->getSection(index);
+}
+
+
+std::vector<nix::DataArray> Section::referringDataArrays(const nix::Block & block) const {
+    std::vector<nix::DataArray> arrays;
+    if (block) {
+        arrays = block.dataArrays(nix::util::MetadataFilter<nix::DataArray>(id()));
+    }
+    return arrays;
 }

--- a/src/Section.cpp
+++ b/src/Section.cpp
@@ -355,3 +355,23 @@ std::vector<nix::DataArray> Section::referringDataArrays(const Block &b) const {
     }
     return arrays;
 }
+
+
+std::vector<nix::Tag> Section::referringTags() const {
+    std::vector<nix::Tag> tags;
+    nix::File f = backend()->parentFile();
+    for (auto b : f.blocks()) {
+        std::vector<nix::Tag> temp = referringTags(b);
+        tags.insert(tags.end(), temp.begin(), temp.end());
+    }
+    return tags;
+}
+
+
+std::vector<nix::Tag> Section::referringTags(const Block &b) const {
+    std::vector<nix::Tag> tags;
+    if (b) {
+        tags = b.tags(nix::util::MetadataFilter<nix::Tag>(id()));
+    }
+    return tags;
+}

--- a/src/Section.cpp
+++ b/src/Section.cpp
@@ -417,7 +417,7 @@ std::vector<nix::Source> Section::referringSources(const Block &b) const {
 }
 
 
-std::vector<nix::Block> Section::   referringBlocks() const {
+std::vector<nix::Block> Section::referringBlocks() const {
     nix::File f = backend()->parentFile();
     return f.blocks(nix::util::MetadataFilter<nix::Block>(id()));
 }

--- a/test/BaseTestSection.cpp
+++ b/test/BaseTestSection.cpp
@@ -358,23 +358,28 @@ void BaseTestSection::testPropertyAccess() {
 void BaseTestSection::testReferringData() {
     nix::Section ref_sec = file.createSection("referrenced", "test");
 
-    nix::Block b;
+    nix::Block b, b2;
     CPPUNIT_ASSERT(ref_sec.referringDataArrays(b).size() == 0);
-    b = file.createBlock("test_block", "test");
-    CPPUNIT_ASSERT(ref_sec.referringDataArrays(b).size() == 0);
+    CPPUNIT_ASSERT(ref_sec.referringDataArrays(b2).size() == 0);
 
+    b = file.createBlock("test_block", "test");
+    b2 = file.createBlock("test_block2", "test");
+    CPPUNIT_ASSERT(ref_sec.referringDataArrays(b).size() == 0);
+    CPPUNIT_ASSERT(ref_sec.referringDataArrays(b2).size() == 0);
 
     for (int i = 0; i < 10; i++) {
         std::string name = "data_array_" + nix::util::numToStr(i);
         nix::DataArray da = b.createDataArray(name, "analog signal", nix::DataType::Double, nix::NDSize({ 20, 20 }));
+        nix::DataArray da2 = b2.createDataArray(name, "analog signal", nix::DataType::Double, nix::NDSize({ 10, 10 }));
         if (i % 2 == 0) {
             da.metadata(ref_sec);
+        } else {
+            da2.metadata(ref_sec);
         }
-
     }
     CPPUNIT_ASSERT(ref_sec.referringDataArrays(b).size() == 5);
-
-
+    CPPUNIT_ASSERT(ref_sec.referringDataArrays(b2).size() == 5);
+    CPPUNIT_ASSERT(ref_sec.referringDataArrays().size() == 10);
 }
 
 

--- a/test/BaseTestSection.cpp
+++ b/test/BaseTestSection.cpp
@@ -383,6 +383,34 @@ void BaseTestSection::testReferringData() {
 }
 
 
+void BaseTestSection::testReferringTags() {
+    nix::Section ref_sec = file.createSection("referrenced", "test");
+
+    nix::Block b, b2;
+    CPPUNIT_ASSERT(ref_sec.referringTags(b).size() == 0);
+    CPPUNIT_ASSERT(ref_sec.referringTags(b2).size() == 0);
+
+    b = file.createBlock("test_block", "test");
+    b2 = file.createBlock("test_block2", "test");
+    CPPUNIT_ASSERT(ref_sec.referringTags(b).size() == 0);
+    CPPUNIT_ASSERT(ref_sec.referringTags(b2).size() == 0);
+
+    for (int i = 0; i < 10; i++) {
+        std::string name = "tag_" + nix::util::numToStr(i);
+        nix::Tag t = b.createTag(name, "some tag", {1.});
+        nix::Tag t2 = b2.createTag(name, "some tag", {1.});
+        if (i % 2 == 0) {
+            t.metadata(ref_sec);
+        } else {
+            t2.metadata(ref_sec);
+        }
+    }
+    CPPUNIT_ASSERT(ref_sec.referringTags(b).size() == 5);
+    CPPUNIT_ASSERT(ref_sec.referringTags(b2).size() == 5);
+    CPPUNIT_ASSERT(ref_sec.referringTags().size() == 10);
+}
+
+
 void BaseTestSection::testOperators() {
     CPPUNIT_ASSERT(section_null == false);
     CPPUNIT_ASSERT(section_null == none);

--- a/test/BaseTestSection.cpp
+++ b/test/BaseTestSection.cpp
@@ -441,6 +441,36 @@ void BaseTestSection::testReferringMultiTags() {
 }
 
 
+void BaseTestSection::testReferringSources() {
+    nix::Section ref_sec = file.createSection("referrenced", "test");
+
+    nix::Block b, b2;
+    CPPUNIT_ASSERT(ref_sec.referringSources(b).size() == 0);
+    CPPUNIT_ASSERT(ref_sec.referringSources(b2).size() == 0);
+
+    b = file.createBlock("test_block", "test");
+    b2 = file.createBlock("test_block2", "test");
+    CPPUNIT_ASSERT(ref_sec.referringSources(b).size() == 0);
+    CPPUNIT_ASSERT(ref_sec.referringSources(b2).size() == 0);
+
+    for (int i = 0; i < 10; i++) {
+        std::string name = "src_" + nix::util::numToStr(i);
+        nix::Source s = b.createSource(name, "some src");
+        nix::Source s2 = b2.createSource(name, "some src");
+        nix::Source s3 = s2.createSource(name + "_child", "child_source");
+        if (i % 2 == 0) {
+            s.metadata(ref_sec);
+        } else {
+            s3.metadata(ref_sec);
+        }
+    }
+    CPPUNIT_ASSERT(ref_sec.referringSources(b).size() == 5);
+    CPPUNIT_ASSERT(ref_sec.referringSources(b2).size() == 5);
+    CPPUNIT_ASSERT(ref_sec.referringSources().size() == 10);
+}
+
+
+
 void BaseTestSection::testOperators() {
     CPPUNIT_ASSERT(section_null == false);
     CPPUNIT_ASSERT(section_null == none);

--- a/test/BaseTestSection.cpp
+++ b/test/BaseTestSection.cpp
@@ -355,6 +355,29 @@ void BaseTestSection::testPropertyAccess() {
 }
 
 
+void BaseTestSection::testReferringData() {
+    nix::Section ref_sec = file.createSection("referrenced", "test");
+
+    nix::Block b;
+    CPPUNIT_ASSERT(ref_sec.referringDataArrays(b).size() == 0);
+    b = file.createBlock("test_block", "test");
+    CPPUNIT_ASSERT(ref_sec.referringDataArrays(b).size() == 0);
+
+
+    for (int i = 0; i < 10; i++) {
+        std::string name = "data_array_" + nix::util::numToStr(i);
+        nix::DataArray da = b.createDataArray(name, "analog signal", nix::DataType::Double, nix::NDSize({ 20, 20 }));
+        if (i % 2 == 0) {
+            da.metadata(ref_sec);
+        }
+
+    }
+    CPPUNIT_ASSERT(ref_sec.referringDataArrays(b).size() == 5);
+
+
+}
+
+
 void BaseTestSection::testOperators() {
     CPPUNIT_ASSERT(section_null == false);
     CPPUNIT_ASSERT(section_null == none);

--- a/test/BaseTestSection.cpp
+++ b/test/BaseTestSection.cpp
@@ -411,6 +411,36 @@ void BaseTestSection::testReferringTags() {
 }
 
 
+void BaseTestSection::testReferringMultiTags() {
+    nix::Section ref_sec = file.createSection("referrenced", "test");
+
+    nix::Block b, b2;
+    CPPUNIT_ASSERT(ref_sec.referringMultiTags(b).size() == 0);
+    CPPUNIT_ASSERT(ref_sec.referringMultiTags(b2).size() == 0);
+
+    b = file.createBlock("test_block", "test");
+    b2 = file.createBlock("test_block2", "test");
+    CPPUNIT_ASSERT(ref_sec.referringMultiTags(b).size() == 0);
+    CPPUNIT_ASSERT(ref_sec.referringMultiTags(b2).size() == 0);
+    DataArray positions = b.createDataArray("positions", "positions", nix::DataType::Double, nix::NDSize({ 20, 1 }));
+    DataArray positions2 = b2.createDataArray("positions", "positions", nix::DataType::Double, nix::NDSize({ 20, 1 }));
+
+    for (int i = 0; i < 10; i++) {
+        std::string name = "tag_" + nix::util::numToStr(i);
+        nix::MultiTag t = b.createMultiTag(name, "some tag", positions);
+        nix::MultiTag t2 = b2.createMultiTag(name, "some tag", positions2);
+        if (i % 2 == 0) {
+            t.metadata(ref_sec);
+        } else {
+            t2.metadata(ref_sec);
+        }
+    }
+    CPPUNIT_ASSERT(ref_sec.referringMultiTags(b).size() == 5);
+    CPPUNIT_ASSERT(ref_sec.referringMultiTags(b2).size() == 5);
+    CPPUNIT_ASSERT(ref_sec.referringMultiTags().size() == 10);
+}
+
+
 void BaseTestSection::testOperators() {
     CPPUNIT_ASSERT(section_null == false);
     CPPUNIT_ASSERT(section_null == none);

--- a/test/BaseTestSection.cpp
+++ b/test/BaseTestSection.cpp
@@ -470,6 +470,19 @@ void BaseTestSection::testReferringSources() {
 }
 
 
+void BaseTestSection::testReferringBlocks() {
+    nix::Section ref_sec = file.createSection("referrenced", "test");
+    for (int i = 0; i < 10; i++) {
+        std::string name = "block_" + nix::util::numToStr(i);
+        nix::Block b = file.createBlock(name, "some blck");
+        nix::Block b2 = file.createBlock(name + "_scnd", "test");
+        if (i % 2 == 0) {
+            b.metadata(ref_sec);
+        }
+    }
+    CPPUNIT_ASSERT(ref_sec.referringBlocks().size() == 5);
+}
+
 
 void BaseTestSection::testOperators() {
     CPPUNIT_ASSERT(section_null == false);

--- a/test/BaseTestSection.hpp
+++ b/test/BaseTestSection.hpp
@@ -40,7 +40,7 @@ public:
     void testReferringTags();
     void testReferringMultiTags();
     void testReferringSources();
-    //void testReferringBlocks();
+    void testReferringBlocks();
 
     void testOperators();
     void testUpdatedAt();

--- a/test/BaseTestSection.hpp
+++ b/test/BaseTestSection.hpp
@@ -37,6 +37,7 @@ public:
     void testFindRelated();
     void testPropertyAccess();
     void testReferringData();
+    void testReferringTags();
 
     void testOperators();
     void testUpdatedAt();

--- a/test/BaseTestSection.hpp
+++ b/test/BaseTestSection.hpp
@@ -39,7 +39,7 @@ public:
     void testReferringData();
     void testReferringTags();
     void testReferringMultiTags();
-    //void testReferringSources();
+    void testReferringSources();
     //void testReferringBlocks();
 
     void testOperators();

--- a/test/BaseTestSection.hpp
+++ b/test/BaseTestSection.hpp
@@ -36,6 +36,7 @@ public:
     void testFindSection();
     void testFindRelated();
     void testPropertyAccess();
+    void testReferringData();
 
     void testOperators();
     void testUpdatedAt();

--- a/test/BaseTestSection.hpp
+++ b/test/BaseTestSection.hpp
@@ -38,6 +38,9 @@ public:
     void testPropertyAccess();
     void testReferringData();
     void testReferringTags();
+    void testReferringMultiTags();
+    //void testReferringSources();
+    //void testReferringBlocks();
 
     void testOperators();
     void testUpdatedAt();

--- a/test/fs/TestSectionFS.hpp
+++ b/test/fs/TestSectionFS.hpp
@@ -33,6 +33,7 @@ class TestSectionFS : public BaseTestSection {
     CPPUNIT_TEST(testReferringTags);
     CPPUNIT_TEST(testReferringMultiTags);
     CPPUNIT_TEST(testReferringSources);
+    CPPUNIT_TEST(testReferringBlocks);
 
     CPPUNIT_TEST(testOperators);
     CPPUNIT_TEST(testUpdatedAt);

--- a/test/fs/TestSectionFS.hpp
+++ b/test/fs/TestSectionFS.hpp
@@ -29,6 +29,7 @@ class TestSectionFS : public BaseTestSection {
     CPPUNIT_TEST(testFindSection);
     CPPUNIT_TEST(testFindRelated);
     CPPUNIT_TEST(testPropertyAccess);
+    CPPUNIT_TEST(testReferringData);
 
     CPPUNIT_TEST(testOperators);
     CPPUNIT_TEST(testUpdatedAt);

--- a/test/fs/TestSectionFS.hpp
+++ b/test/fs/TestSectionFS.hpp
@@ -31,6 +31,7 @@ class TestSectionFS : public BaseTestSection {
     CPPUNIT_TEST(testPropertyAccess);
     CPPUNIT_TEST(testReferringData);
     CPPUNIT_TEST(testReferringTags);
+    CPPUNIT_TEST(testReferringMultiTags);
 
     CPPUNIT_TEST(testOperators);
     CPPUNIT_TEST(testUpdatedAt);

--- a/test/fs/TestSectionFS.hpp
+++ b/test/fs/TestSectionFS.hpp
@@ -32,6 +32,7 @@ class TestSectionFS : public BaseTestSection {
     CPPUNIT_TEST(testReferringData);
     CPPUNIT_TEST(testReferringTags);
     CPPUNIT_TEST(testReferringMultiTags);
+    CPPUNIT_TEST(testReferringSources);
 
     CPPUNIT_TEST(testOperators);
     CPPUNIT_TEST(testUpdatedAt);

--- a/test/fs/TestSectionFS.hpp
+++ b/test/fs/TestSectionFS.hpp
@@ -30,6 +30,7 @@ class TestSectionFS : public BaseTestSection {
     CPPUNIT_TEST(testFindRelated);
     CPPUNIT_TEST(testPropertyAccess);
     CPPUNIT_TEST(testReferringData);
+    CPPUNIT_TEST(testReferringTags);
 
     CPPUNIT_TEST(testOperators);
     CPPUNIT_TEST(testUpdatedAt);

--- a/test/hdf5/TestSectionHDF5.hpp
+++ b/test/hdf5/TestSectionHDF5.hpp
@@ -29,6 +29,7 @@ class TestSectionHDF5 : public BaseTestSection {
     CPPUNIT_TEST(testFindSection);
     CPPUNIT_TEST(testFindRelated);
     CPPUNIT_TEST(testPropertyAccess);
+    CPPUNIT_TEST(testReferringData);
 
     CPPUNIT_TEST(testOperators);
     CPPUNIT_TEST(testUpdatedAt);

--- a/test/hdf5/TestSectionHDF5.hpp
+++ b/test/hdf5/TestSectionHDF5.hpp
@@ -31,6 +31,7 @@ class TestSectionHDF5 : public BaseTestSection {
     CPPUNIT_TEST(testPropertyAccess);
     CPPUNIT_TEST(testReferringData);
     CPPUNIT_TEST(testReferringTags);
+    CPPUNIT_TEST(testReferringMultiTags);
 
     CPPUNIT_TEST(testOperators);
     CPPUNIT_TEST(testUpdatedAt);

--- a/test/hdf5/TestSectionHDF5.hpp
+++ b/test/hdf5/TestSectionHDF5.hpp
@@ -33,6 +33,7 @@ class TestSectionHDF5 : public BaseTestSection {
     CPPUNIT_TEST(testReferringTags);
     CPPUNIT_TEST(testReferringMultiTags);
     CPPUNIT_TEST(testReferringSources);
+    CPPUNIT_TEST(testReferringBlocks);
 
     CPPUNIT_TEST(testOperators);
     CPPUNIT_TEST(testUpdatedAt);

--- a/test/hdf5/TestSectionHDF5.hpp
+++ b/test/hdf5/TestSectionHDF5.hpp
@@ -32,6 +32,7 @@ class TestSectionHDF5 : public BaseTestSection {
     CPPUNIT_TEST(testReferringData);
     CPPUNIT_TEST(testReferringTags);
     CPPUNIT_TEST(testReferringMultiTags);
+    CPPUNIT_TEST(testReferringSources);
 
     CPPUNIT_TEST(testOperators);
     CPPUNIT_TEST(testUpdatedAt);

--- a/test/hdf5/TestSectionHDF5.hpp
+++ b/test/hdf5/TestSectionHDF5.hpp
@@ -30,6 +30,7 @@ class TestSectionHDF5 : public BaseTestSection {
     CPPUNIT_TEST(testFindRelated);
     CPPUNIT_TEST(testPropertyAccess);
     CPPUNIT_TEST(testReferringData);
+    CPPUNIT_TEST(testReferringTags);
 
     CPPUNIT_TEST(testOperators);
     CPPUNIT_TEST(testUpdatedAt);


### PR DESCRIPTION
This pr introduces the long missing convenience methods for inverse search from Sections to referring entities(issue #551). Unfortunately, it is not possible to implement the functionality using templates due to circular includes. 

This relates to issue #560.