### PR TITLE
[Version] move nixversion include inside guards

### DIFF
--- a/include/nix/Version.hpp
+++ b/include/nix/Version.hpp
@@ -2,12 +2,16 @@
 #include <vector>
 #include <stdexcept>
 #include <initializer_list>
-#include <nix/nixversion.hpp>
 
 #include <nix/Platform.hpp>
 
 #ifndef NIX_VERSION_HPP
 #define NIX_VERSION_HPP
+
+/* include this from within the include guards because
+ * it is a private include and does itself not have guards  */
+#include <nix/nixversion.hpp>
+
 
 namespace nix {
 /**


### PR DESCRIPTION
Currently `nixversion.hpp` is included from `Version.hpp` outside the include guards and therefore the version numbers might get unnecessarily redefined. Fix this by moving it inside `Version.hpp`'s guards.