### PR TITLE
Simplify search for referring entities from Source ...

### DIFF
--- a/backend/fs/BlockFS.cpp
+++ b/backend/fs/BlockFS.cpp
@@ -66,7 +66,7 @@ std::shared_ptr<base::ISource> BlockFS::getSource(const std::string &name_or_id)
     std::shared_ptr<base::ISource> source;
     boost::optional<bfs::path> path = source_dir.findByNameOrAttribute("entity_id", name_or_id);
     if (path) {
-        return std::make_shared<SourceFS>(file(), path->string());
+        return std::make_shared<SourceFS>(file(), block(), path->string());
     }
     return source;
 }
@@ -82,7 +82,7 @@ std::shared_ptr<base::ISource> BlockFS::getSource(ndsize_t index) const {
         throw OutOfBounds("Trying to access block.source with invalid index.", index);
     }
     bfs::path p = source_dir.sub_dir_by_index(index);
-    return std::make_shared<SourceFS>(file(), p.string());
+    return std::make_shared<SourceFS>(file(), block(), p.string());
 }
 
 
@@ -94,7 +94,7 @@ std::shared_ptr<base::ISource> BlockFS::createSource(const std::string &name, co
         throw DuplicateName("createSource");
     }
     std::string id = util::createId();
-    return std::make_shared<SourceFS>(file(), source_dir.location(), id, type, name);
+    return std::make_shared<SourceFS>(file(), block(), source_dir.location(), id, type, name);
 }
 
 

