### PR TITLE
Add function overloads that allow accessing reference and feature data by name ...

### DIFF
--- a/backend/fs/BaseTagFS.cpp
+++ b/backend/fs/BaseTagFS.cpp
@@ -155,7 +155,6 @@ void BaseTagFS::references(const std::vector<DataArray> &refs_new) {
 
 bool BaseTagFS::hasFeature(const std::string &name_or_id) const {
     return getFeature(name_or_id) != nullptr;
-    //!feature_group.findByNameOrAttribute("entity_id", name_or_id)->empty();
 }
 
 

--- a/backend/fs/BaseTagFS.cpp
+++ b/backend/fs/BaseTagFS.cpp
@@ -154,7 +154,8 @@ void BaseTagFS::references(const std::vector<DataArray> &refs_new) {
 //--------------------------------------------------
 
 bool BaseTagFS::hasFeature(const std::string &name_or_id) const {
-    return !feature_group.findByNameOrAttribute("entity_id", name_or_id)->empty();
+    return getFeature(name_or_id) != nullptr;
+    //!feature_group.findByNameOrAttribute("entity_id", name_or_id)->empty();
 }
 
 
@@ -168,6 +169,16 @@ std::shared_ptr<base::IFeature> BaseTagFS::getFeature(const std::string &name_or
     boost::optional<bfs::path> p = feature_group.findByNameOrAttribute("name", name_or_id);
     if (p) {
         return std::make_shared<FeatureFS>(file(), block(), p->string());
+    } else {
+        for (ndsize_t i = 0; i < feature_group.subdirCount(); i++) {
+            bfs::path dir = feature_group.sub_dir_by_index(i);
+            std::shared_ptr<base::IFeature> feat = std::make_shared<FeatureFS>(file(), block(), dir.string());
+            std::shared_ptr<base::IDataArray> da = feat->data();
+            if (da->name() == name_or_id || da->id() == name_or_id) {
+                feature = std::make_shared<FeatureFS>(file(), block(), dir.string());
+                break;
+            }
+        }
     }
     return feature;
 }

--- a/include/nix/MultiTag.hpp
+++ b/include/nix/MultiTag.hpp
@@ -345,6 +345,17 @@ public:
      */
     DataView retrieveData(size_t position_index, size_t reference_index) const;
 
+     /**
+     * @brief Retrieves the data slice tagged by a certain position and extent
+     *        of a certain reference.  
+     *
+     * @param position_index      The index of the requested position.
+     * @param name_or_id          The name or id of the requested DataArray.
+     *
+     * @return the requested data.
+     */
+    DataView retrieveData(size_t position_index, const std::string &name_or_id) const;
+
     //--------------------------------------------------
     // Methods concerning features.
     //--------------------------------------------------

--- a/include/nix/MultiTag.hpp
+++ b/include/nix/MultiTag.hpp
@@ -478,6 +478,18 @@ public:
      * @return The data
      */
     DataView retrieveFeatureData(size_t position_index, size_t feature_index) const;
+
+    /**
+     * @brief Retrieves the data stored in a feature related to a certain
+     *        position of this tag.
+     *
+     * @param position_index The index of the requested position.
+     * @param name_or_id     The name or id of the feature that is requested.
+     *
+     * @return The data
+     */
+    DataView retrieveFeatureData(size_t position_index, const std::string &name_or_id) const;
+
     //------------------------------------------------------
     // Operators and other functions
     //------------------------------------------------------

--- a/include/nix/Tag.hpp
+++ b/include/nix/Tag.hpp
@@ -454,6 +454,18 @@ public:
      *
      */
     DataView retrieveFeatureData(size_t feature_index) const;
+
+    /**
+     * @brief Returns the data stored in the selected Feature.
+     *
+     * @param name_or_id     The name or id of the feature or the DataArray stored
+     *                       in the feature.
+     *
+     * @return The data stored in the Feature.
+     *
+     */
+    DataView retrieveFeatureData(const std::string &name_or_id) const;
+
     //--------------------------------------------------
     // Other methods and functions
     //--------------------------------------------------

--- a/include/nix/Tag.hpp
+++ b/include/nix/Tag.hpp
@@ -435,6 +435,15 @@ public:
      * @return the data
      */
     DataView retrieveData(size_t reference_index) const;
+
+    /**
+     * @brief Returns the data associated with a certain reference.
+     *
+     * @param name_or_id      Name or id of the referenced dataArray.
+     *
+     * @return the data
+     */
+    DataView retrieveData(const std::string &name_or_id) const; 
     
     /**
      * @brief Returns the data stored in the selected Feature.

--- a/include/nix/util/dataAccess.hpp
+++ b/include/nix/util/dataAccess.hpp
@@ -94,6 +94,18 @@ NIXAPI void getOffsetAndCount(const Tag &tag, const DataArray &array, NDSize &of
 
 NIXAPI void getOffsetAndCount(const MultiTag &tag, const DataArray &array, ndsize_t index, NDSize &offsets, NDSize &counts);
 
+
+/**
+ * @brief Retrieve the data referenced by the given position and extent of the MultiTag.
+ *
+ * @param tag                   The multi tag.
+ * @param position_index        The index of the position.
+ * @param array                 The referenced DataArray.
+ *
+ * @return The data referenced by position and extent.
+ */
+NIXAPI DataView retrieveData(const MultiTag &tag, ndsize_t position_index, const DataArray &array);
+    
 /**
  * @brief Retrieve the data referenced by the given position and extent of the MultiTag.
  *

--- a/include/nix/util/dataAccess.hpp
+++ b/include/nix/util/dataAccess.hpp
@@ -116,6 +116,17 @@ NIXAPI DataView retrieveData(const MultiTag &tag, ndsize_t position_index, size_
 NIXAPI DataView retrieveData(const Tag &tag, size_t reference_index);
 
 /**
+ * @brief Retrieve the data referenced by the given position and extent of the Tag.
+ *
+ * @param tag                   The multi tag.
+ * @param array                 The referenced DataArray.
+ *
+ * @return The data referenced by the position.
+ */
+NIXAPI DataView retrieveData(const Tag &tag, const DataArray &array);
+
+    
+/**
  * @brief Checks whether a given position is in the extent of the given DataArray.
  *
  * @param data          The data array.

--- a/include/nix/util/dataAccess.hpp
+++ b/include/nix/util/dataAccess.hpp
@@ -170,7 +170,17 @@ NIXAPI bool positionAndExtentInData(const DataArray &data, const NDSize &positio
 NIXAPI DataView retrieveFeatureData(const Tag &tag, size_t feature_index=0);
 
 /**
- * @brief Returns the feature data accosiated with the given MuliTag's position.
+ * @brief Retruns the feature data associated with a Tag.
+ *
+ * @param tag           The Tag whos feature data is requested.
+ * @param feature       The Feature of which the tagged data is requested.
+ *
+ * @return The associated data.
+ */
+NIXAPI DataView retrieveFeatureData(const Tag &tag, const Feature &feature);
+    
+/**
+ * @brief Returns the feature data associated with the given MuliTag's position.
  *
  * @param tag            The MultiTag whos feature data is requested.
  * @param position_index The index of the selected position, respectively the selected tag of the MultiTag.
@@ -179,6 +189,17 @@ NIXAPI DataView retrieveFeatureData(const Tag &tag, size_t feature_index=0);
  * @return The associated data.
  */
 NIXAPI DataView retrieveFeatureData(const MultiTag &tag, ndsize_t position_index, size_t feature_index=0);
+
+/**
+ * @brief Returns the feature data associated with the given MuliTag's position.
+ *
+ * @param tag            The MultiTag whos feature data is requested.
+ * @param position_index The index of the selected position, respectively the selected tag of the MultiTag.
+ * @param feature        The feature of which the tagged data is requested.
+ *
+ * @return The associated data.
+ */
+NIXAPI DataView retrieveFeatureData(const MultiTag &tag, ndsize_t position_index, const Feature &feature);
 
 }
 }

