### PR TITLE
Editors: add editorconfig, ns indent for emacs

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,6 +1,6 @@
-((c++-mode .
-	   (
-	    (indent-tabs-mode . nil)
-	    (tab-width . 4)
-	    (c-basic-offset . 4)
-	    (fill-column . 80))))
+
+((c++-mode . ((indent-tabs-mode . nil)
+              (tab-width . 4)
+              (c-basic-offset . 4)
+              (fill-column . 80)
+              (c-offsets-alist . ((innamespace . [0]))))))

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+trim_trailing_whitespace = true
+
+[*.{cpp,hpp}]
+indent_size = 4
+
+[CMakeList.txt]
+indent_size = 2
+
+[*.yaml]
+indent_size = 2


### PR DESCRIPTION
Help editors doing the right thing for various files using the
editorconfig standard: http://editorconfig.org