--- a/backend/fs/EntityWithSourcesFS.cpp
+++ b/backend/fs/EntityWithSourcesFS.cpp
@@ -60,7 +60,7 @@ std::shared_ptr<base::ISource> EntityWithSourcesFS::getSource(const std::string 
     std::shared_ptr<base::ISource> source;
     boost::optional<bfs::path> path = sources_dir.findByNameOrAttribute("name", name_or_id);
     if (path) {
-        return std::make_shared<SourceFS>(file(), path->string());
+        return std::make_shared<SourceFS>(file(), entity_block, path->string());
 
     }
     return source;
@@ -70,7 +70,7 @@ std::shared_ptr<base::ISource> EntityWithSourcesFS::getSource(const size_t index
     std::shared_ptr<base::ISource> source;
     bfs::path p = sources_dir.sub_dir_by_index(index);
     if (!p.empty()) {
-        return std::make_shared<SourceFS>(file(), p.string());
+        return std::make_shared<SourceFS>(file(), entity_block, p.string());
 
     }
     return source;

--- a/backend/fs/SourceFS.cpp
+++ b/backend/fs/SourceFS.cpp
@@ -15,23 +15,23 @@ namespace nix {
 namespace file {
 
 
-SourceFS::SourceFS(const std::shared_ptr<base::IFile> &file, const std::string &loc)
-    : EntityWithMetadataFS(file, loc)
+SourceFS::SourceFS(const std::shared_ptr<base::IFile> &file, const std::shared_ptr<base::IBlock> &block, const std::string &loc)
+    : EntityWithMetadataFS(file, loc), parent_block(block)
 {
     createSubFolders(file);
 }
 
 
-SourceFS::SourceFS(const std::shared_ptr<base::IFile> &file, const std::string &loc, const std::string &id,
-                   const std::string &type, const std::string &name)
-    : SourceFS(file, loc, id, type, name, util::getTime())
+SourceFS::SourceFS(const std::shared_ptr<base::IFile> &file, const std::shared_ptr<base::IBlock> &block,
+                   const std::string &loc, const std::string &id, const std::string &type, const std::string &name)
+    : SourceFS(file, block, loc, id, type, name, util::getTime())
 {
 }
 
 
-SourceFS::SourceFS(const std::shared_ptr<base::IFile> &file, const std::string &loc, const std::string &id,
-                   const std::string &type, const std::string &name, time_t time)
-    : EntityWithMetadataFS(file, loc, id, type, name, time)
+SourceFS::SourceFS(const std::shared_ptr<base::IFile> &file, const std::shared_ptr<base::IBlock> &block,
+                   const std::string &loc, const std::string &id, const std::string &type, const std::string &name, time_t time)
+    : EntityWithMetadataFS(file, loc, id, type, name, time), parent_block(block)
 {
     createSubFolders(file);
 }
@@ -51,7 +51,7 @@ std::shared_ptr<base::ISource> SourceFS::getSource(const std::string &name_or_id
     std::shared_ptr<SourceFS> source;
     boost::optional<bfs::path> p = sources_dir.findByNameOrAttribute("entity_id", name_or_id);
     if (p) {
-        source = std::make_shared<SourceFS>(file(), p->string());
+        source = std::make_shared<SourceFS>(file(), parentBlock(), p->string());
     }
 
     return source;
@@ -63,7 +63,7 @@ std::shared_ptr<base::ISource> SourceFS::getSource(ndsize_t index) const {
         throw OutOfBounds("Trying to access source.source with invalid index.", index);
     }
     bfs::path p = sources_dir.sub_dir_by_index(index);
-    return std::make_shared<SourceFS>(file(), p.string());
+    return std::make_shared<SourceFS>(file(), parentBlock(), p.string());
 }
 
 
@@ -80,7 +80,7 @@ std::shared_ptr<base::ISource> SourceFS::createSource(const std::string &name, c
         throw DuplicateName("createSource");
     }
     std::string id = util::createId();
-    return std::make_shared<SourceFS>(file(), sources_dir.location(), id, type, name);
+    return std::make_shared<SourceFS>(file(), parentBlock(), sources_dir.location(), id, type, name);
 }
 
 
@@ -91,6 +91,11 @@ bool SourceFS::deleteSource(const std::string &name_or_id) {
 
 std::shared_ptr<base::IFile> SourceFS::parentFile() const {
     return file();
+}
+
+
+std::shared_ptr<base::IBlock> SourceFS::parentBlock() const {
+    return parent_block;
 }
 
 

--- a/backend/fs/SourceFS.hpp
+++ b/backend/fs/SourceFS.hpp
@@ -25,7 +25,7 @@ class SourceFS : virtual public base::ISource, public EntityWithMetadataFS  {
 
 private:
     Directory sources_dir;
-
+    std::shared_ptr<base::IBlock> parent_block;
     void createSubFolders(const std::shared_ptr<base::IFile> &file);
 
 public:
@@ -33,19 +33,19 @@ public:
     /**
      * Standard constructor for existing Source
      */
-    SourceFS(const std::shared_ptr<base::IFile> &file, const std::string &loc);
+    SourceFS(const std::shared_ptr<base::IFile> &file, const std::shared_ptr<base::IBlock> &block, const std::string &loc);
 
     /**
      * Default constructor.
      */
-    SourceFS(const std::shared_ptr<base::IFile> &file, const std::string &loc, const std::string &id, const std::string &type,
-               const std::string &name);
+    SourceFS(const std::shared_ptr<base::IFile> &file, const std::shared_ptr<base::IBlock> &block, const std::string &loc,
+             const std::string &id, const std::string &type, const std::string &name);
 
     /**
      * Default constructor that preserves the creation time.
      */
-    SourceFS(const std::shared_ptr<base::IFile> &file, const std::string &loc, const std::string &id, const std::string &type,
-               const std::string &name, time_t time);
+    SourceFS(const std::shared_ptr<base::IFile> &file, const std::shared_ptr<base::IBlock> &block, const std::string &loc,
+             const std::string &id, const std::string &type, const std::string &name, time_t time);
 
     //--------------------------------------------------
     // Methods concerning child sources
@@ -76,6 +76,7 @@ public:
     std::shared_ptr<base::IFile> parentFile() const;
 
 
+    std::shared_ptr<base::IBlock> parentBlock() const;
     virtual ~SourceFS();
 };
 

--- a/backend/hdf5/BlockHDF5.cpp
+++ b/backend/hdf5/BlockHDF5.cpp
@@ -66,7 +66,7 @@ shared_ptr<ISource> BlockHDF5::getSource(const string &name_or_id) const {
     if (g) {
         boost::optional<H5Group> group = g->findGroupByNameOrAttribute("entity_id", name_or_id);
         if (group)
-            source = make_shared<SourceHDF5>(file(), *group);
+            source = make_shared<SourceHDF5>(file(), block(), *group);
     }
 
     return source;
@@ -91,7 +91,7 @@ shared_ptr<ISource> BlockHDF5::createSource(const string &name, const string &ty
     boost::optional<H5Group> g = source_group(true);
 
     H5Group group = g->openGroup(name, true);
-    return make_shared<SourceHDF5>(file(), group, id, type, name);
+    return make_shared<SourceHDF5>(file(), block(), group, id, type, name);
 }
 
 

--- a/backend/hdf5/EntityWithSourcesHDF5.cpp
+++ b/backend/hdf5/EntityWithSourcesHDF5.cpp
@@ -71,7 +71,7 @@ std::shared_ptr<ISource> EntityWithSourcesHDF5::getSource(const std::string &nam
 
     if (g && hasSource(id)) {
         H5Group group = g->openGroup(id);
-        source = std::make_shared<SourceHDF5>(file(), group);
+        source = std::make_shared<SourceHDF5>(file(), entity_block, group);
     }
 
     return source;

--- a/backend/hdf5/SourceHDF5.cpp
+++ b/backend/hdf5/SourceHDF5.cpp
@@ -105,6 +105,10 @@ shared_ptr<IFile> SourceHDF5::parentFile() const {
 }
 
 
+std::shared_ptr<base::IBlock> SourceHDF5::parentBlock() const {
+    return entity_block;
+}
+
 SourceHDF5::~SourceHDF5() {}
 
 } // ns nix::hdf5

--- a/backend/hdf5/SourceHDF5.cpp
+++ b/backend/hdf5/SourceHDF5.cpp
@@ -17,21 +17,21 @@ namespace nix {
 namespace hdf5 {
 
 
-SourceHDF5::SourceHDF5(const std::shared_ptr<IFile> &file, const H5Group &group)
-    : EntityWithMetadataHDF5(file, group)
+SourceHDF5::SourceHDF5(const std::shared_ptr<IFile> &file,  const std::shared_ptr<IBlock> &block, const H5Group &group)
+    : EntityWithMetadataHDF5(file, group), entity_block(block)
 {
     source_group = this->group().openOptGroup("sources");
 }
     
     
-SourceHDF5::SourceHDF5(const shared_ptr<IFile> &file, const H5Group &group, const std::string &id, const string &type, const string &name)
-    : SourceHDF5(file, group, id, type, name, util::getTime())
+SourceHDF5::SourceHDF5(const shared_ptr<IFile> &file,  const std::shared_ptr<IBlock> &block, const H5Group &group, const std::string &id, const string &type, const string &name)
+    : SourceHDF5(file, block, group, id, type, name, util::getTime())
 {
 }
 
 
-SourceHDF5::SourceHDF5(const shared_ptr<IFile> &file, const H5Group &group, const std::string &id, const string &type, const string &name, time_t time)
-    : EntityWithMetadataHDF5(file, group, id, type, name, time)
+SourceHDF5::SourceHDF5(const shared_ptr<IFile> &file,  const std::shared_ptr<IBlock> &block, const H5Group &group, const std::string &id, const string &type, const string &name, time_t time)
+    : EntityWithMetadataHDF5(file, group, id, type, name, time), entity_block(block)
 {
     source_group = this->group().openOptGroup("sources");
 }
@@ -49,7 +49,7 @@ shared_ptr<ISource> SourceHDF5::getSource(const string &name_or_id) const {
     if (g) {
         boost::optional<H5Group> group = g->findGroupByNameOrAttribute("entity_id", name_or_id);
         if (group)
-            source = make_shared<SourceHDF5>(file(), *group);
+            source = make_shared<SourceHDF5>(file(), parentBlock(), *group);
     }
 
     return source;
@@ -74,7 +74,7 @@ shared_ptr<ISource> SourceHDF5::createSource(const string &name, const string &t
     boost::optional<H5Group> g = source_group(true);
 
     H5Group group = g->openGroup(name, true);
-    return make_shared<SourceHDF5>(file(), group, id, type, name);
+    return make_shared<SourceHDF5>(file(), parentBlock(), group, id, type, name);
 }
 
 

--- a/backend/hdf5/SourceHDF5.hpp
+++ b/backend/hdf5/SourceHDF5.hpp
@@ -27,6 +27,7 @@ class SourceHDF5 : virtual public base::ISource, public EntityWithMetadataHDF5  
 private:
 
     optGroup source_group;
+    std::shared_ptr<base::IBlock> entity_block;
 
 public:
 
@@ -34,19 +35,19 @@ public:
     /**
      * Standard constructor for existing Source
      */
-    SourceHDF5(const std::shared_ptr<base::IFile> &file, const H5Group &group);
+    SourceHDF5(const std::shared_ptr<base::IFile> &file, const std::shared_ptr<base::IBlock> &block, const H5Group &group);
 
     /**
      * Default constructor.
      */
-    SourceHDF5(const std::shared_ptr<base::IFile> &file, const H5Group &group, const std::string &id, const std::string &type,
-               const std::string &name);
+    SourceHDF5(const std::shared_ptr<base::IFile> &file,  const std::shared_ptr<base::IBlock> &block,
+               const H5Group &group, const std::string &id, const std::string &type, const std::string &name);
 
     /**
      * Default constructor that preserves the creation time.
      */
-    SourceHDF5(const std::shared_ptr<base::IFile> &file, const H5Group &group, const std::string &id, const std::string &type,
-               const std::string &name, time_t time);
+    SourceHDF5(const std::shared_ptr<base::IFile> &file,  const std::shared_ptr<base::IBlock> &block,
+               const H5Group &group, const std::string &id, const std::string &type, const std::string &name, time_t time);
 
     //--------------------------------------------------
     // Methods concerning child sources

--- a/backend/hdf5/SourceHDF5.hpp
+++ b/backend/hdf5/SourceHDF5.hpp
@@ -78,6 +78,8 @@ public:
     std::shared_ptr<base::IFile> parentFile() const;
 
 
+    std::shared_ptr<base::IBlock> parentBlock() const;
+
     virtual ~SourceHDF5();
 };
 

--- a/include/nix/Source.hpp
+++ b/include/nix/Source.hpp
@@ -202,6 +202,14 @@ public:
     //--------------------------------------------------
 
     /**
+     * @brief Returns the parent Source of this Source. Method performs a search,
+     * may thus not be the most efficient way.
+     *
+     * @return The parent Source if there is any, an empty Source otherwise.
+     */
+    nix::Source parentSource() const;
+
+    /**
      * Returns all DataArrays that refer to this Source.
      *
      * @return std::vector of DataArrays.

--- a/include/nix/base/ISource.hpp
+++ b/include/nix/base/ISource.hpp
@@ -11,13 +11,13 @@
 
 
 #include <nix/base/IEntityWithMetadata.hpp>
-
 #include <string>
 #include <memory>
 
 namespace nix {
 namespace base {
 
+class IBlock;
 
 /**
  * @brief Interface for implementations of the Source entity.
@@ -47,6 +47,9 @@ public:
 
 
     virtual std::shared_ptr<IFile> parentFile() const = 0;
+
+
+    virtual std::shared_ptr<IBlock> parentBlock() const = 0;
 
 
     virtual ~ISource() {}

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -114,6 +114,13 @@ std::vector<Source> Source::findSources(const util::Filter<Source>::type &filter
 // Operators and other functions
 //------------------------------------------------------
 
+nix::Source Source::parentSource() const {
+    nix::Source s;
+    nix::Block b = backend()->parentBlock();
+    std::vector<nix::Source> srcs = b.sources(nix::util::SourceFilter<nix::Source>(id()));
+    return (srcs.size() > 0) ? srcs[0] : s;
+}
+
 
 std::vector<nix::DataArray> Source::referringDataArrays() const {
     nix::File f = backend()->parentFile();

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -123,21 +123,18 @@ nix::Source Source::parentSource() const {
 
 
 std::vector<nix::DataArray> Source::referringDataArrays() const {
-    nix::File f = backend()->parentFile();
     nix::Block b = backend()->parentBlock();
     return b.dataArrays(nix::util::SourceFilter<nix::DataArray>(id()));
 }
 
 
 std::vector<nix::Tag> Source::referringTags() const {
-    nix::File f = backend()->parentFile();
     nix::Block b = backend()->parentBlock();
     return b.tags(nix::util::SourceFilter<nix::Tag>(id()));
 }
 
 
 std::vector<nix::MultiTag> Source::referringMultiTags() const {
-    nix::File f = backend()->parentFile();
     nix::Block b = backend()->parentBlock();
     return b.multiTags(nix::util::SourceFilter<nix::MultiTag>(id()));
 }

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -116,35 +116,23 @@ std::vector<Source> Source::findSources(const util::Filter<Source>::type &filter
 
 
 std::vector<nix::DataArray> Source::referringDataArrays() const {
-    std::vector<nix::DataArray> arrays;
     nix::File f = backend()->parentFile();
-    for (auto b : f.blocks()) {
-        std::vector<nix::DataArray> temp = b.dataArrays(nix::util::SourceFilter<nix::DataArray>(id()));
-        arrays.insert(arrays.end(), temp.begin(), temp.end());
-    }
-    return arrays;
+    nix::Block b = backend()->parentBlock();
+    return b.dataArrays(nix::util::SourceFilter<nix::DataArray>(id()));
 }
 
 
 std::vector<nix::Tag> Source::referringTags() const {
-    std::vector<nix::Tag> tags;
     nix::File f = backend()->parentFile();
-    for (auto b : f.blocks()) {
-        std::vector<nix::Tag> temp = b.tags(nix::util::SourceFilter<nix::Tag>(id()));
-        tags.insert(tags.end(), temp.begin(), temp.end());
-    }
-    return tags;
+    nix::Block b = backend()->parentBlock();
+    return b.tags(nix::util::SourceFilter<nix::Tag>(id()));
 }
 
 
 std::vector<nix::MultiTag> Source::referringMultiTags() const {
-    std::vector<nix::MultiTag> tags;
     nix::File f = backend()->parentFile();
-    for (auto b : f.blocks()) {
-        std::vector<nix::MultiTag> temp =  b.multiTags(nix::util::SourceFilter<nix::MultiTag>(id()));
-        tags.insert(tags.end(), temp.begin(), temp.end());
-    }
-    return tags;
+    nix::Block b = backend()->parentBlock();
+    return b.multiTags(nix::util::SourceFilter<nix::MultiTag>(id()));
 }
 
 

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -117,7 +117,7 @@ std::vector<Source> Source::findSources(const util::Filter<Source>::type &filter
 nix::Source Source::parentSource() const {
     nix::Source s;
     nix::Block b = backend()->parentBlock();
-    std::vector<nix::Source> srcs = b.sources(nix::util::SourceFilter<nix::Source>(id()));
+    std::vector<nix::Source> srcs = b.findSources(nix::util::SourceFilter<nix::Source>(id()));
     return (srcs.size() > 0) ? srcs[0] : s;
 }
 

--- a/test/BaseTestSource.cpp
+++ b/test/BaseTestSource.cpp
@@ -274,6 +274,15 @@ void BaseTestSource::testReferringTags() {
 }
 
 
+void BaseTestSource::testParentSource() {
+    nix::Source child_source  = source.createSource("child", "test");
+    nix::Source grandchild_source = child_source.createSource("grand_child", "test");
+    CPPUNIT_ASSERT(child_source.parentSource().id() == source.id());
+    CPPUNIT_ASSERT(grandchild_source.parentSource().id() == child_source.id());
+    CPPUNIT_ASSERT(!source.parentSource());
+}
+
+
 void BaseTestSource::testOperators() {
     CPPUNIT_ASSERT(source_null == false);
     CPPUNIT_ASSERT(source_null == none);

--- a/test/BaseTestSource.hpp
+++ b/test/BaseTestSource.hpp
@@ -38,6 +38,7 @@ public:
     void testReferringDataArrays();
     void testReferringMultiTags();
     void testReferringTags();
+    void testParentSource();
 
     void testOperators();
     void testUpdatedAt();

--- a/test/fs/TestSourceFS.hpp
+++ b/test/fs/TestSourceFS.hpp
@@ -27,6 +27,7 @@ class TestSourceFS : public BaseTestSource {
     CPPUNIT_TEST(testReferringDataArrays);
     CPPUNIT_TEST(testReferringMultiTags);
     CPPUNIT_TEST(testReferringTags);
+    CPPUNIT_TEST(testParentSource);
 
     CPPUNIT_TEST(testOperators);
     CPPUNIT_TEST(testUpdatedAt);

--- a/test/hdf5/TestSourceHDF5.hpp
+++ b/test/hdf5/TestSourceHDF5.hpp
@@ -28,6 +28,7 @@ class TestSourceHDF5 : public BaseTestSource {
     CPPUNIT_TEST(testReferringDataArrays);
     CPPUNIT_TEST(testReferringMultiTags);
     CPPUNIT_TEST(testReferringTags);
+    CPPUNIT_TEST(testParentSource);
 
     CPPUNIT_TEST(testOperators);
     CPPUNIT_TEST(testUpdatedAt);


### PR DESCRIPTION

- added a shared ptr of the parent Block to the Source entities
- add respective backend methods to get it
- use the parent block to restrict search of  referring entities to the given Block
- add convenience method to get the parent source of a given source (issue #259).