--- a/src/MultiTag.cpp
+++ b/src/MultiTag.cpp
@@ -104,6 +104,16 @@ DataView MultiTag::retrieveData(size_t position_index, size_t reference_index) c
 }
 
 
+DataView MultiTag::retrieveData(size_t position_index, const std::string &name_or_id) const {
+    nix::DataArray array = backend()->getReference(name_or_id);
+    if (array) {
+        return util::retrieveData(*this, position_index, array);
+    } else {
+        throw nix::OutOfBounds("There is no DataArray with the specified name or id!", 0);
+    }
+}
+
+
 bool MultiTag::hasFeature(const Feature &feature) const {
     if (!util::checkEntityInput(feature, false)) {
         return false;

--- a/src/MultiTag.cpp
+++ b/src/MultiTag.cpp
@@ -140,6 +140,16 @@ DataView MultiTag::retrieveFeatureData(size_t position_index, size_t feature_ind
     return util::retrieveFeatureData(*this, position_index, feature_index);
 }
 
+
+DataView MultiTag::retrieveFeatureData(size_t position_index, const std::string &name_or_id) const {
+    nix::Feature feature = backend()->getFeature(name_or_id);
+    if (feature) {
+        return util::retrieveFeatureData(*this, position_index, feature);
+    } else {
+        throw nix::OutOfBounds("There is no Feature with the specified name or id!", 0);
+    }
+}
+
 std::ostream& operator<<(std::ostream &out, const MultiTag &ent) {
     out << "MultiTag: {name = " << ent.name();
     out << ", type = " << ent.type();

--- a/src/MultiTag.cpp
+++ b/src/MultiTag.cpp
@@ -109,7 +109,7 @@ DataView MultiTag::retrieveData(size_t position_index, const std::string &name_o
     if (array) {
         return util::retrieveData(*this, position_index, array);
     } else {
-        throw nix::OutOfBounds("There is no DataArray with the specified name or id!", 0);
+        throw std::invalid_argument("There is no DataArray with the specified name or id! Evoked at MultiTag::retrieveData");
     }
 }
 
@@ -146,7 +146,7 @@ DataView MultiTag::retrieveFeatureData(size_t position_index, const std::string 
     if (feature) {
         return util::retrieveFeatureData(*this, position_index, feature);
     } else {
-        throw nix::OutOfBounds("There is no Feature with the specified name or id!", 0);
+        throw std::invalid_argument("There is no Feature with the specified name or id! Evoked at MultiTag::retrieveFeatureData");
     }
 }
 

--- a/src/Tag.cpp
+++ b/src/Tag.cpp
@@ -137,6 +137,16 @@ DataView Tag::retrieveFeatureData(size_t feature_index) const {
 }
 
 
+DataView Tag::retrieveFeatureData(const std::string &name_or_id) const {
+    nix::Feature feature = backend()->getFeature(name_or_id);
+    if (feature) {
+        return util::retrieveFeatureData(*this, feature);
+    } else {
+        throw nix::OutOfBounds("There is no Feature with the specified name or id!", 0);
+    }
+}
+
+
 std::ostream &nix::operator<<(std::ostream &out, const Tag &ent) {
     out << "Tag: {name = " << ent.name();
     out << ", type = " << ent.type();

--- a/src/Tag.cpp
+++ b/src/Tag.cpp
@@ -122,6 +122,16 @@ DataView Tag::retrieveData(size_t reference_index) const {
 }
 
 
+DataView Tag::retrieveData(const std::string &name_or_id) const {
+    nix::DataArray array = backend()->getReference(name_or_id);
+    if (array) {
+        return util::retrieveData(*this, array);
+    } else {
+        throw nix::OutOfBounds("There is no data array with the specified name or id!", 0);
+    }
+}
+
+
 DataView Tag::retrieveFeatureData(size_t feature_index) const {
     return util::retrieveFeatureData(*this, feature_index);
 }

--- a/src/Tag.cpp
+++ b/src/Tag.cpp
@@ -127,7 +127,7 @@ DataView Tag::retrieveData(const std::string &name_or_id) const {
     if (array) {
         return util::retrieveData(*this, array);
     } else {
-        throw nix::OutOfBounds("There is no data array with the specified name or id!", 0);
+        throw std::invalid_argument("There is no DataArray with the specified name or id! Evoked at Tag::retrieveData");
     }
 }
 
@@ -142,7 +142,7 @@ DataView Tag::retrieveFeatureData(const std::string &name_or_id) const {
     if (feature) {
         return util::retrieveFeatureData(*this, feature);
     } else {
-        throw nix::OutOfBounds("There is no Feature with the specified name or id!", 0);
+        throw std::invalid_argument("There is no Feature with the specified name or id! Evoked at Tag::retrieveFeatureData");
     }
 }
 

--- a/src/util/dataAccess.cpp
+++ b/src/util/dataAccess.cpp
@@ -251,8 +251,6 @@ DataView retrieveData(const MultiTag &tag, ndsize_t position_index, size_t refer
 
 
 DataView retrieveData(const Tag &tag, size_t reference_index) {
-    vector<double> positions = tag.position();
-    vector<double> extents = tag.extent();
     vector<DataArray> refs = tag.references();
     if (refs.size() == 0) {
         throw nix::OutOfBounds("There are no references in this tag!", 0);
@@ -260,19 +258,26 @@ DataView retrieveData(const Tag &tag, size_t reference_index) {
     if (!(reference_index < tag.referenceCount())) {
         throw nix::OutOfBounds("Reference index out of bounds.", 0);
     }
-    ndsize_t dimension_count = refs[reference_index].dimensionCount();
+    return retrieveData(tag, refs[reference_index]);
+}
+
+
+DataView retrieveData(const Tag &tag, const DataArray &array) {
+    vector<double> positions = tag.position();
+    vector<double> extents = tag.extent();
+    ndsize_t dimension_count = array.dimensionCount();
     if (positions.size() != dimension_count || (extents.size() > 0 && extents.size() != dimension_count)) {
-        throw nix::IncompatibleDimensions("Number of dimensions in position or extent do not match dimensionality of data","util::retrieveData");
+        throw nix::IncompatibleDimensions("Number of dimensions in position or extent do not match dimensionality of data", "util::retrieveData");
     }
 
     NDSize offset, count;
-    getOffsetAndCount(tag, refs[reference_index], offset, count);
-    if (!positionAndExtentInData(refs[reference_index], offset, count)) {
+    getOffsetAndCount(tag, array, offset, count);
+    if (!positionAndExtentInData(array, offset, count)) {
         throw nix::OutOfBounds("Referenced data slice out of the extent of the DataArray!", 0);
     }
-    DataView io = DataView(refs[reference_index], count, offset);
+    DataView io = DataView(array, count, offset);
     return io;
-}
+}        
 
 
 DataView retrieveFeatureData(const Tag &tag, size_t feature_index) {

--- a/test/BaseTestDataAccess.cpp
+++ b/test/BaseTestDataAccess.cpp
@@ -185,6 +185,16 @@ void BaseTestDataAccess::testTagFeatureData() {
     CPPUNIT_ASSERT(data1.dataExtent().nelms() == 1);
     CPPUNIT_ASSERT(data2.dataExtent().nelms() == 1);
     CPPUNIT_ASSERT(data3.dataExtent().nelms() == ramp_data.size());
+
+    data1 = util::retrieveFeatureData(pos_tag, f1);
+    data2 = util::retrieveFeatureData(pos_tag, f2);
+    data3 = util::retrieveFeatureData(pos_tag, f3);
+
+    CPPUNIT_ASSERT(pos_tag.featureCount() == 3);
+    CPPUNIT_ASSERT(data1.dataExtent().nelms() == 1);
+    CPPUNIT_ASSERT(data2.dataExtent().nelms() == 1);
+    CPPUNIT_ASSERT(data3.dataExtent().nelms() == ramp_data.size());
+    
     // make tag pointing to a slice
     pos_tag.extent({2.0});
     data1 = util::retrieveFeatureData(pos_tag, 0);
@@ -299,6 +309,10 @@ void BaseTestDataAccess::testMultiTagFeatureData() {
     CPPUNIT_ASSERT(sum == total);
     // tagged feature
     data_view = util::retrieveFeatureData(multi_tag, 0, 1);
+    data_size = data_view.dataExtent();
+    CPPUNIT_ASSERT(data_size.size() == 3);
+
+    data_view = util::retrieveFeatureData(multi_tag, 0, tagged_feature);
     data_size = data_view.dataExtent();
     CPPUNIT_ASSERT(data_size.size() == 3);
 

--- a/test/BaseTestMultiTag.cpp
+++ b/test/BaseTestMultiTag.cpp
@@ -381,6 +381,11 @@ void BaseTestMultiTag::testDataAccess() {
     CPPUNIT_ASSERT(data_size.size() == 3);
     CPPUNIT_ASSERT(data_size[0] == 1 && data_size[1] == 6 && data_size[2] == 2);
 
+    ret_data = multi_tag.retrieveData(0, data_array.name());
+    data_size = ret_data.dataExtent();
+    CPPUNIT_ASSERT(data_size.size() == 3);
+    CPPUNIT_ASSERT(data_size[0] == 1 && data_size[1] == 6 && data_size[2] == 2);
+
     CPPUNIT_ASSERT_THROW(multi_tag.retrieveData(1, 0), nix::OutOfBounds);
     
     block.deleteMultiTag(multi_tag);

--- a/test/BaseTestTag.cpp
+++ b/test/BaseTestTag.cpp
@@ -235,7 +235,10 @@ void BaseTestTag::testReferences() {
     CPPUNIT_ASSERT(tag.referenceCount() == 0);
     for (size_t i = 0; i < refs.size(); ++i) {
         CPPUNIT_ASSERT(!tag.hasReference(refs[i]));
+        CPPUNIT_ASSERT(!tag.hasReference(refs[i].name()));
         CPPUNIT_ASSERT_NO_THROW(tag.addReference(refs[i]));
+        CPPUNIT_ASSERT(tag.hasReference(refs[i].name()));
+        CPPUNIT_ASSERT(tag.hasReference(refs[i].id()));
         CPPUNIT_ASSERT(tag.hasReference(refs[i]));
     }
     CPPUNIT_ASSERT(tag.referenceCount() == refs.size());

--- a/test/BaseTestTag.cpp
+++ b/test/BaseTestTag.cpp
@@ -261,6 +261,8 @@ void BaseTestTag::testFeatures() {
     DataArray da = block.createDataArray("feature", "test", DataType::Double, NDSize({0, 0}));
     CPPUNIT_ASSERT_NO_THROW(f = tag.createFeature(da, nix::LinkType::Indexed));
     CPPUNIT_ASSERT(tag.hasFeature(f));
+    CPPUNIT_ASSERT(tag.hasFeature(da.name()));
+    CPPUNIT_ASSERT(tag.hasFeature(da.id()));
     CPPUNIT_ASSERT(tag.featureCount() == 1);
     CPPUNIT_ASSERT(tag.deleteFeature(f));
     CPPUNIT_ASSERT(tag.featureCount() == 0);

--- a/test/BaseTestTag.cpp
+++ b/test/BaseTestTag.cpp
@@ -328,6 +328,8 @@ void BaseTestTag::testDataAccess() {
     CPPUNIT_ASSERT(data_size.size() == 3);
     CPPUNIT_ASSERT(data_size[0] == 1 && data_size[1] == 1 &&  data_size[2] == 1);
 
+    CPPUNIT_ASSERT_THROW(position_tag.retrieveData("invalid name"), std::invalid_argument);
+
     retrieved_data = position_tag.retrieveData(data_array.name());
     data_size = retrieved_data.dataExtent();
     CPPUNIT_ASSERT(data_size.size() == 3);

--- a/test/BaseTestTag.cpp
+++ b/test/BaseTestTag.cpp
@@ -328,6 +328,11 @@ void BaseTestTag::testDataAccess() {
     CPPUNIT_ASSERT(data_size.size() == 3);
     CPPUNIT_ASSERT(data_size[0] == 1 && data_size[1] == 1 &&  data_size[2] == 1);
 
+    retrieved_data = position_tag.retrieveData(data_array.name());
+    data_size = retrieved_data.dataExtent();
+    CPPUNIT_ASSERT(data_size.size() == 3);
+    CPPUNIT_ASSERT(data_size[0] == 1 && data_size[1] == 1 &&  data_size[2] == 1);
+
     retrieved_data = segment_tag.retrieveData( 0);
     data_size = retrieved_data.dataExtent();
     CPPUNIT_ASSERT(data_size.size() == 3);


### PR DESCRIPTION
get- and hasFeature/Reference also accepts the name or id of the searched entity (issue #650). Heuristic first searches among the id of the features for direct hits otherwise it the names and ids of the linked dataArrays are checked.