### PR TITLE
Prefix PACKED macro to avoid clash with openmpi's PACKED type

### DIFF
--- a/backend/hdf5/PropertyHDF5.cpp
+++ b/backend/hdf5/PropertyHDF5.cpp
@@ -227,7 +227,7 @@ PropertyHDF5::~PropertyHDF5() {}
 #pragma pack(push,1)
 #endif
 template<typename T>
-struct PACKED FileValue  {
+struct NIX_PACKED FileValue  {
 
     T       value;
 

--- a/include/nix/Platform.hpp
+++ b/include/nix/Platform.hpp
@@ -32,10 +32,10 @@
 
 #ifdef _MSC_VER
 #define NOEXCEPT
-#define PACKED
+#define NIX_PACKED
 #else
 #define NOEXCEPT noexcept
-#define PACKED __attribute__((packed))
+#define NIX_PACKED __attribute__((packed))
 #endif
 
 #define NIX_SRC_FILE __FILE__


### PR DESCRIPTION
When building `nix` using `gcc@4.9.2` and `openmpi@2.0.1`, we get:
```
                 from /path_to/nix-1.3.2/src/DataArray.cpp:12:
/path_to/nix-1.3.2/include/nix/Platform.hpp:38:38: error: declaration does not declare anything [-fpermissive]
```
We tracked back and found a type `PACKED` in https://github.com/open-mpi/ompi/blob/master/ompi/mpi/cxx/constants.h#L128
```
OMPI_DECLSPEC extern const Datatype PACKED;
```
which gets replaced by the preprocessor:
```
OMPI_DECLSPEC extern const Datatype __attribute__((packed));
```

We did a short test using build llvm/clang 3.9.0 but could not reproduce this problem; it could be a compiler version-specific issue.