### PR TITLE
[Cmake] HDF5_INCLUDE_DIR -> HDF5_INCLUDE_DIRS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ else()
   set(HDF5_USE_STATIC_LIBS OFF)
   find_package (HDF5 REQUIRED COMPONENTS C)
 endif()
-include_directories (${HDF5_INCLUDE_DIR})
+include_directories (${HDF5_INCLUDE_DIRS})
 set (LINK_LIBS ${LINK_LIBS} ${HDF5_LIBRARIES})
 
 


### PR DESCRIPTION
The former is deprecated for quite some time (at least since FindHDF5 3.0).
https://cmake.org/cmake/help/v3.5/module/FindHDF5.html

Kind of broke for me during the "tübingenhackathon" and the +d fixed it. 