### PR TITLE
Fixing bug #672

### DIFF
--- a/backend/fs/BaseTagFS.cpp
+++ b/backend/fs/BaseTagFS.cpp
@@ -110,42 +110,32 @@ bool BaseTagFS::removeReference(const std::string &name_or_id) {
 
 
 void BaseTagFS::references(const std::vector<DataArray> &refs_new) {
-    // extract vectors of names from vectors of new & old references
-    std::vector<std::string> names_new(refs_new.size());
-    transform(refs_new.begin(), refs_new.end(), names_new.begin(), util::toName<DataArray>);
-
-    size_t count = nix::check::fits_in_size_t(referenceCount(), "referenceCount() failed! count > than size_t!");
-    std::vector<DataArray> refs_old(count);
-    for (size_t i = 0; i < refs_old.size(); i++){
-        refs_old[i] = getReference(i);
+    auto cmp = [](const DataArray &a, const DataArray& b) { return a.name() < b.name(); };
+    std::vector<DataArray> new_arrays(refs_new);
+    size_t ref_count = nix::check::fits_in_size_t(referenceCount(), "referenceCount() failed; count > size_t.");
+    std::vector<DataArray> old_arrays(ref_count);
+    for (size_t i = 0; i < old_arrays.size(); i++) {
+        old_arrays[i] = getReference(i);
     }
+    std::sort(new_arrays.begin(), new_arrays.end(), cmp);
+    std::sort(old_arrays.begin(), old_arrays.end(), cmp);
+    std::vector<DataArray> add;
+    std::vector<DataArray> rem;
+    
+    std::set_difference(new_arrays.begin(), new_arrays.end(), old_arrays.begin(), old_arrays.end(),
+                        std::inserter(add, add.begin()), cmp);
+    std::set_difference(old_arrays.begin(), old_arrays.end(), new_arrays.begin(), new_arrays.end(),
+                        std::inserter(rem, rem.begin()), cmp);
 
-    std::vector<std::string> names_old(refs_old.size());
-    std::transform(refs_old.begin(), refs_old.end(), names_old.begin(), util::toName<DataArray>);
-
-    // sort them
-    std::sort(names_new.begin(), names_new.end());
-    std::sort(names_new.begin(), names_new.end());
-
-    // get names only in names_new (add), names only in names_old (remove) & ignore rest
-    std::vector<std::string> names_add;
-    std::vector<std::string> names_rem;
-    std::set_difference(names_new.begin(), names_new.end(), names_old.begin(), names_old.end(),
-                        std::inserter(names_add, names_add.begin()));
-    std::set_difference(names_old.begin(), names_old.end(), names_new.begin(), names_new.end(),
-                        std::inserter(names_rem, names_rem.begin()));
-
-    // check if all new references exist & add sources
     auto blck = std::dynamic_pointer_cast<BlockFS>(block());
-    for (auto name : names_add) {
-        if (!blck->hasDataArray(name))
+    for (auto da : add) {
+        DataArray a = blck->getDataArray(da.name());
+        if (!a || a.id() != da.id())
             throw std::runtime_error("One or more data arrays do not exist in this block!");
-        addReference(blck->getDataArray(name)->id());
+        addReference(a.id());
     }
-    // remove references
-    for (auto name : names_rem) {
-        if (!blck->hasDataArray(name))
-            removeReference(blck->getDataArray(name)->id());
+    for (auto da : rem) {
+        removeReference(da.id());
     }
 }
 

--- a/backend/fs/BaseTagFS.cpp
+++ b/backend/fs/BaseTagFS.cpp
@@ -128,13 +128,13 @@ void BaseTagFS::references(const std::vector<DataArray> &refs_new) {
                         std::inserter(rem, rem.begin()), cmp);
 
     auto blck = std::dynamic_pointer_cast<BlockFS>(block());
-    for (auto da : add) {
+    for (const auto &da : add) {
         DataArray a = blck->getDataArray(da.name());
         if (!a || a.id() != da.id())
             throw std::runtime_error("One or more data arrays do not exist in this block!");
         addReference(a.id());
     }
-    for (auto da : rem) {
+    for (const auto &da : rem) {
         removeReference(da.id());
     }
 }

--- a/backend/fs/GroupFS.cpp
+++ b/backend/fs/GroupFS.cpp
@@ -115,41 +115,33 @@ bool GroupFS::removeDataArray(const std::string &name_or_id) {
 
 
 void GroupFS::dataArrays(const std::vector<DataArray> &data_arrays) {
-    // extract vectors of names from vectors of new & old references
-    std::vector<std::string> names_new(data_arrays.size());
-    transform(data_arrays.begin(), data_arrays.end(), names_new.begin(), util::toName<DataArray>);
+    auto cmp = [](const DataArray &a, const DataArray& b) { return a.name() < b.name(); };
+    std::vector<DataArray> new_arrays(data_arrays);
+    size_t array_count = nix::check::fits_in_size_t(dataArrayCount(), "dataArrayCount() failed; count > size_t.");
 
-    size_t count = nix::check::fits_in_size_t(dataArrayCount(), "dataArrayCount failed! count > than size_t!");
-    std::vector<DataArray> refs_old(count);
-    for (size_t i = 0; i < refs_old.size(); i++){
-        refs_old[i] = getDataArray(i);
+    std::vector<DataArray> old_arrays(array_count);
+    for (size_t i = 0; i < old_arrays.size(); i++) {
+        old_arrays[i] = getDataArray(i);
     }
-    std::vector<std::string> names_old(refs_old.size());
-    std::transform(refs_old.begin(), refs_old.end(), names_old.begin(), util::toName<DataArray>);
+    std::sort(new_arrays.begin(), new_arrays.end(), cmp);
+    std::sort(old_arrays.begin(), old_arrays.end(), cmp);
+    std::vector<DataArray> add;
+    std::vector<DataArray> rem;
+    
+    std::set_difference(new_arrays.begin(), new_arrays.end(), old_arrays.begin(), old_arrays.end(),
+                        std::inserter(add, add.begin()), cmp);
+    std::set_difference(old_arrays.begin(), old_arrays.end(), new_arrays.begin(), new_arrays.end(),
+                        std::inserter(rem, rem.begin()), cmp);
 
-    // sort them
-    std::sort(names_new.begin(), names_new.end());
-    std::sort(names_new.begin(), names_new.end());
-
-    // get names only in names_new (add), names only in names_old (remove) & ignore rest
-    std::vector<std::string> names_add;
-    std::vector<std::string> names_rem;
-    std::set_difference(names_new.begin(), names_new.end(), names_old.begin(), names_old.end(),
-                        std::inserter(names_add, names_add.begin()));
-    std::set_difference(names_old.begin(), names_old.end(), names_new.begin(), names_new.end(),
-                        std::inserter(names_rem, names_rem.begin()));
-
-    // check if all new references exist & add sources
     auto blck = std::dynamic_pointer_cast<BlockFS>(block());
-    for (auto name : names_add) {
-        if (!blck->hasDataArray(name))
+    for (auto da : add) {
+        DataArray a = blck->getDataArray(da.name());
+        if (!a || a.id() != da.id())
             throw std::runtime_error("One or more data arrays do not exist in this block!");
-        addDataArray(blck->getDataArray(name)->id());
+        addDataArray(a.id());
     }
-    // remove references
-    for (auto name : names_rem) {
-        if (!blck->hasDataArray(name))
-            removeDataArray(blck->getDataArray(name)->id());
+    for (auto da : rem) {
+        removeDataArray(da.id());
     }
 }
 
@@ -213,41 +205,33 @@ bool GroupFS::removeTag(const std::string &name_or_id) {
 
 
 void GroupFS::tags(const std::vector<Tag> &tags) {
-    // extract vectors of names from vectors of new & old references
-    std::vector<std::string> names_new(tags.size());
-    transform(tags.begin(), tags.end(), names_new.begin(), util::toName<Tag>);
-
-    size_t count = nix::check::fits_in_size_t(tagCount(), "tagCount() failed! count > than size_t!");
-    std::vector<Tag> refs_old(count);
-    for (size_t i = 0; i < refs_old.size(); i++){
-        refs_old[i] = getTag(i);
+    auto cmp = [](const Tag &a, const Tag& b) { return a.name() < b.name(); };
+    
+    std::vector<Tag> new_tags(tags); 
+    size_t tag_count = nix::check::fits_in_size_t(tagCount(), "tagCount() failed; count > size_t.");
+    std::vector<Tag> old_tags(tag_count);
+    for (size_t i = 0; i < old_tags.size(); i++) {
+        old_tags[i] = getTag(i);
     }
-    std::vector<std::string> names_old(refs_old.size());
-    std::transform(refs_old.begin(), refs_old.end(), names_old.begin(), util::toName<Tag>);
+    std::sort(new_tags.begin(), new_tags.end(), cmp);
+    std::sort(old_tags.begin(), old_tags.end(), cmp);
+    std::vector<Tag> add;
+    std::vector<Tag> rem;
+    
+    std::set_difference(new_tags.begin(), new_tags.end(), old_tags.begin(), old_tags.end(),
+                        std::inserter(add, add.begin()), cmp);
+    std::set_difference(old_tags.begin(), old_tags.end(), new_tags.begin(), new_tags.end(),
+                        std::inserter(rem, rem.begin()), cmp);
 
-    // sort them
-    std::sort(names_new.begin(), names_new.end());
-    std::sort(names_new.begin(), names_new.end());
-
-    // get names only in names_new (add), names only in names_old (remove) & ignore rest
-    std::vector<std::string> names_add;
-    std::vector<std::string> names_rem;
-    std::set_difference(names_new.begin(), names_new.end(), names_old.begin(), names_old.end(),
-                        std::inserter(names_add, names_add.begin()));
-    std::set_difference(names_old.begin(), names_old.end(), names_new.begin(), names_new.end(),
-                        std::inserter(names_rem, names_rem.begin()));
-
-    // check if all new references exist & add sources
     auto blck = std::dynamic_pointer_cast<BlockFS>(block());
-    for (auto name : names_add) {
-        if (!blck->hasTag(name))
+    for (auto t : add) {
+        Tag tag = blck->getTag(t.name());
+        if (!tag || tag.id() != t.id())
             throw std::runtime_error("One or more tags do not exist in this block!");
-        addTag(blck->getTag(name)->id());
+        addTag(t.id());
     }
-    // remove references
-    for (auto name : names_rem) {
-        if (!blck->hasTag(name))
-            removeTag(blck->getTag(name)->id());
+    for (auto t : rem) {
+        removeTag(t.id());
     }
 }
 
@@ -311,41 +295,32 @@ bool GroupFS::removeMultiTag(const std::string &name_or_id) {
 
 
 void GroupFS::multiTags(const std::vector<MultiTag> &multi_tags) {
-    // extract vectors of names from vectors of new & old references
-    std::vector<std::string> names_new(multi_tags.size());
-    transform(multi_tags.begin(), multi_tags.end(), names_new.begin(), util::toName<MultiTag>);
-
-    size_t count = nix::check::fits_in_size_t(multiTagCount(), "multiTagCount() failed! count > than size_t!");
-    std::vector<MultiTag> refs_old(count);
-    for (size_t i = 0; i < refs_old.size(); i++){
-        refs_old[i] = getMultiTag(i);
+    auto cmp = [](const MultiTag &a, const MultiTag& b) { return a.name() < b.name(); };
+    std::vector<MultiTag> new_tags(multi_tags); 
+    size_t tag_count = nix::check::fits_in_size_t(multiTagCount(), "multiTagCount() failed; count > size_t.");
+    std::vector<MultiTag> old_tags(tag_count);
+    for (size_t i = 0; i < old_tags.size(); i++) {
+        old_tags[i] = getMultiTag(i);
     }
-    std::vector<std::string> names_old(refs_old.size());
-    std::transform(refs_old.begin(), refs_old.end(), names_old.begin(), util::toName<MultiTag>);
+    std::sort(new_tags.begin(), new_tags.end(), cmp);
+    std::sort(old_tags.begin(), old_tags.end(), cmp);
+    std::vector<MultiTag> add;
+    std::vector<MultiTag> rem;
+    
+    std::set_difference(new_tags.begin(), new_tags.end(), old_tags.begin(), old_tags.end(),
+                        std::inserter(add, add.begin()), cmp);
+    std::set_difference(old_tags.begin(), old_tags.end(), new_tags.begin(), new_tags.end(),
+                        std::inserter(rem, rem.begin()), cmp);
 
-    // sort them
-    std::sort(names_new.begin(), names_new.end());
-    std::sort(names_new.begin(), names_new.end());
-
-    // get names only in names_new (add), names only in names_old (remove) & ignore rest
-    std::vector<std::string> names_add;
-    std::vector<std::string> names_rem;
-    std::set_difference(names_new.begin(), names_new.end(), names_old.begin(), names_old.end(),
-                        std::inserter(names_add, names_add.begin()));
-    std::set_difference(names_old.begin(), names_old.end(), names_new.begin(), names_new.end(),
-                        std::inserter(names_rem, names_rem.begin()));
-
-    // check if all new references exist & add sources
     auto blck = std::dynamic_pointer_cast<BlockFS>(block());
-    for (auto name : names_add) {
-        if (!blck->hasMultiTag(name))
-            throw std::runtime_error("One or more multiTags do not exist in this block!");
-        addMultiTag(blck->getMultiTag(name)->id());
+    for (auto t : add) {
+        MultiTag tag = blck->getMultiTag(t.name());
+        if (!tag || tag.id() != t.id())
+            throw std::runtime_error("One or more data multiTags do not exist in this block!");
+        addMultiTag(t.id());
     }
-    // remove references
-    for (auto name : names_rem) {
-        if (!blck->hasMultiTag(name))
-            removeMultiTag(blck->getMultiTag(name)->id());
+    for (auto t : rem) {
+        removeMultiTag(t.id());
     }
 }
 

--- a/backend/fs/GroupFS.cpp
+++ b/backend/fs/GroupFS.cpp
@@ -134,13 +134,13 @@ void GroupFS::dataArrays(const std::vector<DataArray> &data_arrays) {
                         std::inserter(rem, rem.begin()), cmp);
 
     auto blck = std::dynamic_pointer_cast<BlockFS>(block());
-    for (auto da : add) {
+    for (const auto &da : add) {
         DataArray a = blck->getDataArray(da.name());
         if (!a || a.id() != da.id())
             throw std::runtime_error("One or more data arrays do not exist in this block!");
         addDataArray(a.id());
     }
-    for (auto da : rem) {
+    for (const auto &da : rem) {
         removeDataArray(da.id());
     }
 }
@@ -224,13 +224,13 @@ void GroupFS::tags(const std::vector<Tag> &tags) {
                         std::inserter(rem, rem.begin()), cmp);
 
     auto blck = std::dynamic_pointer_cast<BlockFS>(block());
-    for (auto t : add) {
+    for (const auto &t : add) {
         Tag tag = blck->getTag(t.name());
         if (!tag || tag.id() != t.id())
             throw std::runtime_error("One or more tags do not exist in this block!");
         addTag(t.id());
     }
-    for (auto t : rem) {
+    for (const auto &t : rem) {
         removeTag(t.id());
     }
 }
@@ -313,13 +313,13 @@ void GroupFS::multiTags(const std::vector<MultiTag> &multi_tags) {
                         std::inserter(rem, rem.begin()), cmp);
 
     auto blck = std::dynamic_pointer_cast<BlockFS>(block());
-    for (auto t : add) {
+    for (const auto &t : add) {
         MultiTag tag = blck->getMultiTag(t.name());
         if (!tag || tag.id() != t.id())
             throw std::runtime_error("One or more data multiTags do not exist in this block!");
         addMultiTag(t.id());
     }
-    for (auto t : rem) {
+    for (const auto &t : rem) {
         removeMultiTag(t.id());
     }
 }

--- a/backend/hdf5/BaseTagHDF5.cpp
+++ b/backend/hdf5/BaseTagHDF5.cpp
@@ -133,13 +133,13 @@ void BaseTagHDF5::references(const std::vector<DataArray> &refs_new) {
                         std::inserter(rem, rem.begin()), cmp);
 
     auto blck = std::dynamic_pointer_cast<BlockHDF5>(block());
-    for (auto da : add) {
+    for (const auto &da : add) {
         DataArray a = blck->getDataArray(da.name());
         if (!a || a.id() != da.id())
             throw std::runtime_error("One or more data arrays do not exist in this block!");
         addReference(a.id());
     }
-    for (auto da : rem) {
+    for (const auto &da : rem) {
         removeReference(da.id());
     }
 }

--- a/backend/hdf5/BaseTagHDF5.cpp
+++ b/backend/hdf5/BaseTagHDF5.cpp
@@ -115,40 +115,32 @@ bool BaseTagHDF5::removeReference(const std::string &name_or_id) {
 
 
 void BaseTagHDF5::references(const std::vector<DataArray> &refs_new) {
-
-    // extract vectors of names from vectors of new & old references
-    std::vector<std::string> names_new(refs_new.size());
-    std::transform(refs_new.begin(), refs_new.end(), names_new.begin(), util::toName<DataArray>);
-
-    size_t ref_count = nix::check::fits_in_size_t(referenceCount(), "refrenceCount() failed; count > size_t.");
-    std::vector<DataArray> refs_old(ref_count);
-    for (size_t i = 0; i < refs_old.size(); i++) refs_old[i] = getReference(i);
-    std::vector<std::string> names_old(refs_old.size());
-    std::transform(refs_old.begin(), refs_old.end(), names_old.begin(), util::toName<DataArray>);
-
-    // sort them
-    std::sort(names_new.begin(), names_new.end());
-    std::sort(names_new.begin(), names_new.end());
-
-    // get names only in names_new (add), names only in names_old (remove) & ignore rest
-    std::vector<std::string> names_add;
-    std::vector<std::string> names_rem;
-    std::set_difference(names_new.begin(), names_new.end(), names_old.begin(), names_old.end(),
-            std::inserter(names_add, names_add.begin()));
-    std::set_difference(names_old.begin(), names_old.end(), names_new.begin(), names_new.end(),
-            std::inserter(names_rem, names_rem.begin()));
-
-    // check if all new references exist & add sources
-    auto blck = std::dynamic_pointer_cast<BlockHDF5>(block());
-    for (auto name : names_add) {
-        if (!blck->hasDataArray(name))
-            throw std::runtime_error("One or more data arrays do not exist in this block!");
-        addReference(blck->getDataArray(name)->id());
+    auto cmp = [](const DataArray &a, const DataArray& b) { return a.name() < b.name(); };
+    std::vector<DataArray> new_arrays(refs_new);
+    size_t ref_count = nix::check::fits_in_size_t(referenceCount(), "referenceCount() failed; count > size_t.");
+    std::vector<DataArray> old_arrays(ref_count);
+    for (size_t i = 0; i < old_arrays.size(); i++) {
+        old_arrays[i] = getReference(i);
     }
-    // remove references
-    for (auto name : names_rem) {
-        if (!blck->hasDataArray(name))
-            removeReference(blck->getDataArray(name)->id());
+    std::sort(new_arrays.begin(), new_arrays.end(), cmp);
+    std::sort(old_arrays.begin(), old_arrays.end(), cmp);
+    std::vector<DataArray> add;
+    std::vector<DataArray> rem;
+    
+    std::set_difference(new_arrays.begin(), new_arrays.end(), old_arrays.begin(), old_arrays.end(),
+                        std::inserter(add, add.begin()), cmp);
+    std::set_difference(old_arrays.begin(), old_arrays.end(), new_arrays.begin(), new_arrays.end(),
+                        std::inserter(rem, rem.begin()), cmp);
+
+    auto blck = std::dynamic_pointer_cast<BlockHDF5>(block());
+    for (auto da : add) {
+        DataArray a = blck->getDataArray(da.name());
+        if (!a || a.id() != da.id())
+            throw std::runtime_error("One or more data arrays do not exist in this block!");
+        addReference(a.id());
+    }
+    for (auto da : rem) {
+        removeReference(da.id());
     }
 }
 

--- a/backend/hdf5/GroupHDF5.cpp
+++ b/backend/hdf5/GroupHDF5.cpp
@@ -106,40 +106,34 @@ bool GroupHDF5::removeDataArray(const std::string &name_or_id) {
 
 
 void GroupHDF5::dataArrays(const std::vector<DataArray> &data_arrays) {
-
-    // extract vectors of names from vectors of new & old references
-    std::vector<std::string> names_new(data_arrays.size());
-    std::transform(data_arrays.begin(), data_arrays.end(), names_new.begin(), util::toName<DataArray>);
-
+    auto cmp = [](const DataArray &a, const DataArray& b) { return a.name() < b.name(); };
+    
+    std::vector<DataArray> new_arrays(data_arrays); 
     size_t array_count = nix::check::fits_in_size_t(dataArrayCount(), "dataArrayCount() failed; count > size_t.");
-    std::vector<DataArray> refs_old(array_count);
-    for (size_t i = 0; i < refs_old.size(); i++) refs_old[i] = getDataArray(i);
-    std::vector<std::string> names_old(refs_old.size());
-    std::transform(refs_old.begin(), refs_old.end(), names_old.begin(), util::toName<DataArray>);
-
-    // sort them
-    std::sort(names_new.begin(), names_new.end());
-    std::sort(names_new.begin(), names_new.end());
-
-    // get names only in names_new (add), names only in names_old (remove) & ignore rest
-    std::vector<std::string> names_add;
-    std::vector<std::string> names_rem;
-    std::set_difference(names_new.begin(), names_new.end(), names_old.begin(), names_old.end(),
-                        std::inserter(names_add, names_add.begin()));
-    std::set_difference(names_old.begin(), names_old.end(), names_new.begin(), names_new.end(),
-                        std::inserter(names_rem, names_rem.begin()));
-
-    // check if all new data_arrays exist & add them
-    auto blck = std::dynamic_pointer_cast<BlockHDF5>(block());
-    for (auto name : names_add) {
-        if (!blck->hasDataArray(name))
-            throw std::runtime_error("One or more data arrays do not exist in this block!");
-        addDataArray(blck->getDataArray(name)->id());
+    std::vector<DataArray> old_arrays(array_count);
+    for (size_t i = 0; i < old_arrays.size(); i++) {
+        old_arrays[i] = getDataArray(i);
     }
-    // remove references
-    for (auto name : names_rem) {
-        if (!blck->hasDataArray(name))
-            removeDataArray(blck->getDataArray(name)->id());
+    std::sort(new_arrays.begin(), new_arrays.end(), cmp);
+    std::sort(old_arrays.begin(), old_arrays.end(), cmp);
+    std::vector<DataArray> add;
+    std::vector<DataArray> rem;
+    
+    std::set_difference(new_arrays.begin(), new_arrays.end(), old_arrays.begin(), old_arrays.end(),
+                        std::inserter(add, add.begin()), cmp);
+    std::set_difference(old_arrays.begin(), old_arrays.end(), new_arrays.begin(), new_arrays.end(),
+                        std::inserter(rem, rem.begin()), cmp);
+
+    auto blck = std::dynamic_pointer_cast<BlockHDF5>(block());
+    for (auto da : add) {
+        DataArray a = blck->getDataArray(da.name());
+        if (!a || a.id() != da.id())
+            throw std::runtime_error("One or more data arrays do not exist in this block!");
+        addDataArray(a.id());
+    }
+
+    for (auto da : rem) {
+        removeDataArray(da.id());
     }
 }
 
@@ -208,40 +202,34 @@ bool GroupHDF5::removeTag(const std::string &name_or_id) {
 
 
 void GroupHDF5::tags(const std::vector<Tag> &tags) {
-
-    // extract vectors of names from vectors of new & old references
-    std::vector<std::string> names_new(tags.size());
-    std::transform(tags.begin(), tags.end(), names_new.begin(), util::toName<Tag>);
-
+    auto cmp = [](const Tag &a, const Tag& b) { return a.name() < b.name(); };
+    
+    std::vector<Tag> new_tags(tags); 
     size_t tag_count = nix::check::fits_in_size_t(tagCount(), "tagCount() failed; count > size_t.");
-    std::vector<Tag> refs_old(tag_count);
-    for (size_t i = 0; i < refs_old.size(); i++) refs_old[i] = getTag(i);
-    std::vector<std::string> names_old(refs_old.size());
-    std::transform(refs_old.begin(), refs_old.end(), names_old.begin(), util::toName<Tag>);
-
-    // sort them
-    std::sort(names_new.begin(), names_new.end());
-    std::sort(names_new.begin(), names_new.end());
-
-    // get names only in names_new (add), names only in names_old (remove) & ignore rest
-    std::vector<std::string> names_add;
-    std::vector<std::string> names_rem;
-    std::set_difference(names_new.begin(), names_new.end(), names_old.begin(), names_old.end(),
-                        std::inserter(names_add, names_add.begin()));
-    std::set_difference(names_old.begin(), names_old.end(), names_new.begin(), names_new.end(),
-                        std::inserter(names_rem, names_rem.begin()));
-
-    // check if all new tags exist & add them
-    auto blck = std::dynamic_pointer_cast<BlockHDF5>(block());
-    for (auto name : names_add) {
-        if (!blck->hasTag(name))
-            throw std::runtime_error("One or more tags do not exist in this block!");
-        addTag(blck->getTag(name)->id());
+    std::vector<Tag> old_tags(tag_count);
+    for (size_t i = 0; i < old_tags.size(); i++) {
+        old_tags[i] = getTag(i);
     }
-    // remove references
-    for (auto name : names_rem) {
-        if (!blck->hasTag(name))
-            removeTag(blck->getTag(name)->id());
+    std::sort(new_tags.begin(), new_tags.end(), cmp);
+    std::sort(old_tags.begin(), old_tags.end(), cmp);
+    std::vector<Tag> add;
+    std::vector<Tag> rem;
+    
+    std::set_difference(new_tags.begin(), new_tags.end(), old_tags.begin(), old_tags.end(),
+                        std::inserter(add, add.begin()), cmp);
+    std::set_difference(old_tags.begin(), old_tags.end(), new_tags.begin(), new_tags.end(),
+                        std::inserter(rem, rem.begin()), cmp);
+
+    auto blck = std::dynamic_pointer_cast<BlockHDF5>(block());
+    for (auto t : add) {
+        Tag tag = blck->getTag(t.name());
+        if (!tag || tag.id() != t.id())
+            throw std::runtime_error("One or more data tags do not exist in this block!");
+        addTag(t.id());
+    }
+
+    for (auto t : rem) {
+        removeTag(t.id());
     }
 }
 
@@ -310,39 +298,34 @@ bool GroupHDF5::removeMultiTag(const std::string &name_or_id) {
 
 
 void GroupHDF5::multiTags(const std::vector<MultiTag> &multi_tags) {
-    // extract vectors of names from vectors of new & old references
-    std::vector<std::string> names_new(multi_tags.size());
-    std::transform(multi_tags.begin(), multi_tags.end(), names_new.begin(), util::toName<MultiTag>);
-
-    size_t mtag_count = nix::check::fits_in_size_t(multiTagCount(), "multiTagCount() failed; count > size_t.");
-    std::vector<MultiTag> refs_old(mtag_count);
-    for (size_t i = 0; i < refs_old.size(); i++) refs_old[i] = getMultiTag(i);
-    std::vector<std::string> names_old(refs_old.size());
-    std::transform(refs_old.begin(), refs_old.end(), names_old.begin(), util::toName<MultiTag>);
-
-    // sort them
-    std::sort(names_new.begin(), names_new.end());
-    std::sort(names_new.begin(), names_new.end());
-
-    // get names only in names_new (add), names only in names_old (remove) & ignore rest
-    std::vector<std::string> names_add;
-    std::vector<std::string> names_rem;
-    std::set_difference(names_new.begin(), names_new.end(), names_old.begin(), names_old.end(),
-                        std::inserter(names_add, names_add.begin()));
-    std::set_difference(names_old.begin(), names_old.end(), names_new.begin(), names_new.end(),
-                        std::inserter(names_rem, names_rem.begin()));
-
-    // check if all new tags exist & add them
-    auto blck = std::dynamic_pointer_cast<BlockHDF5>(block());
-    for (auto name : names_add) {
-        if (!blck->hasMultiTag(name))
-            throw std::runtime_error("One or more MultiTag do not exist in this block!");
-        addMultiTag(blck->getMultiTag(name)->id());
+    auto cmp = [](const MultiTag &a, const MultiTag& b) { return a.name() < b.name(); };
+    
+    std::vector<MultiTag> new_tags(multi_tags); 
+    size_t tag_count = nix::check::fits_in_size_t(multiTagCount(), "multiTagCount() failed; count > size_t.");
+    std::vector<MultiTag> old_tags(tag_count);
+    for (size_t i = 0; i < old_tags.size(); i++) {
+        old_tags[i] = getMultiTag(i);
     }
-    // remove references
-    for (auto name : names_rem) {
-        if (!blck->hasMultiTag(name))
-            removeMultiTag(blck->getMultiTag(name)->id());
+    std::sort(new_tags.begin(), new_tags.end(), cmp);
+    std::sort(old_tags.begin(), old_tags.end(), cmp);
+    std::vector<MultiTag> add;
+    std::vector<MultiTag> rem;
+    
+    std::set_difference(new_tags.begin(), new_tags.end(), old_tags.begin(), old_tags.end(),
+                        std::inserter(add, add.begin()), cmp);
+    std::set_difference(old_tags.begin(), old_tags.end(), new_tags.begin(), new_tags.end(),
+                        std::inserter(rem, rem.begin()), cmp);
+
+    auto blck = std::dynamic_pointer_cast<BlockHDF5>(block());
+    for (auto t : add) {
+        MultiTag tag = blck->getMultiTag(t.name());
+        if (!tag || tag.id() != t.id())
+            throw std::runtime_error("One or more data multiTags do not exist in this block!");
+        addMultiTag(t.id());
+    }
+
+    for (auto t : rem) {
+        removeMultiTag(t.id());
     }
 }
 

--- a/backend/hdf5/GroupHDF5.cpp
+++ b/backend/hdf5/GroupHDF5.cpp
@@ -125,14 +125,14 @@ void GroupHDF5::dataArrays(const std::vector<DataArray> &data_arrays) {
                         std::inserter(rem, rem.begin()), cmp);
 
     auto blck = std::dynamic_pointer_cast<BlockHDF5>(block());
-    for (auto da : add) {
+    for (const auto &da : add) {
         DataArray a = blck->getDataArray(da.name());
         if (!a || a.id() != da.id())
             throw std::runtime_error("One or more data arrays do not exist in this block!");
         addDataArray(a.id());
     }
 
-    for (auto da : rem) {
+    for (const auto &da : rem) {
         removeDataArray(da.id());
     }
 }
@@ -221,14 +221,14 @@ void GroupHDF5::tags(const std::vector<Tag> &tags) {
                         std::inserter(rem, rem.begin()), cmp);
 
     auto blck = std::dynamic_pointer_cast<BlockHDF5>(block());
-    for (auto t : add) {
+    for (const auto &t : add) {
         Tag tag = blck->getTag(t.name());
         if (!tag || tag.id() != t.id())
             throw std::runtime_error("One or more data tags do not exist in this block!");
         addTag(t.id());
     }
 
-    for (auto t : rem) {
+    for (const auto &t : rem) {
         removeTag(t.id());
     }
 }
@@ -317,14 +317,14 @@ void GroupHDF5::multiTags(const std::vector<MultiTag> &multi_tags) {
                         std::inserter(rem, rem.begin()), cmp);
 
     auto blck = std::dynamic_pointer_cast<BlockHDF5>(block());
-    for (auto t : add) {
+    for (const auto &t : add) {
         MultiTag tag = blck->getMultiTag(t.name());
         if (!tag || tag.id() != t.id())
             throw std::runtime_error("One or more data multiTags do not exist in this block!");
         addMultiTag(t.id());
     }
 
-    for (auto t : rem) {
+    for (const auto &t : rem) {
         removeMultiTag(t.id());
     }
 }

--- a/src/Block.cpp
+++ b/src/Block.cpp
@@ -57,7 +57,7 @@ bool Block::deleteSource(const Source &source) {
     if (!util::checkEntityInput(source, false)) {
         return false;
     }
-    return backend()->deleteSource(source.id());
+    return backend()->deleteSource(source.name());
 }
 
 DataArray Block::createDataArray(const std::string &name, const std::string &type, nix::DataType data_type,
@@ -86,7 +86,7 @@ bool Block::deleteDataArray(const DataArray &data_array) {
     if (!util::checkEntityInput(data_array, false)) {
         return false;
     }
-    return backend()->deleteDataArray(data_array.id());
+    return backend()->deleteDataArray(data_array.name());
 }
 
 Tag Block::createTag(const std::string &name, const std::string &type, const std::vector<double> &position) {
@@ -121,7 +121,7 @@ bool Block::deleteTag(const Tag &tag) {
     if (!util::checkEntityInput(tag, false)) {
         return false;
     }
-    return backend()->deleteTag(tag.id());
+    return backend()->deleteTag(tag.name());
 }
 
 MultiTag Block::createMultiTag(const std::string &name, const std::string &type, const DataArray &positions) {
@@ -160,7 +160,7 @@ bool Block::deleteMultiTag(const MultiTag &multi_tag) {
     if (!util::checkEntityInput(multi_tag, false)) {
         return false;
     }
-    return backend()->deleteMultiTag(multi_tag.id());
+    return backend()->deleteMultiTag(multi_tag.name());
 }
 
 Group Block::createGroup(const std::string &name, const std::string &type) {
@@ -188,7 +188,7 @@ bool Block::deleteGroup(const Group &group) {
     if (!util::checkEntityInput(group, false)) {
         return false;
     }
-    return backend()->deleteGroup(group.id());
+    return backend()->deleteGroup(group.name());
 }
 
 std::ostream &operator<<(std::ostream &out, const Block &ent) {

--- a/src/Block.cpp
+++ b/src/Block.cpp
@@ -37,7 +37,8 @@ bool Block::hasSource(const Source &source) const {
     if (!util::checkEntityInput(source, false)) {
         return false;
     }
-    return backend()->hasSource(source.id());
+    Source s = backend()->getSource(source.name());
+    return s && s.id() == source.id();
 }
 
 Source Block::getSource(ndsize_t index) const {
@@ -72,7 +73,8 @@ bool Block::hasDataArray(const DataArray &data_array) const {
     if (!util::checkEntityInput(data_array, false)) {
         return false;
     }
-    return backend()->hasDataArray(data_array.id());
+    DataArray da = backend()->getDataArray(data_array.name());
+    return  da && da.id() == data_array.id();
 }
 
 std::vector<DataArray> Block::dataArrays(const util::AcceptAll<DataArray>::type &filter) const {
@@ -99,7 +101,8 @@ bool Block::hasTag(const Tag &tag) const {
     if (!util::checkEntityInput(tag, false)) {
         return false;
     }
-    return backend()->hasTag(tag.id());
+    Tag t = backend()->getTag(tag.name());
+    return  t && t.id() == tag.id();
 }
 
 Tag Block::getTag(ndsize_t index) const {
@@ -144,7 +147,8 @@ bool Block::hasMultiTag(const MultiTag &multi_tag) const {
     if (!util::checkEntityInput(multi_tag, false)) {
         return false;
     }
-    return backend()->hasMultiTag(multi_tag.id());
+    MultiTag mt = backend()->getMultiTag(multi_tag.name());
+    return mt && mt.id() == multi_tag.id();
 }
 
 std::vector<MultiTag> Block::multiTags(const util::AcceptAll<MultiTag>::type &filter) const {
@@ -171,7 +175,8 @@ bool Block::hasGroup(const Group &group) const {
     if (!util::checkEntityInput(group, false)) {
         return false;
     }
-    return backend()->hasGroup(group.id());
+    Group g = backend()->getGroup(group.name());
+    return g && g.id() == group.id();
 }
 
 std::vector<Group> Block::groups(const util::AcceptAll<Group>::type &filter) const {

--- a/src/MultiTag.cpp
+++ b/src/MultiTag.cpp
@@ -65,7 +65,8 @@ bool MultiTag::hasReference(const DataArray &reference) const {
     if(!util::checkEntityInput(reference, false)) {
         return false;
     }
-    return backend()->hasReference(reference.id());
+    DataArray da = backend()->getReference(reference.name());
+    return da && da.id() == reference.id();
 }
 
 
@@ -81,7 +82,7 @@ void MultiTag::addReference(const DataArray &reference) {
     if(!util::checkEntityInput(reference)) {
         throw UninitializedEntity();
     }
-    backend()->addReference(reference.id());
+    backend()->addReference(reference.name());
 }
 
 
@@ -89,7 +90,7 @@ bool MultiTag::removeReference(const DataArray &reference) {
     if (!util::checkEntityInput(reference)) {
         return false;
     }
-    return backend()->removeReference(reference.id());
+    return backend()->removeReference(reference.name());
 }
 
 

--- a/src/Tag.cpp
+++ b/src/Tag.cpp
@@ -33,7 +33,8 @@ bool Tag::hasReference(const DataArray &reference) const {
     if (!util::checkEntityInput(reference, false)) {
         return false;
     }
-    return backend()->hasReference(reference.id());
+    DataArray da = backend()->getReference(reference.name());
+    return da && da.id() == reference.id();
 }
 
 
@@ -49,7 +50,7 @@ void Tag::addReference(const DataArray &reference) {
     if (!util::checkEntityInput(reference, false)) {
         throw UninitializedEntity();
     }
-    backend()->addReference(reference.id());
+    backend()->addReference(reference.name());
 }
 
 
@@ -63,7 +64,7 @@ bool Tag::removeReference(const DataArray &reference) {
     if (!util::checkEntityInput(reference, false)) {
         return false;
     }
-    return backend()->removeReference(reference.id());
+    return backend()->removeReference(reference.name());
 }
 
 


### PR DESCRIPTION
all(?!) vector setters verify entity identity by name and id

change behaviour of has-, add-, removeEntity methods to use the name instead of the id