### PR TITLE
Adding GSoC contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,12 @@ would stick to the following development workflow:
    Merge conflicts or errors reported by travis should be resolved by the original author before the request is merged.
 
 
+Google Summer of Code contributors
+----------------------------------
+
+Please see the corresponding [Google Summer of Code](GSoC.md) file if you are interested in contributing as part of the GSoC programme.
+
+
 The issue tracker
 -----------------
 

--- a/GSoC.md
+++ b/GSoC.md
@@ -1,0 +1,31 @@
+Google Summer of Code contributions
+===================================
+
+
+General guidelines
+------------------
+
+Google Summer of Code candidates should follow the [general contribution guidelines](CONTRIBUTING.md) before beginning work on an issue and submitting pull requests.
+Students interested in working on NIX as part of GSoC 2017 should read the guidelines described in the [GSoC student guide](http://write.flossmanuals.net/gsocstudentguide/making-first-contact/) regarding making first contact.
+They're quite useful for general open source contributions as well.
+
+
+Open communication
+------------------
+
+The GSoC programme encourages open communication and so do we.
+While directly contacting the mentors may get a response, please refrain from doing so unless discussing personal matters.
+For all topics regarding the project, issues, patches, preparing proposals, please use the discussion threads on Trellis ([NIX Dataframe support](https://www.trelliscience.com/#/discussions-about/13795/0/), [NIX filesystem backend](https://www.trelliscience.com/#/discussions-about/13796/0/)), or comment directly on a relevant issue or pull request, whichever is more appropriate.
+
+There is a #gnode IRC channel on Freenode which you may join for more casual discussions with the team.
+
+
+Discussion venues
+-----------------
+
+Please keep discussion topics in their relevant venue.
+Thoughts and concerns regarding NIX should be discussed in GitHub issues.
+Project ideas should be discussed on Trellis.
+Less formal discussions can be had in the IRC chatroom.
+If you are new to IRC, this [etiquette guide](https://github.com/fizerkhan/irc-etiquette) may be useful.
+


### PR DESCRIPTION
Also renamed Contributing.md to CONTRIBUTING.md for consistency with other projects.