### PR TITLE
Generic entity access methods for Block

### DIFF
--- a/backend/fs/BaseTagFS.cpp
+++ b/backend/fs/BaseTagFS.cpp
@@ -56,12 +56,7 @@ void BaseTagFS::createSubFolders(const std::shared_ptr<base::IFile> &file) {
 //--------------------------------------------------
 
 bool BaseTagFS::hasReference(const std::string &name_or_id) const {
-    std::string id = name_or_id;
-
-    if (!util::looksLikeUUID(name_or_id) && block()->hasEntity({name_or_id, ObjectType::DataArray})) {
-        id = block()->getEntity({name_or_id, ObjectType::DataArray})->id();
-    }
-
+    std::string id = block()->resolveEntityId({name_or_id, ObjectType::DataArray});
     return refs_group.hasObject(id);
 }
 
@@ -74,10 +69,7 @@ ndsize_t BaseTagFS::referenceCount() const {
 std::shared_ptr<base::IDataArray>  BaseTagFS::getReference(const std::string &name_or_id) const {
     std::shared_ptr<base::IDataArray> da;
 
-    std::string id = name_or_id;
-    if (!util::looksLikeUUID(name_or_id) && block()->hasEntity({name_or_id, ObjectType::DataArray})) {
-        id = block()->getEntity({name_or_id, ObjectType::DataArray})->id();
-    }
+    std::string id = block()->resolveEntityId({name_or_id, ObjectType::DataArray});
 
     if (hasReference(id)) {
         boost::optional<bfs::path> path = refs_group.findByNameOrAttribute("name", name_or_id);

--- a/backend/fs/BlockFS.cpp
+++ b/backend/fs/BlockFS.cpp
@@ -54,37 +54,180 @@ void nix::file::BlockFS::createSubFolders(const std::shared_ptr<base::IFile> &fi
 }
 
 //--------------------------------------------------
+// Generic access methods
+//--------------------------------------------------
+
+boost::optional<Directory> BlockFS::groupForObjectType(ObjectType type) const {
+    boost::optional<Directory> p;
+
+    switch (type) {
+    case ObjectType::DataArray:
+        p = data_array_dir;
+        break;
+    case ObjectType::Group:
+        p = group_dir;
+        break;
+    case ObjectType::MultiTag:
+        p = multi_tag_dir;
+        break;
+    case ObjectType::Source:
+        p = source_dir;
+        break;
+    case ObjectType::Tag:
+        p = tag_dir;
+        break;
+    default:
+        p = boost::optional<Directory>();
+    }
+
+    return p;
+}
+
+
+boost::optional<bfs::path> BlockFS::findEntityGroup(const nix::Identity &ident) const {
+    boost::optional<Directory> p = groupForObjectType(ident.type());
+
+    if (!p) {
+        return  boost::optional<bfs::path>();
+    }
+
+    boost::optional<bfs::path> g;
+    const std::string &iname = ident.name();
+    const std::string &iid = ident.id();
+
+    bool haveName = !iname.empty();
+    bool haveId = !iid.empty();
+
+    if (!haveName && !haveId) {
+        return g;
+    }
+
+    std::string needle = haveName ? iname : iid;
+    bool foundNeedle = p->hasObject(needle);
+
+    if (foundNeedle) {
+        g = boost::make_optional(bfs::path(p->location()) / needle);
+    } else if (haveId) {
+        g = p->findByNameOrAttribute("entity_id", iid);
+    }
+
+    if (g && haveName && haveId) {
+        std::string eid;
+        DirectoryWithAttributes temp(*g);
+        temp.getAttr("entity_id", eid);
+
+        if (eid != iid) {
+            return boost::optional<bfs::path>();
+        }
+    }
+
+    return g;
+}
+
+std::string BlockFS::resolveEntityId(const nix::Identity &ident) const {
+    if (!ident.id().empty()) {
+        return ident.id();
+    }
+
+    boost::optional<bfs::path> g = findEntityGroup(ident);
+    if (!g) {
+        return "";
+    }
+
+     std::string eid = "";
+     DirectoryWithAttributes temp(*g);
+     temp.getAttr("entity_id", eid);
+
+     return eid;
+}
+
+bool BlockFS::hasEntity(const nix::Identity &ident) const {
+    boost::optional<bfs::path> p = findEntityGroup(ident);
+    return !!p;
+}
+
+std::shared_ptr<base::IEntity> BlockFS::getEntity(const nix::Identity &ident) const {
+    boost::optional<bfs::path> eg = findEntityGroup(ident);
+
+    switch (ident.type()) {
+    case ObjectType::DataArray: {
+        std::shared_ptr<DataArrayFS> da;
+        if (eg) {
+            da = std::make_shared<DataArrayFS>(file(), block(), *eg);
+        }
+        return da;
+    }
+    case ObjectType::Tag: {
+        std::shared_ptr<TagFS> tag;
+        if (eg) {
+            tag = std::make_shared<TagFS>(file(), block(), eg->string());
+        }
+        return tag;
+    }
+    case ObjectType::MultiTag: {
+        std::shared_ptr<MultiTagFS> tag;
+        if (eg) {
+            tag = std::make_shared<MultiTagFS>(file(), block(), eg->string());
+        }
+        return tag;
+    }
+    case ObjectType::Group: {
+        std::shared_ptr<GroupFS> groups;
+        if (eg) {
+            groups = std::make_shared<GroupFS>(file(), block(), eg->string());
+        }
+        return groups;
+    }
+    case ObjectType::Source: {
+        std::shared_ptr<SourceFS> source;
+        if (eg) {
+            source = std::make_shared<SourceFS>(file(), block(), eg->string());
+        }
+        return source;
+    }
+    default:
+        return std::shared_ptr<base::IEntity>();
+    }
+
+    return std::shared_ptr<base::IEntity>();
+}
+
+std::shared_ptr<base::IEntity> BlockFS::getEntity(ObjectType type, ndsize_t index) const {
+    boost::optional<Directory> eg = groupForObjectType(type);
+    std::string full_path = eg ? eg->sub_dir_by_index(index).string() : "";
+    std::size_t pos = full_path.find_last_of(bfs::path::preferred_separator);      // position of "live" in str
+    if (pos == std::string::npos)
+        return getEntity({"", "", type});
+    std::string name = full_path.substr (pos+1);
+    return getEntity({name, "", type});
+}
+
+ndsize_t BlockFS::entityCount(ObjectType type) const {
+    boost::optional<Directory> g = groupForObjectType(type);
+    return g ? g->subdirCount() : ndsize_t(0);
+}
+
+bool BlockFS::removeEntity(const nix::Identity &ident) {
+    boost::optional<Directory> p = groupForObjectType(ident.type());
+    boost::optional<bfs::path> eg = findEntityGroup(ident);
+
+    if (!p || !eg) {
+        return false;
+    }
+
+    std::string name;
+    DirectoryWithAttributes temp(*eg);
+    temp.getAttr("name", name);
+    return p->removeObjectByNameOrAttribute("entity_id", name);
+}
+
+//--------------------------------------------------
 // Methods concerning sources
 //--------------------------------------------------
 
 bool BlockFS::hasSource(const std::string &name_or_id) const {
-    return getSource(name_or_id) != nullptr;
+    return hasEntity({name_or_id, ObjectType::Source});
 }
-
-
-std::shared_ptr<base::ISource> BlockFS::getSource(const std::string &name_or_id) const {
-    std::shared_ptr<base::ISource> source;
-    boost::optional<bfs::path> path = source_dir.findByNameOrAttribute("entity_id", name_or_id);
-    if (path) {
-        return std::make_shared<SourceFS>(file(), block(), path->string());
-    }
-    return source;
-}
-
-
-ndsize_t BlockFS::sourceCount() const {
-    return source_dir.subdirCount();
-}
-
-
-std::shared_ptr<base::ISource> BlockFS::getSource(ndsize_t index) const {
-    if (index >= sourceCount()) {
-        throw OutOfBounds("Trying to access block.source with invalid index.", index);
-    }
-    bfs::path p = source_dir.sub_dir_by_index(index);
-    return std::make_shared<SourceFS>(file(), block(), p.string());
-}
-
 
 std::shared_ptr<base::ISource> BlockFS::createSource(const std::string &name, const std::string &type) {
     if (name.empty()) {
@@ -106,41 +249,12 @@ bool BlockFS::deleteSource(const std::string &name_or_id) {
 // Methods concerning data arrays
 //--------------------------------------------------
 
-bool BlockFS::hasDataArray(const std::string &name_or_id) const {
-    return getDataArray(name_or_id) != nullptr;
-}
-
-
-std::shared_ptr<base::IDataArray> BlockFS::getDataArray(const std::string &name_or_id) const {
-    std::shared_ptr<base::IDataArray> array;
-    boost::optional<bfs::path> path = data_array_dir.findByNameOrAttribute("entity_id", name_or_id);
-    if (path) {
-        return std::make_shared<DataArrayFS>(file(), block(), path->string());
-    }
-    return array;
-}
-
-
-std::shared_ptr<base::IDataArray> BlockFS::getDataArray(ndsize_t index) const {
-    if (index >= dataArrayCount()) {
-        throw OutOfBounds("Trying to access block.dataArray with invalid index.", index);
-    }
-    bfs::path p = data_array_dir.sub_dir_by_index(index);
-    return std::make_shared<DataArrayFS>(file(), block(), p.string());
-}
-
-
-ndsize_t BlockFS::dataArrayCount() const {
-    return data_array_dir.subdirCount();
-}
-
-
 std::shared_ptr<base::IDataArray> BlockFS::createDataArray(const std::string &name, const std::string &type,
                                                            nix::DataType data_type, const NDSize &shape) {
     if (name.empty()) {
         throw EmptyString("Block::createDataArray empty name provided!");
     }
-    if (hasDataArray(name)) {
+    if (hasEntity({name, ObjectType::DataArray})) {
         throw DuplicateName("Block::createDataArray: an entity with the same name already exists!");
     }
     std::string id = util::createId();
@@ -149,93 +263,25 @@ std::shared_ptr<base::IDataArray> BlockFS::createDataArray(const std::string &na
     return std::make_shared<DataArrayFS>(da);
 }
 
-
-bool BlockFS::deleteDataArray(const std::string &name_or_id) {
-    return data_array_dir.removeObjectByNameOrAttribute("entity_id", name_or_id);
-}
-
 //--------------------------------------------------
 // Methods concerning tags
 //--------------------------------------------------
-
-bool BlockFS::hasTag(const std::string &name_or_id) const {
-    return getTag(name_or_id) != nullptr;
-}
-
-
-ndsize_t BlockFS::tagCount() const {
-    return tag_dir.subdirCount();
-}
-
-
-std::shared_ptr<base::ITag> BlockFS::getTag(const std::string &name_or_id) const {
-    std::shared_ptr<base::ITag> tag;
-    boost::optional<bfs::path> path = tag_dir.findByNameOrAttribute("entity_id", name_or_id);
-    if (path) {
-        return std::make_shared<TagFS>(file(), block(), path->string());
-    }
-    return tag;
-}
-
-
-std::shared_ptr<base::ITag> BlockFS::getTag(ndsize_t index) const {
-    if (index >= tagCount()) {
-        throw OutOfBounds("Trying to access block.tag with invalid index.", index);
-    }
-    boost::filesystem::path p = tag_dir.sub_dir_by_index(index);
-    return std::make_shared<TagFS>(file(), block(), p.string());
-}
-
 
 std::shared_ptr<base::ITag> BlockFS::createTag(const std::string &name, const std::string &type,
                                                const std::vector<double> &position) {
     if (name.empty()) {
         throw EmptyString("Block::createTag empty name provided!");
     }
-    if (hasTag(name)) {
+    if (hasEntity({name, ObjectType::Tag})) {
         throw DuplicateName("Block::createTag: an entity with the same name already exists!");
     }
     std::string id = util::createId();
     return std::make_shared<TagFS>(file(), block(), tag_dir.location(), id, type, name, position);
 }
 
-
-bool BlockFS::deleteTag(const std::string &name_or_id) {
-    return tag_dir.removeObjectByNameOrAttribute("entity_id", name_or_id);
-}
-
 //--------------------------------------------------
 // Methods concerning multi tags.
 //--------------------------------------------------
-
-bool BlockFS::hasMultiTag(const std::string &name_or_id) const {
-    return getMultiTag(name_or_id) != nullptr;
-}
-
-
-ndsize_t BlockFS::multiTagCount() const {
-    return multi_tag_dir.subdirCount();
-}
-
-
-std::shared_ptr<base::IMultiTag> BlockFS::getMultiTag(const std::string &name_or_id) const {
-    std::shared_ptr<base::IMultiTag> mtag;
-    boost::optional<bfs::path> path = multi_tag_dir.findByNameOrAttribute("entity_id", name_or_id);
-    if (path) {
-        return std::make_shared<MultiTagFS>(file(), block(), path->string());
-    }
-    return mtag;
-}
-
-
-std::shared_ptr<base::IMultiTag> BlockFS::getMultiTag(ndsize_t index) const {
-    if (index >= multiTagCount()) {
-        throw OutOfBounds("Trying to access block.multiTag with invalid index.", index);
-    }
-    bfs::path p = multi_tag_dir.sub_dir_by_index(index);
-    return std::make_shared<MultiTagFS>(file(), block(), p.string());
-}
-
 
 std::shared_ptr<base::IMultiTag> BlockFS::createMultiTag(const std::string &name, const std::string &type,
                                                          const DataArray &positions) {
@@ -245,65 +291,26 @@ std::shared_ptr<base::IMultiTag> BlockFS::createMultiTag(const std::string &name
     if (!positions) {
         throw UninitializedEntity();
     }
-    if (hasMultiTag(name)) {
+    if (hasEntity({name, ObjectType::MultiTag})) {
         throw DuplicateName("Block::createMultiTag: an entity with the same name already exists!");
     }
     std::string id = util::createId();
     return std::make_shared<MultiTagFS>(file(), block(), multi_tag_dir.location(), id, type, name, positions);
 }
 
-
-bool BlockFS::deleteMultiTag(const std::string &name_or_id) {
-    return multi_tag_dir.removeObjectByNameOrAttribute("entity_id", name_or_id);
-}
-
 //--------------------------------------------------
 // Methods concerning groups.
 //--------------------------------------------------
-
-bool BlockFS::hasGroup(const std::string &name_or_id) const {
-    return getGroup(name_or_id) != nullptr;
-}
-
-
-ndsize_t BlockFS::groupCount() const {
-    return group_dir.subdirCount();
-}
-
-
-std::shared_ptr<base::IGroup> BlockFS::getGroup(const std::string &name_or_id) const {
-    std::shared_ptr<base::IGroup> g;
-    boost::optional<bfs::path> path = group_dir.findByNameOrAttribute("entity_id", name_or_id);
-    if (path) {
-        return std::make_shared<GroupFS>(file(), block(), path->string());
-    }
-    return g;
-}
-
-
-std::shared_ptr<base::IGroup> BlockFS::getGroup(ndsize_t index) const {
-    if (index >= groupCount()) {
-        throw OutOfBounds("Trying to access block.group with invalid index.", index);
-    }
-    bfs::path p = group_dir.sub_dir_by_index(index);
-    return std::make_shared<GroupFS>(file(), block(), p.string());
-}
-
 
 std::shared_ptr<base::IGroup> BlockFS::createGroup(const std::string &name, const std::string &type) {
     if (name.empty()) {
         throw EmptyString("Block::createGroup empty name provided!");
     }
-    if (hasGroup(name)) {
+    if (hasEntity({name, ObjectType::Group})) {
         throw DuplicateName("Block::createGroup: an entity with the same name already exists!");
     }
     std::string id = util::createId();
     return std::make_shared<GroupFS>(file(), block(), group_dir.location(), id, type, name);
-}
-
-
-bool BlockFS::deleteGroup(const std::string &name_or_id) {
-    return group_dir.removeObjectByNameOrAttribute("entity_id", name_or_id);
 }
 
 

--- a/backend/fs/BlockFS.hpp
+++ b/backend/fs/BlockFS.hpp
@@ -33,6 +33,10 @@ private:
 
     void createSubFolders(const std::shared_ptr<base::IFile> &file);
 
+    // Helper methods for generic entity related methods below
+    boost::optional<Directory> groupForObjectType(ObjectType ot) const;
+
+    boost::optional<boost::filesystem::path> findEntityGroup(const nix::Identity &ident) const;
 public:
 
     /**
@@ -67,6 +71,23 @@ public:
     BlockFS(const std::shared_ptr<base::IFile> &file, const std::string &loc, const std::string &id, const std::string &type, const std::string &name, time_t time);
 
     //--------------------------------------------------
+    // Generic entity methods
+    //--------------------------------------------------
+    std::string resolveEntityId(const nix::Identity &ident) const;
+
+    bool hasEntity(const nix::Identity &ident) const;
+
+    std::shared_ptr<base::IEntity> getEntity(const nix::Identity &ident) const;
+
+    std::shared_ptr<base::IEntity> getEntity(ObjectType type, ndsize_t index) const;
+
+    ndsize_t entityCount(ObjectType type) const;
+
+    bool removeEntity(const nix::Identity &ident);
+
+    void addEntity(const nix::Identity &ident);
+
+    //--------------------------------------------------
     // Methods concerning sources
     //--------------------------------------------------
 
@@ -91,96 +112,34 @@ public:
     // Methods concerning data arrays
     //--------------------------------------------------
 
-    bool hasDataArray(const std::string &name_or_id) const;
-
-
-    std::shared_ptr<base::IDataArray> getDataArray(const std::string &name_or_id) const;
-
-
-    std::shared_ptr<base::IDataArray> getDataArray(ndsize_t index) const;
-
-
-    ndsize_t dataArrayCount() const;
-
-
     std::shared_ptr<base::IDataArray> createDataArray(const std::string &name, const std::string &type,
                                                       nix::DataType data_type, const NDSize &shape);
-
-
-    bool deleteDataArray(const std::string &name_or_id);
 
     //--------------------------------------------------
     // Methods concerning tags.
     //--------------------------------------------------
 
-    bool hasTag(const std::string &name_or_id) const;
-
-
-    std::shared_ptr<base::ITag> getTag(const std::string &name_or_id) const;
-
-
-    std::shared_ptr<base::ITag> getTag(ndsize_t index) const;
-
-
-    ndsize_t tagCount() const;
-
-
     std::shared_ptr<base::ITag> createTag(const std::string &name, const std::string &type,
                                           const std::vector<double> &position);
-
-
-    bool deleteTag(const std::string &name_or_id);
 
     //--------------------------------------------------
     // Methods concerning multi tags.
     //--------------------------------------------------
 
-    bool hasMultiTag(const std::string &name_or_id) const;
-
-
-    std::shared_ptr<base::IMultiTag> getMultiTag(const std::string &name_or_id) const;
-
-
-    std::shared_ptr<base::IMultiTag> getMultiTag(ndsize_t index) const;
-
-
-    ndsize_t multiTagCount() const;
-
-
     std::shared_ptr<base::IMultiTag> createMultiTag(const std::string &name, const std::string &type,
                                                     const DataArray &positions);
-
-
-    bool deleteMultiTag(const std::string &name_or_id);
 
     //--------------------------------------------------
     // Methods concerning groups.
     //--------------------------------------------------
 
-    bool hasGroup(const std::string &name_or_id) const;
-
-
-    std::shared_ptr<base::IGroup> getGroup(const std::string &name_or_id) const;
-
-
-    std::shared_ptr<base::IGroup> getGroup(ndsize_t index) const;
-
-
-    ndsize_t groupCount() const;
-
-
     std::shared_ptr<base::IGroup> createGroup(const std::string &name, const std::string &type);
-
-
-    bool deleteGroup(const std::string &name_or_id);
 
     //--------------------------------------------------
     // Other methods and functions
     //--------------------------------------------------
 
-
     virtual ~BlockFS();
-
 
     std::shared_ptr<base::IBlock> block() const;
 

--- a/backend/fs/FeatureFS.cpp
+++ b/backend/fs/FeatureFS.cpp
@@ -69,11 +69,11 @@ void FeatureFS::linkType(LinkType link_type) {
 void FeatureFS::data(const std::string &name_or_id) {
     if (name_or_id.empty())
         throw EmptyString("data(id)");
-    if (!block->hasDataArray(name_or_id))
+    if (!block->hasEntity({name_or_id, ObjectType::DataArray}))
         throw std::runtime_error("FeatureFS::data: DataArray not found in block!");
     if (hasObject("data"))
         removeObjectByNameOrAttribute("name", "data");
-    auto target = std::dynamic_pointer_cast<DataArrayFS>(block->getDataArray(name_or_id));
+    auto target = std::dynamic_pointer_cast<DataArrayFS>(block->getEntity({name_or_id, ObjectType::DataArray}));
     bfs::path p(location()), m("data");
     target->createLink(p / m);
     forceUpdatedAt();

--- a/backend/fs/GroupFS.cpp
+++ b/backend/fs/GroupFS.cpp
@@ -54,276 +54,141 @@ void GroupFS::createSubFolders(const std::shared_ptr<base::IFile> &file) {
 }
 
 
-bool GroupFS::hasDataArray(const std::string &name_or_id) const {
-    std::string id = name_or_id;
+boost::optional<Directory> GroupFS::groupForObjectType(ObjectType type) const {
+    boost::optional<Directory> p;
 
-    if (!util::looksLikeUUID(name_or_id) && block()->hasDataArray(name_or_id)) {
-        id = block()->getDataArray(name_or_id)->id();
+    switch (type) {
+    case ObjectType::DataArray:
+        p = data_array_group;
+        break;
+    case ObjectType::Tag:
+        p = tag_group;
+        break;
+    case ObjectType::MultiTag:
+        p = multi_tag_group;
+        break;
+    default:
+        p = boost::optional<Directory>();
     }
 
-    return data_array_group.hasObject(id);
+    return p;
 }
 
-
-ndsize_t GroupFS::dataArrayCount() const {
-    return data_array_group.subdirCount();
-}
-
-
-void GroupFS::addDataArray(const std::string &name_or_id) {
-    if (name_or_id.empty())
-        throw EmptyString("addDataArray");
-
-    if (!block()->hasDataArray(name_or_id))
-        throw std::runtime_error("GroupFS::addDataArray: DataArray not found in block!");
-
-    auto target = std::dynamic_pointer_cast<DataArrayFS>(block()->getDataArray(name_or_id));
-    data_array_group.createDirectoryLink(target->location(), target->id());
-}
-
-
-std::shared_ptr<base::IDataArray> GroupFS::getDataArray(const std::string &name_or_id) const {
-    std::shared_ptr<base::IDataArray> da;
-
-    std::string id = name_or_id;
-    if (!util::looksLikeUUID(name_or_id) && block()->hasDataArray(name_or_id)) {
-        id = block()->getDataArray(name_or_id)->id();
+boost::optional<bfs::path> GroupFS::findEntityGroup(const nix::Identity &ident) const {
+    boost::optional<Directory> p = groupForObjectType(ident.type());
+    if (!p) {
+        return  boost::optional<bfs::path>();
     }
 
-    if (hasDataArray(id)) {
-        boost::optional<bfs::path> path = data_array_group.findByNameOrAttribute("name", name_or_id);
-        if (path) {
-            return std::make_shared<DataArrayFS>(file(), block(), path->string());
+    boost::optional<bfs::path> g;
+    const std::string &iname = ident.name();
+    const std::string &iid = ident.id();
+
+    bool haveName = !iname.empty();
+    bool haveId = !iid.empty();
+
+    if (!haveName && !haveId) {
+        return g;
+    }
+    std::string needle = haveId ? iid : iname;
+    bool foundNeedle = p->hasObject(needle);
+
+    if (foundNeedle) {
+        g = boost::make_optional(bfs::path(p->location()) / needle);
+    } else if (haveName) {
+        g = p->findByNameOrAttribute("name", iname);
+    }
+
+    if (g && haveName && haveId) {
+        std::string ename;
+        DirectoryWithAttributes temp(*g);
+        temp.getAttr("name", ename);
+
+        if (ename != iname) {
+            return boost::optional<bfs::path>();
         }
     }
-    return da;
+
+    return g;
+}
+
+bool GroupFS::hasEntity(const nix::Identity &ident) const {
+    boost::optional<bfs::path> p = findEntityGroup(ident);
+    return !!p;
 }
 
 
-std::shared_ptr<base::IDataArray>  GroupFS::getDataArray(ndsize_t index) const {
-    if(index > dataArrayCount()) {
-        throw OutOfBounds("No reference at given index", index);
-    }
-    bfs::path p = data_array_group.sub_dir_by_index(index);
-    return std::make_shared<DataArrayFS>(file(), block(), p.string());
-}
+std::shared_ptr<base::IEntity> GroupFS::getEntity(const nix::Identity &ident) const {
+    boost::optional<bfs::path> eg = findEntityGroup(ident);
 
-
-bool GroupFS::removeDataArray(const std::string &name_or_id) {
-    return data_array_group.removeObjectByNameOrAttribute("name", name_or_id);
-}
-
-
-void GroupFS::dataArrays(const std::vector<DataArray> &data_arrays) {
-    auto cmp = [](const DataArray &a, const DataArray& b) { return a.name() < b.name(); };
-    std::vector<DataArray> new_arrays(data_arrays);
-    size_t array_count = nix::check::fits_in_size_t(dataArrayCount(), "dataArrayCount() failed; count > size_t.");
-
-    std::vector<DataArray> old_arrays(array_count);
-    for (size_t i = 0; i < old_arrays.size(); i++) {
-        old_arrays[i] = getDataArray(i);
-    }
-    std::sort(new_arrays.begin(), new_arrays.end(), cmp);
-    std::sort(old_arrays.begin(), old_arrays.end(), cmp);
-    std::vector<DataArray> add;
-    std::vector<DataArray> rem;
-    
-    std::set_difference(new_arrays.begin(), new_arrays.end(), old_arrays.begin(), old_arrays.end(),
-                        std::inserter(add, add.begin()), cmp);
-    std::set_difference(old_arrays.begin(), old_arrays.end(), new_arrays.begin(), new_arrays.end(),
-                        std::inserter(rem, rem.begin()), cmp);
-
-    auto blck = std::dynamic_pointer_cast<BlockFS>(block());
-    for (const auto &da : add) {
-        DataArray a = blck->getDataArray(da.name());
-        if (!a || a.id() != da.id())
-            throw std::runtime_error("One or more data arrays do not exist in this block!");
-        addDataArray(a.id());
-    }
-    for (const auto &da : rem) {
-        removeDataArray(da.id());
-    }
-}
-
-
-bool GroupFS::hasTag(const std::string &name_or_id) const {
-    std::string id = name_or_id;
-    if (!util::looksLikeUUID(name_or_id) && block()->hasTag(name_or_id)) {
-        id = block()->getTag(name_or_id)->id();
-    }
-    return tag_group.hasObject(id);
-}
-
-
-ndsize_t GroupFS::tagCount() const {
-    return tag_group.subdirCount();
-}
-
-
-void GroupFS::addTag(const std::string &name_or_id) {
-    if (name_or_id.empty())
-        throw EmptyString("addTag");
-
-    if (!block()->hasTag(name_or_id))
-        throw std::runtime_error("GroupFS::addTag: Tag not found in block!");
-
-    auto target = std::dynamic_pointer_cast<TagFS>(block()->getTag(name_or_id));
-    tag_group.createDirectoryLink(target->location(), target->id());
-}
-
-
-std::shared_ptr<base::ITag> GroupFS::getTag(const std::string &name_or_id) const {
-    std::shared_ptr<base::ITag> tag;
-
-    std::string id = name_or_id;
-    if (!util::looksLikeUUID(name_or_id) && block()->hasTag(name_or_id)) {
-        id = block()->getTag(name_or_id)->id();
-    }
-
-    if (hasTag(id)) {
-        boost::optional<bfs::path> path = tag_group.findByNameOrAttribute("name", name_or_id);
-        if (path) {
-            return std::make_shared<TagFS>(file(), block(), path->string());
+    switch (ident.type()) {
+    case ObjectType::DataArray: {
+        std::shared_ptr<DataArrayFS> da;
+        if (eg) {
+            da = std::make_shared<DataArrayFS>(file(), block(), *eg);
         }
+        return da;
     }
-    return tag;
-}
-
-
-std::shared_ptr<base::ITag>  GroupFS::getTag(ndsize_t index) const {
-    if(index > tagCount()) {
-        throw OutOfBounds("No tag at given index", index);
-    }
-    bfs::path p = tag_group.sub_dir_by_index(index);
-    return std::make_shared<TagFS>(file(), block(), p.string());
-}
-
-
-bool GroupFS::removeTag(const std::string &name_or_id) {
-    return tag_group.removeObjectByNameOrAttribute("name", name_or_id);
-}
-
-
-void GroupFS::tags(const std::vector<Tag> &tags) {
-    auto cmp = [](const Tag &a, const Tag& b) { return a.name() < b.name(); };
-    
-    std::vector<Tag> new_tags(tags); 
-    size_t tag_count = nix::check::fits_in_size_t(tagCount(), "tagCount() failed; count > size_t.");
-    std::vector<Tag> old_tags(tag_count);
-    for (size_t i = 0; i < old_tags.size(); i++) {
-        old_tags[i] = getTag(i);
-    }
-    std::sort(new_tags.begin(), new_tags.end(), cmp);
-    std::sort(old_tags.begin(), old_tags.end(), cmp);
-    std::vector<Tag> add;
-    std::vector<Tag> rem;
-    
-    std::set_difference(new_tags.begin(), new_tags.end(), old_tags.begin(), old_tags.end(),
-                        std::inserter(add, add.begin()), cmp);
-    std::set_difference(old_tags.begin(), old_tags.end(), new_tags.begin(), new_tags.end(),
-                        std::inserter(rem, rem.begin()), cmp);
-
-    auto blck = std::dynamic_pointer_cast<BlockFS>(block());
-    for (const auto &t : add) {
-        Tag tag = blck->getTag(t.name());
-        if (!tag || tag.id() != t.id())
-            throw std::runtime_error("One or more tags do not exist in this block!");
-        addTag(t.id());
-    }
-    for (const auto &t : rem) {
-        removeTag(t.id());
-    }
-}
-
-
-bool GroupFS::hasMultiTag(const std::string &name_or_id) const {
-    std::string id = name_or_id;
-    if (!util::looksLikeUUID(name_or_id) && block()->hasMultiTag(name_or_id)) {
-        id = block()->getMultiTag(name_or_id)->id();
-    }
-    return multi_tag_group.hasObject(id);
-}
-
-
-ndsize_t GroupFS::multiTagCount() const {
-    return multi_tag_group.subdirCount();
-}
-
-
-void GroupFS::addMultiTag(const std::string &name_or_id) {
-    if (name_or_id.empty())
-        throw EmptyString("addTag");
-
-    if (!block()->hasMultiTag(name_or_id))
-        throw std::runtime_error("GroupFS::addMultiTag: MultiTag not found in block!");
-
-    auto target = std::dynamic_pointer_cast<MultiTagFS>(block()->getMultiTag(name_or_id));
-    multi_tag_group.createDirectoryLink(target->location(), target->id());
-}
-
-
-std::shared_ptr<base::IMultiTag> GroupFS::getMultiTag(const std::string &name_or_id) const {
-    std::shared_ptr<base::IMultiTag> mtag;
-
-    std::string id = name_or_id;
-    if (!util::looksLikeUUID(name_or_id) && block()->hasMultiTag(name_or_id)) {
-        id = block()->getMultiTag(name_or_id)->id();
-    }
-
-    if (hasMultiTag(id)) {
-        boost::optional<bfs::path> path = multi_tag_group.findByNameOrAttribute("name", name_or_id);
-        if (path) {
-            return std::make_shared<MultiTagFS>(file(), block(), path->string());
+    case ObjectType::Tag: {
+        std::shared_ptr<TagFS> t;
+        if (eg) {
+            t = std::make_shared<TagFS>(file(), block(), eg->string());
         }
+        return t;
     }
-    return mtag;
+    case ObjectType::MultiTag: {
+        std::shared_ptr<MultiTagFS> t;
+        if (eg) {
+            t = std::make_shared<MultiTagFS>(file(), block(), eg->string());
+        }
+        return t;
+    }
+    default:
+        return std::shared_ptr<base::IEntity>();
+    }
 }
 
 
-std::shared_ptr<base::IMultiTag>  GroupFS::getMultiTag(ndsize_t index) const {
-    if(index > multiTagCount()) {
-        throw OutOfBounds("No multi tag at given index", index);
-    }
-    bfs::path p = multi_tag_group.sub_dir_by_index(index);
-    return std::make_shared<MultiTagFS>(file(), block(), p.string());
+std::shared_ptr<base::IEntity> GroupFS::getEntity(ObjectType type, ndsize_t index) const {
+    boost::optional<Directory> eg = groupForObjectType(type);
+    std::string name = eg ? eg->sub_dir_by_index(index).string() : "";
+    std::string full_path = eg ? eg->sub_dir_by_index(index).string() : "";
+    std::size_t pos = full_path.find_last_of(bfs::path::preferred_separator);      // position of "live" in str
+    if (pos == std::string::npos)
+        return getEntity({"", "", type});
+    std::string id = full_path.substr (pos+1);
+    return getEntity({id, "", type});
 }
 
 
-bool GroupFS::removeMultiTag(const std::string &name_or_id) {
-    return multi_tag_group.removeObjectByNameOrAttribute("name", name_or_id);
+ndsize_t GroupFS::entityCount(ObjectType type) const {
+    boost::optional<Directory> g = groupForObjectType(type);
+    return g ? g->subdirCount() : ndsize_t(0);
 }
 
 
-void GroupFS::multiTags(const std::vector<MultiTag> &multi_tags) {
-    auto cmp = [](const MultiTag &a, const MultiTag& b) { return a.name() < b.name(); };
-    std::vector<MultiTag> new_tags(multi_tags); 
-    size_t tag_count = nix::check::fits_in_size_t(multiTagCount(), "multiTagCount() failed; count > size_t.");
-    std::vector<MultiTag> old_tags(tag_count);
-    for (size_t i = 0; i < old_tags.size(); i++) {
-        old_tags[i] = getMultiTag(i);
+bool GroupFS::removeEntity(const nix::Identity &ident) {
+    boost::optional<Directory> p = groupForObjectType(ident.type());
+    bool have_name = ident.name() != "";
+    bool have_id = ident.id() != "";
+    if (!have_name && !have_id) {
+        return false;
     }
-    std::sort(new_tags.begin(), new_tags.end(), cmp);
-    std::sort(old_tags.begin(), old_tags.end(), cmp);
-    std::vector<MultiTag> add;
-    std::vector<MultiTag> rem;
-    
-    std::set_difference(new_tags.begin(), new_tags.end(), old_tags.begin(), old_tags.end(),
-                        std::inserter(add, add.begin()), cmp);
-    std::set_difference(old_tags.begin(), old_tags.end(), new_tags.begin(), new_tags.end(),
-                        std::inserter(rem, rem.begin()), cmp);
+    if (have_id) {
+        return p->removeObjectByNameOrAttribute("entity_id", ident.id());
+    }
+    return p->removeObjectByNameOrAttribute("name", ident.name());
+}
 
-    auto blck = std::dynamic_pointer_cast<BlockFS>(block());
-    for (const auto &t : add) {
-        MultiTag tag = blck->getMultiTag(t.name());
-        if (!tag || tag.id() != t.id())
-            throw std::runtime_error("One or more data multiTags do not exist in this block!");
-        addMultiTag(t.id());
+
+void GroupFS::addEntity(const nix::Identity &ident) {
+    boost::optional<Directory> p = groupForObjectType(ident.type());
+    if(!block()->hasEntity(ident)) {
+        throw std::runtime_error("Entity do not exist in this block!");
     }
-    for (const auto &t : rem) {
-        removeMultiTag(t.id());
-    }
+    auto target = std::dynamic_pointer_cast<EntityFS>(block()->getEntity(ident));
+    p->createDirectoryLink(target->location(), target->id());
 }
 
 } // file
 } // nix
-

--- a/backend/fs/GroupFS.hpp
+++ b/backend/fs/GroupFS.hpp
@@ -13,8 +13,6 @@
 #include "Directory.hpp"
 #include <nix/util/util.hpp>
 #include <nix/Group.hpp>
-#include "hdf5/DataArrayHDF5.hpp"
-
 
 namespace nix {
 namespace file {
@@ -31,8 +29,25 @@ private:
 
     void createSubFolders(const std::shared_ptr<base::IFile> &file);
 
+    // Helper methods for generic entity related methods below
+    boost::optional<Directory> groupForObjectType(ObjectType ot) const;
 
+    boost::optional<boost::filesystem::path> findEntityGroup(const nix::Identity &ident) const;
 public:
+    //--------------------------------------------------
+    // Generic entity methods
+    //--------------------------------------------------
+    bool hasEntity(const nix::Identity &ident) const;
+
+    std::shared_ptr<base::IEntity> getEntity(const nix::Identity &ident) const;
+
+    std::shared_ptr<base::IEntity> getEntity(ObjectType type, ndsize_t index) const;
+
+    ndsize_t entityCount(ObjectType type) const;
+
+    bool removeEntity(const nix::Identity &ident);
+
+    void addEntity(const nix::Identity &ident);
 
     /**
     * Standard constructor for an existing Group
@@ -51,78 +66,6 @@ public:
     GroupFS(const std::shared_ptr<base::IFile> &file, const std::shared_ptr<base::IBlock> &block, const std::string &loc, const std::string &id,
               const std::string &type, const std::string &name, const time_t time);
 
-
-    //--------------------------------------------------
-    // Methods concerning data arrays.
-    //--------------------------------------------------
-
-    virtual bool hasDataArray(const std::string &name_or_id) const;
-
-
-    virtual ndsize_t dataArrayCount() const;
-
-
-    virtual std::shared_ptr<base::IDataArray> getDataArray(const std::string &name_or_id) const;
-
-
-    virtual std::shared_ptr<base::IDataArray> getDataArray(ndsize_t index) const;
-
-
-    virtual void addDataArray(const std::string &name_or_id);
-
-
-    virtual bool removeDataArray(const std::string &name_or_id);
-
-    // TODO evaluate if DataArray can be replaced by shared_ptr<IDataArray>
-    virtual void dataArrays(const std::vector<DataArray> &data_arrays);
-
-    //--------------------------------------------------
-    // Methods concerning tags.
-    //--------------------------------------------------
-
-    virtual bool hasTag(const std::string &name_or_id) const;
-
-
-    virtual ndsize_t tagCount() const;
-
-
-    virtual std::shared_ptr<base::ITag> getTag(const std::string &name_or_id) const;
-
-
-    virtual std::shared_ptr<base::ITag> getTag(ndsize_t index) const;
-
-
-    virtual void addTag(const std::string &name_or_id);
-
-
-    virtual bool removeTag(const std::string &name_or_id);
-
-
-    virtual void tags(const std::vector<Tag> &tags);
-
-    //--------------------------------------------------
-    // Methods concerning multi tags.
-    //--------------------------------------------------
-
-    virtual bool hasMultiTag(const std::string &name_or_id) const;
-
-
-    virtual ndsize_t multiTagCount() const;
-
-
-    virtual std::shared_ptr<base::IMultiTag> getMultiTag(const std::string &name_or_id) const;
-
-
-    virtual std::shared_ptr<base::IMultiTag> getMultiTag(ndsize_t index) const;
-
-
-    virtual void addMultiTag(const std::string &name_or_id);
-
-
-    virtual bool removeMultiTag(const std::string &name_or_id);
-
-
-    virtual void multiTags(const std::vector<MultiTag> &multi_tags);
 };
 }
 }

--- a/backend/fs/MultiTagFS.cpp
+++ b/backend/fs/MultiTagFS.cpp
@@ -64,12 +64,12 @@ std::shared_ptr<base::IDataArray> MultiTagFS::positions() const {
 void MultiTagFS::positions(const std::string &name_or_id) {
     if (name_or_id.empty())
         throw EmptyString("positions");
-    if (!block()->hasDataArray(name_or_id))
+    if (!block()->hasEntity({name_or_id, ObjectType::DataArray}))
         throw std::runtime_error("MultiTagFS::positions: DataArray not found in block!");
     if (hasObject("positions"))
         removeObjectByNameOrAttribute("name", "positions");
 
-    auto target = std::dynamic_pointer_cast<DataArrayFS>(block()->getDataArray(name_or_id));
+    auto target = std::dynamic_pointer_cast<DataArrayFS>(block()->getEntity({name_or_id, ObjectType::DataArray}));
     bfs::path p(location()), m("positions");
     target->createLink(p / m);
     forceUpdatedAt();
@@ -97,15 +97,15 @@ std::shared_ptr<base::IDataArray>  MultiTagFS::extents() const {
 void MultiTagFS::extents(const std::string &name_or_id) {
     if (name_or_id.empty())
         throw EmptyString("extents");
-    if (!block()->hasDataArray(name_or_id))
+    if (!block()->hasEntity({name_or_id, ObjectType::DataArray}))
         throw std::runtime_error("MultiTagFS::extents: DataArray not found in block!");
     if (hasObject("extents"))
         removeObjectByNameOrAttribute("name", "extents");
-    DataArray da = block()->getDataArray(name_or_id);
+    DataArray da = std::dynamic_pointer_cast<base::IDataArray>(block()->getEntity({name_or_id, ObjectType::DataArray}));
     if (!checkDimensions(da, positions()))
         throw std::runtime_error("MultiTagFS::extents: cannot set Extent because dimensionality of extent and position data do not match!");
 
-    auto target = std::dynamic_pointer_cast<DataArrayFS>(block()->getDataArray(name_or_id));
+    auto target = std::dynamic_pointer_cast<DataArrayFS>(block()->getEntity({name_or_id, ObjectType::DataArray}));
     bfs::path p(location()), m("extents");
     target->createLink(p / m);
     forceUpdatedAt();

--- a/backend/hdf5/BlockHDF5.cpp
+++ b/backend/hdf5/BlockHDF5.cpp
@@ -300,38 +300,6 @@ bool BlockHDF5::deleteTag(const std::string &name_or_id) {
 //--------------------------------------------------
 
 
-bool BlockHDF5::hasDataArray(const string &name_or_id) const {
-    return getDataArray(name_or_id) != nullptr;
-}
-
-
-shared_ptr<IDataArray> BlockHDF5::getDataArray(const string &name_or_id) const {
-    shared_ptr<DataArrayHDF5> da;
-    boost::optional<H5Group> g = data_array_group();
-
-    if (g) {
-        boost::optional<H5Group> group = g->findGroupByNameOrAttribute("entity_id", name_or_id);
-        if (group)
-            da = make_shared<DataArrayHDF5>(file(), block(), *group);
-    }
-
-    return da;
-}
-
-
-shared_ptr<IDataArray> BlockHDF5::getDataArray(ndsize_t index) const {
-    boost::optional<H5Group> g = data_array_group();
-    string name = g ? g->objectName(index) : "";
-    return getDataArray(name);
-}
-
-
-ndsize_t BlockHDF5::dataArrayCount() const {
-    boost::optional<H5Group> g = data_array_group();
-    return g ? g->objectCount() : size_t(0);
-}
-
-
 shared_ptr<IDataArray> BlockHDF5::createDataArray(const std::string &name,
                                                   const std::string &type,
                                                   nix::DataType data_type,
@@ -346,20 +314,6 @@ shared_ptr<IDataArray> BlockHDF5::createDataArray(const std::string &name,
     da->createData(data_type, shape);
     return da;
 }
-
-
-bool BlockHDF5::deleteDataArray(const string &name_or_id) {
-    bool deleted = false;
-    boost::optional<H5Group> g = data_array_group();
-
-    if (hasDataArray(name_or_id) && g) {
-        // we get first "entity" link by name, but delete all others whatever their name with it
-        deleted = g->removeAllLinks(getDataArray(name_or_id)->name());
-    }
-
-    return deleted;
-}
-
 
 //--------------------------------------------------
 // Methods related to MultiTag

--- a/backend/hdf5/BlockHDF5.cpp
+++ b/backend/hdf5/BlockHDF5.cpp
@@ -108,6 +108,22 @@ boost::optional<H5Group> BlockHDF5::findEntityGroup(const nix::Identity &ident) 
     return g;
 }
 
+std::string BlockHDF5::resolveEntityId(const nix::Identity &ident) const {
+    if (!ident.id().empty()) {
+        return ident.id();
+    }
+
+    boost::optional<H5Group> g = findEntityGroup(ident);
+    if (!g) {
+        return "";
+    }
+
+     std::string eid = "";
+     g->getAttr("entity_id", eid);
+
+     return eid;
+}
+
 bool BlockHDF5::hasEntity(const nix::Identity &ident) const {
     boost::optional<H5Group> p = findEntityGroup(ident);
     return !!p;

--- a/backend/hdf5/BlockHDF5.cpp
+++ b/backend/hdf5/BlockHDF5.cpp
@@ -69,6 +69,10 @@ boost::optional<H5Group> BlockHDF5::groupForObjectType(ObjectType type) const {
         p = multi_tag_group();
         break;
 
+    case ObjectType::Group:
+        p = groups_group();
+        break;
+
     //TODO
     default:
        p = boost::optional<H5Group>();
@@ -163,6 +167,14 @@ std::shared_ptr<base::IEntity> BlockHDF5::getEntity(const nix::Identity &ident) 
             tag = make_shared<MultiTagHDF5>(file(), block(), *eg);
         }
         return tag;
+    }
+
+    case ObjectType::Group: {
+        shared_ptr<GroupHDF5> groups;
+        if (eg) {
+            groups = make_shared<GroupHDF5>(file(), block(), *eg);
+        }
+        return groups;
     }
 
     }
@@ -319,48 +331,6 @@ shared_ptr<IGroup> BlockHDF5::createGroup(const std::string &name, const std::st
 
     H5Group group = g->openGroup(name);
     return make_shared<GroupHDF5>(file(), block(), group, id, type, name);
-}
-
-
-    bool BlockHDF5::hasGroup(const string &name_or_id) const {
-    return getGroup(name_or_id) != nullptr;
-}
-
-
-shared_ptr<IGroup> BlockHDF5::getGroup(const string &name_or_id) const {
-    shared_ptr<GroupHDF5> group;
-    boost::optional<H5Group> g = groups_group();
-
-    if (g) {
-        boost::optional<H5Group> h5g = g->findGroupByNameOrAttribute("entity_id", name_or_id);
-        if (h5g)
-            group = make_shared<GroupHDF5>(file(), block(), *h5g);
-    }
-    return group;
-}
-
-
-shared_ptr<IGroup> BlockHDF5::getGroup(ndsize_t index) const {
-    boost::optional<H5Group> g = groups_group();
-    string name = g ? g->objectName(index) : "";
-    return getGroup(name);
-}
-
-
-ndsize_t BlockHDF5::groupCount() const {
-    boost::optional<H5Group> g = groups_group();
-    return g ? g->objectCount() : size_t(0);
-}
-
-
-bool BlockHDF5::deleteGroup(const std::string &name_or_id) {
-    boost::optional<H5Group> g = groups_group();
-    bool deleted = false;
-
-    if (hasGroup(name_or_id) && g) {
-        deleted = g->removeAllLinks(getGroup(name_or_id)->name());
-    }
-    return deleted;
 }
 
 

--- a/backend/hdf5/BlockHDF5.cpp
+++ b/backend/hdf5/BlockHDF5.cpp
@@ -50,7 +50,7 @@ BlockHDF5::BlockHDF5(const shared_ptr<IFile> &file, const H5Group &group, const 
 
 
 //--------------------------------------------------
-// Methods concerning sources
+// Generic access methods
 //--------------------------------------------------
 
 boost::optional<H5Group> BlockHDF5::groupForObjectType(ObjectType type) const {
@@ -231,7 +231,10 @@ bool BlockHDF5::removeEntity(const nix::Identity &ident) {
     return p->removeAllLinks(name);
 }
 
-//
+
+//--------------------------------------------------
+// Methods concerning sources
+//--------------------------------------------------
 
 shared_ptr<ISource> BlockHDF5::createSource(const string &name, const string &type) {
     string id = util::createId();

--- a/backend/hdf5/BlockHDF5.hpp
+++ b/backend/hdf5/BlockHDF5.hpp
@@ -90,6 +90,18 @@ public:
     // Methods concerning sources
     //--------------------------------------------------
 
+    bool hasSource(const std::string &name_or_id) const;
+
+
+    std::shared_ptr<base::ISource> getSource(const std::string &name_or_id) const;
+
+
+    std::shared_ptr<base::ISource> getSource(ndsize_t index) const;
+
+
+    ndsize_t sourceCount() const;
+
+
     std::shared_ptr<base::ISource> createSource(const std::string &name, const std::string &type);
 
 

--- a/backend/hdf5/BlockHDF5.hpp
+++ b/backend/hdf5/BlockHDF5.hpp
@@ -126,23 +126,8 @@ public:
     // Methods concerning multi tags.
     //--------------------------------------------------
 
-    bool hasMultiTag(const std::string &name_or_id) const;
-
-
-    std::shared_ptr<base::IMultiTag> getMultiTag(const std::string &name_or_id) const;
-
-
-    std::shared_ptr<base::IMultiTag> getMultiTag(ndsize_t index) const;
-
-
-    ndsize_t multiTagCount() const;
-
-
     std::shared_ptr<base::IMultiTag> createMultiTag(const std::string &name, const std::string &type,
                                                   const DataArray &positions);
-
-
-    bool deleteMultiTag(const std::string &name_or_id);
 
     //--------------------------------------------------
     // Methods concerning groups.

--- a/backend/hdf5/BlockHDF5.hpp
+++ b/backend/hdf5/BlockHDF5.hpp
@@ -90,18 +90,6 @@ public:
     // Methods concerning sources
     //--------------------------------------------------
 
-    bool hasSource(const std::string &name_or_id) const;
-
-
-    std::shared_ptr<base::ISource> getSource(const std::string &name_or_id) const;
-
-
-    std::shared_ptr<base::ISource> getSource(ndsize_t index) const;
-
-
-    ndsize_t sourceCount() const;
-
-
     std::shared_ptr<base::ISource> createSource(const std::string &name, const std::string &type);
 
 
@@ -132,18 +120,6 @@ public:
     //--------------------------------------------------
     // Methods concerning groups.
     //--------------------------------------------------
-
-    bool hasGroup(const std::string &name_or_id) const;
-
-
-    std::shared_ptr<base::IGroup> getGroup(const std::string &name_or_id) const;
-
-
-    std::shared_ptr<base::IGroup> getGroup(ndsize_t index) const;
-
-
-    ndsize_t groupCount() const;
-
 
     std::shared_ptr<base::IGroup> createGroup(const std::string &name, const std::string &type);
 

--- a/backend/hdf5/BlockHDF5.hpp
+++ b/backend/hdf5/BlockHDF5.hpp
@@ -119,23 +119,8 @@ public:
     // Methods concerning tags.
     //--------------------------------------------------
 
-    bool hasTag(const std::string &name_or_id) const;
-
-
-    std::shared_ptr<base::ITag> getTag(const std::string &name_or_id) const;
-
-
-    std::shared_ptr<base::ITag> getTag(ndsize_t index) const;
-
-
-    ndsize_t tagCount() const;
-
-
     std::shared_ptr<base::ITag> createTag(const std::string &name, const std::string &type,
                                                       const std::vector<double> &position);
-
-
-    bool deleteTag(const std::string &name_or_id);
 
     //--------------------------------------------------
     // Methods concerning multi tags.

--- a/backend/hdf5/BlockHDF5.hpp
+++ b/backend/hdf5/BlockHDF5.hpp
@@ -92,7 +92,7 @@ public:
 
     bool hasSource(const std::string &name_or_id) const;
 
-    
+
     std::shared_ptr<base::ISource> getSource(const std::string &name_or_id) const;
 
 
@@ -111,23 +111,9 @@ public:
     // Methods concerning data arrays
     //--------------------------------------------------
 
-    bool hasDataArray(const std::string &name_or_id) const;
-
-
-    std::shared_ptr<base::IDataArray> getDataArray(const std::string &name_or_id) const;
-
-    
-    std::shared_ptr<base::IDataArray> getDataArray(ndsize_t index) const;
-
-
-    ndsize_t dataArrayCount() const;
-
-
     std::shared_ptr<base::IDataArray> createDataArray(const std::string &name, const std::string &type,
                                                       nix::DataType data_type, const NDSize &shape);
 
-
-    bool deleteDataArray(const std::string &name_or_id);
 
     //--------------------------------------------------
     // Methods concerning tags.

--- a/backend/hdf5/BlockHDF5.hpp
+++ b/backend/hdf5/BlockHDF5.hpp
@@ -73,6 +73,7 @@ public:
     //--------------------------------------------------
     // Generic entity methods
     //--------------------------------------------------
+    std::string resolveEntityId(const nix::Identity &ident) const;
 
     bool hasEntity(const nix::Identity &ident) const;
 

--- a/backend/hdf5/BlockHDF5.hpp
+++ b/backend/hdf5/BlockHDF5.hpp
@@ -62,6 +62,29 @@ public:
      */
     BlockHDF5(const std::shared_ptr<base::IFile> &file, const H5Group &group, const std::string &id, const std::string &type, const std::string &name, time_t time);
 
+
+private:
+    // Helper methods for generic entity related methods below
+    boost::optional<H5Group> groupForObjectType(ObjectType ot) const;
+
+    boost::optional<H5Group> findEntityGroup(const nix::Identity &ident) const;
+
+public:
+    //--------------------------------------------------
+    // Generic entity methods
+    //--------------------------------------------------
+
+    bool hasEntity(const nix::Identity &ident) const;
+
+    std::shared_ptr<base::IEntity> getEntity(const nix::Identity &ident) const;
+
+    std::shared_ptr<base::IEntity> getEntity(ObjectType type, ndsize_t index) const;
+
+    ndsize_t entityCount(ObjectType type) const;
+
+    bool removeEntity(const nix::Identity &ident);
+
+
     //--------------------------------------------------
     // Methods concerning sources
     //--------------------------------------------------

--- a/backend/hdf5/FeatureHDF5.cpp
+++ b/backend/hdf5/FeatureHDF5.cpp
@@ -69,14 +69,15 @@ void FeatureHDF5::linkType(LinkType link_type) {
 
 
 void FeatureHDF5::data(const std::string &name_or_id) {
-    if (!block->hasDataArray(name_or_id)) {
+    std::shared_ptr<IDataArray> ida = block->getEntity<IDataArray>(name_or_id);
+    if (!ida) {
         throw std::runtime_error("FeatureHDF5::data: DataArray not found in block!");
     }
     if (group().hasGroup("data")) {
         group().removeGroup("data");
     }
-    
-    auto target = dynamic_pointer_cast<DataArrayHDF5>(block->getDataArray(name_or_id));
+
+    auto target = dynamic_pointer_cast<DataArrayHDF5>(ida);
 
     group().createLink(target->group(), "data");
     forceUpdatedAt();
@@ -89,7 +90,7 @@ shared_ptr<IDataArray> FeatureHDF5::data() const {
     if (group().hasGroup("data")) {
         H5Group other_group = group().openGroup("data", false);
         da = make_shared<DataArrayHDF5>(file(), block, other_group);
-        if (!block->hasDataArray(da->id())) {
+        if (!block->hasEntity(da)) {
             throw std::runtime_error("FeatureHDF5::data: DataArray not found!");
         }
     }

--- a/backend/hdf5/GroupHDF5.cpp
+++ b/backend/hdf5/GroupHDF5.cpp
@@ -43,10 +43,7 @@ GroupHDF5::GroupHDF5(const std::shared_ptr<base::IFile> &file, const std::shared
 
 
 bool GroupHDF5::hasDataArray(const std::string &name_or_id) const {
-    std::string id = name_or_id;
-    if (!util::looksLikeUUID(name_or_id) && block()->hasDataArray(name_or_id)) {
-        id = block()->getDataArray(name_or_id)->id();
-    }
+    std::string id = block()->resolveEntityId({name_or_id, ObjectType::DataArray});
     return data_array_group(false) ? data_array_group(false)->hasGroup(id) : false;
 }
 
@@ -59,11 +56,12 @@ ndsize_t GroupHDF5::dataArrayCount() const {
 
 void GroupHDF5::addDataArray(const std::string &name_or_id) {
     boost::optional<H5Group> g = data_array_group(true);
+    std::shared_ptr<IDataArray> ida = block()->getEntity<IDataArray>(name_or_id);
 
-    if (!block()->hasDataArray(name_or_id))
+    if (!ida)
         throw std::runtime_error("GroupHDF5::addDataArray: DataArray not found in block!");
 
-    auto target = std::dynamic_pointer_cast<DataArrayHDF5>(block()->getDataArray(name_or_id));
+    auto target = std::dynamic_pointer_cast<DataArrayHDF5>(ida);
     g->createLink(target->group(), target->id());
 }
 
@@ -71,10 +69,7 @@ void GroupHDF5::addDataArray(const std::string &name_or_id) {
 std::shared_ptr<base::IDataArray> GroupHDF5::getDataArray(const std::string &name_or_id) const {
     std::shared_ptr<IDataArray> da;
     boost::optional<H5Group> g = data_array_group(false);
-    std::string id = name_or_id;
-    if (!util::looksLikeUUID(name_or_id) && block()->hasDataArray(name_or_id)) {
-        id = block()->getDataArray(name_or_id)->id();
-    }
+    std::string id = block()->resolveEntityId({name_or_id, ObjectType::DataArray});
 
     if (g && hasDataArray(id)) {
         H5Group h5g = g->openGroup(id);
@@ -107,8 +102,8 @@ bool GroupHDF5::removeDataArray(const std::string &name_or_id) {
 
 void GroupHDF5::dataArrays(const std::vector<DataArray> &data_arrays) {
     auto cmp = [](const DataArray &a, const DataArray& b) { return a.name() < b.name(); };
-    
-    std::vector<DataArray> new_arrays(data_arrays); 
+
+    std::vector<DataArray> new_arrays(data_arrays);
     size_t array_count = nix::check::fits_in_size_t(dataArrayCount(), "dataArrayCount() failed; count > size_t.");
     std::vector<DataArray> old_arrays(array_count);
     for (size_t i = 0; i < old_arrays.size(); i++) {
@@ -118,16 +113,15 @@ void GroupHDF5::dataArrays(const std::vector<DataArray> &data_arrays) {
     std::sort(old_arrays.begin(), old_arrays.end(), cmp);
     std::vector<DataArray> add;
     std::vector<DataArray> rem;
-    
+
     std::set_difference(new_arrays.begin(), new_arrays.end(), old_arrays.begin(), old_arrays.end(),
                         std::inserter(add, add.begin()), cmp);
     std::set_difference(old_arrays.begin(), old_arrays.end(), new_arrays.begin(), new_arrays.end(),
                         std::inserter(rem, rem.begin()), cmp);
 
-    auto blck = std::dynamic_pointer_cast<BlockHDF5>(block());
     for (const auto &da : add) {
-        DataArray a = blck->getDataArray(da.name());
-        if (!a || a.id() != da.id())
+        DataArray a = block()->getEntity<base::IDataArray>(da);
+        if (!a)
             throw std::runtime_error("One or more data arrays do not exist in this block!");
         addDataArray(a.id());
     }
@@ -203,8 +197,8 @@ bool GroupHDF5::removeTag(const std::string &name_or_id) {
 
 void GroupHDF5::tags(const std::vector<Tag> &tags) {
     auto cmp = [](const Tag &a, const Tag& b) { return a.name() < b.name(); };
-    
-    std::vector<Tag> new_tags(tags); 
+
+    std::vector<Tag> new_tags(tags);
     size_t tag_count = nix::check::fits_in_size_t(tagCount(), "tagCount() failed; count > size_t.");
     std::vector<Tag> old_tags(tag_count);
     for (size_t i = 0; i < old_tags.size(); i++) {
@@ -214,7 +208,7 @@ void GroupHDF5::tags(const std::vector<Tag> &tags) {
     std::sort(old_tags.begin(), old_tags.end(), cmp);
     std::vector<Tag> add;
     std::vector<Tag> rem;
-    
+
     std::set_difference(new_tags.begin(), new_tags.end(), old_tags.begin(), old_tags.end(),
                         std::inserter(add, add.begin()), cmp);
     std::set_difference(old_tags.begin(), old_tags.end(), new_tags.begin(), new_tags.end(),
@@ -299,8 +293,8 @@ bool GroupHDF5::removeMultiTag(const std::string &name_or_id) {
 
 void GroupHDF5::multiTags(const std::vector<MultiTag> &multi_tags) {
     auto cmp = [](const MultiTag &a, const MultiTag& b) { return a.name() < b.name(); };
-    
-    std::vector<MultiTag> new_tags(multi_tags); 
+
+    std::vector<MultiTag> new_tags(multi_tags);
     size_t tag_count = nix::check::fits_in_size_t(multiTagCount(), "multiTagCount() failed; count > size_t.");
     std::vector<MultiTag> old_tags(tag_count);
     for (size_t i = 0; i < old_tags.size(); i++) {
@@ -310,7 +304,7 @@ void GroupHDF5::multiTags(const std::vector<MultiTag> &multi_tags) {
     std::sort(old_tags.begin(), old_tags.end(), cmp);
     std::vector<MultiTag> add;
     std::vector<MultiTag> rem;
-    
+
     std::set_difference(new_tags.begin(), new_tags.end(), old_tags.begin(), old_tags.end(),
                         std::inserter(add, add.begin()), cmp);
     std::set_difference(old_tags.begin(), old_tags.end(), new_tags.begin(), new_tags.end(),

--- a/backend/hdf5/GroupHDF5.hpp
+++ b/backend/hdf5/GroupHDF5.hpp
@@ -61,29 +61,6 @@ public:
      */
     GroupHDF5(const std::shared_ptr<base::IFile> &file, const std::shared_ptr<base::IBlock> &block, const H5Group &h5group,
               const std::string &id, const std::string &type, const std::string &name, time_t time);
-    //--------------------------------------------------
-    // Methods concerning multi tags.
-    //--------------------------------------------------
-
-    virtual bool hasMultiTag(const std::string &name_or_id) const;
-
-
-    virtual ndsize_t multiTagCount() const;
-
-
-    virtual std::shared_ptr<base::IMultiTag> getMultiTag(const std::string &name_or_id) const;
-
-
-    virtual std::shared_ptr<base::IMultiTag> getMultiTag(ndsize_t index) const;
-
-
-    virtual void addMultiTag(const std::string &name_or_id);
-
-
-    virtual bool removeMultiTag(const std::string &name_or_id);
-
-
-    virtual void multiTags(const std::vector<MultiTag> &multi_tags);
 };
 }
 }

--- a/backend/hdf5/GroupHDF5.hpp
+++ b/backend/hdf5/GroupHDF5.hpp
@@ -23,7 +23,28 @@ private:
 
     optGroup data_array_group, tag_group, multi_tag_group;
 
+
+    // Helper methods for generic entity related methods below
+    boost::optional<H5Group> groupForObjectType(ObjectType ot) const;
+
+    boost::optional<H5Group> findEntityGroup(const nix::Identity &ident) const;
+
 public:
+
+    //--------------------------------------------------
+    // Generic entity methods
+    //--------------------------------------------------
+    bool hasEntity(const nix::Identity &ident) const ;
+
+    std::shared_ptr<base::IEntity> getEntity(const nix::Identity &ident) const;
+
+    std::shared_ptr<base::IEntity> getEntity(ObjectType type, ndsize_t index) const;
+
+    ndsize_t entityCount(ObjectType type) const;
+
+    bool removeEntity(const nix::Identity &ident);
+
+    void addEntity(const nix::Identity &ident);
     /**
      * Standard constructor for existing Group
      */
@@ -40,31 +61,6 @@ public:
      */
     GroupHDF5(const std::shared_ptr<base::IFile> &file, const std::shared_ptr<base::IBlock> &block, const H5Group &h5group,
               const std::string &id, const std::string &type, const std::string &name, time_t time);
-
-
-    //--------------------------------------------------
-    // Methods concerning data arrays.
-    //--------------------------------------------------
-
-    virtual bool hasDataArray(const std::string &name_or_id) const;
-
-
-    virtual ndsize_t dataArrayCount() const;
-
-
-    virtual std::shared_ptr<base::IDataArray> getDataArray(const std::string &name_or_id) const;
-
-
-    virtual std::shared_ptr<base::IDataArray> getDataArray(ndsize_t index) const;
-
-
-    virtual void addDataArray(const std::string &name_or_id);
-
-
-    virtual bool removeDataArray(const std::string &name_or_id);
-
-    // TODO evaluate if DataArray can be replaced by shared_ptr<IDataArray>
-    virtual void dataArrays(const std::vector<DataArray> &data_arrays);
 
     //--------------------------------------------------
     // Methods concerning tags.

--- a/backend/hdf5/GroupHDF5.hpp
+++ b/backend/hdf5/GroupHDF5.hpp
@@ -61,31 +61,6 @@ public:
      */
     GroupHDF5(const std::shared_ptr<base::IFile> &file, const std::shared_ptr<base::IBlock> &block, const H5Group &h5group,
               const std::string &id, const std::string &type, const std::string &name, time_t time);
-
-    //--------------------------------------------------
-    // Methods concerning tags.
-    //--------------------------------------------------
-
-    virtual bool hasTag(const std::string &name_or_id) const;
-
-
-    virtual ndsize_t tagCount() const;
-
-
-    virtual std::shared_ptr<base::ITag> getTag(const std::string &name_or_id) const;
-
-
-    virtual std::shared_ptr<base::ITag> getTag(ndsize_t index) const;
-
-
-    virtual void addTag(const std::string &name_or_id);
-
-
-    virtual bool removeTag(const std::string &name_or_id);
-
-
-    virtual void tags(const std::vector<Tag> &tags);
-
     //--------------------------------------------------
     // Methods concerning multi tags.
     //--------------------------------------------------

--- a/docs/inheritance.txt
+++ b/docs/inheritance.txt
@@ -1,0 +1,39 @@
+Backend Interfaces
+------------------
+  IEntity
+    INamedEntity
+      IEntityWithMetadata
+        IEntityWithSources
+          IFile
+          IBlock
+          IGroup
+          ...
+
+Backend Implementation
+----------------------
+  EntityHDF5                    : *IEntity
+    NamedEntityHDF5             :   *INamedEnity$
+      EntityWithMetadataHDF5    :     *IEntityWithMetadata
+        EntityWithSourceHDF5    :       *IEntityWithSources
+          FileHDF5  : H5Object  :         *IFile
+          BlockHDF5             :         *IBlock
+
+Diamond Pattern:
+  $ NamedEntityHdf5 : [ EntityHDF5<> : IEntity# ]
+        INamedEnity : [                IEntity# ]
+
+Frontend
+--------
+ImplContainer<T> { shared_ptr<T> impl_ptr; }
+  Entity<T>
+    NamedEntity<T>
+      EntityWithMetadata<T>
+        EntityWouthSources<T>
+          File<IFile>
+          Block<IBlock>
+          Group<IGroup>
+          ...
+
+ImplContainer holds the specific backend implementation of the corresponding
+interface, i.e FileHDF5 for the IFile:
+  ImplContainer<IFile> { shared_ptr<IFile = FileHDF5> impl_ptr }

--- a/include/nix/Block.hpp
+++ b/include/nix/Block.hpp
@@ -802,6 +802,7 @@ template<>
 struct objectToType<Block> {
     static const bool isValid = true;
     static const ObjectType value = ObjectType::Block;
+    typedef nix::base::IBlock backendType;
 };
 
 }

--- a/include/nix/Block.hpp
+++ b/include/nix/Block.hpp
@@ -146,7 +146,7 @@ public:
      *         otherwise.
      */
     bool hasSource(const std::string &name_or_id) const {
-        return backend()->hasSource(name_or_id);
+        return backend()->hasEntity({name_or_id, ObjectType::Source});
     }
 
     /**
@@ -157,7 +157,12 @@ public:
      * @return True if the source exists at the root, false
      *         otherwise.
      */
-    bool hasSource(const Source &source) const;
+    bool hasSource(const Source &source) const {
+        if (!util::checkEntityInput(source, false)) {
+            return false;
+        }
+        return backend()->hasEntity(source);
+    }
 
     /**
      * @brief Retrieves a specific root source by its id.
@@ -168,7 +173,7 @@ public:
      *         will be thrown.
      */
     Source getSource(const std::string &name_or_id) const {
-        return backend()->getSource(name_or_id);
+        return backend()->getEntity<base::ISource>(name_or_id);
     }
 
     /**
@@ -178,7 +183,12 @@ public:
      *
      * @return The source at the specified index.
      */
-    Source getSource(ndsize_t index) const;
+    Source getSource(ndsize_t index) const {
+        if (index >= sourceCount()) {
+            throw OutOfBounds("Block::getSource: index is out of bounds!");
+        }
+        return backend()->getEntity<base::ISource>(index);
+    }
 
     /**
      * @brief Returns the number of root sources in this block.
@@ -186,7 +196,7 @@ public:
      * @return The number of root sources.
      */
     ndsize_t sourceCount() const {
-        return backend()->sourceCount();
+        return backend()->entityCount(ObjectType::Source);
     }
 
     /**

--- a/include/nix/Block.hpp
+++ b/include/nix/Block.hpp
@@ -425,7 +425,7 @@ public:
      * @return True if the tag exists, false otherwise.
      */
     bool hasTag(const std::string &name_or_id) const {
-        return backend()->hasTag(name_or_id);
+        return backend()->hasEntity({name_or_id, ObjectType::Tag});
     }
 
     /**
@@ -435,7 +435,12 @@ public:
     *
     * @return True if the tag exists, false otherwise.
     */
-    bool hasTag(const Tag &tag) const;
+    bool hasTag(const Tag &tag) const {
+        if (!util::checkEntityInput(tag, false)) {
+            return false;
+        }
+        return backend()->hasEntity(tag);
+    }
 
     /**
      * @brief Retrieves a specific tag from the block by its id.
@@ -446,7 +451,7 @@ public:
      *         an exception will be thrown.
      */
     Tag getTag(const std::string &name_or_id) const {
-        return backend()->getTag(name_or_id);
+        return backend()->getEntity<base::ITag>(name_or_id);
     }
 
     /**
@@ -456,7 +461,12 @@ public:
      *
      * @return The tag at the specified index.
      */
-    Tag getTag(ndsize_t index) const;
+    Tag getTag(ndsize_t index) const {
+        if (index >= tagCount()) {
+            throw OutOfBounds("Block::getTag: index is out of bounds!");
+        }
+        return backend()->getEntity<base::ITag>(index);
+    }
 
     /**
      * @brief Get tags within this block.
@@ -477,7 +487,7 @@ public:
      * @return The number of tags.
      */
     ndsize_t tagCount() const {
-        return backend()->tagCount();
+        return backend()->entityCount(ObjectType::Tag);
     }
 
     /**
@@ -503,7 +513,7 @@ public:
      * @return True if the tag was removed, false otherwise.
      */
     bool deleteTag(const std::string &name_or_id) {
-        return backend()->deleteTag(name_or_id);
+        return backend()->removeEntity({name_or_id, ObjectType::Tag});
     }
 
     /**
@@ -516,7 +526,12 @@ public:
     *
     * @return True if the tag was removed, false otherwise.
     */
-    bool deleteTag(const Tag &tag);
+    bool deleteTag(const Tag &tag) {
+        if (!util::checkEntityInput(tag, false)) {
+            return false;
+        }
+        return backend()->removeEntity(tag);
+    }
 
     //--------------------------------------------------
     // Methods concerning multi tags.

--- a/include/nix/Block.hpp
+++ b/include/nix/Block.hpp
@@ -545,7 +545,7 @@ public:
      * @return True if the multi tag exists, false otherwise.
      */
     bool hasMultiTag(const std::string &name_or_id) const {
-        return backend()->hasMultiTag(name_or_id);
+        return backend()->hasEntity({name_or_id, ObjectType::MultiTag});
     }
 
     /**
@@ -555,7 +555,12 @@ public:
     *
     * @return True if the multi tag exists, false otherwise.
     */
-    bool hasMultiTag(const MultiTag &multi_tag) const;
+    bool hasMultiTag(const MultiTag &multi_tag) const {
+        if (!util::checkEntityInput(multi_tag, false)) {
+            return false;
+        }
+        return backend()->hasEntity(multi_tag);
+    }
 
     /**
      * @brief Retrieves a specific multi tag from the block by its id.
@@ -566,7 +571,7 @@ public:
      *         an exception will be thrown.
      */
     MultiTag getMultiTag(const std::string &name_or_id) const {
-        return backend()->getMultiTag(name_or_id);
+        return backend()->getEntity<base::IMultiTag>(name_or_id);
     }
 
     /**
@@ -576,7 +581,12 @@ public:
      *
      * @return The multi tag at the specified index.
      */
-    MultiTag getMultiTag(ndsize_t index) const;
+    MultiTag getMultiTag(ndsize_t index) const {
+        if (index >= multiTagCount()) {
+            throw OutOfBounds("Block::getMultiTag: index is out of bounds!");
+        }
+        return backend()->getEntity<base::IMultiTag>(index);
+    }
 
     /**
      * @brief Get multi tags within this block.
@@ -597,7 +607,7 @@ public:
      * @return The number of multi tags.
      */
     ndsize_t multiTagCount() const {
-        return backend()->multiTagCount();
+        return backend()->entityCount(ObjectType::MultiTag);
     }
 
     /**
@@ -623,7 +633,7 @@ public:
      * @return True if the tag was removed, false otherwise.
      */
     bool deleteMultiTag(const std::string &name_or_id) {
-        return backend()->deleteMultiTag(name_or_id);
+        return backend()->removeEntity({name_or_id, ObjectType::MultiTag});
     }
 
     /**
@@ -636,7 +646,12 @@ public:
     *
     * @return True if the tag was removed, false otherwise.
     */
-    bool deleteMultiTag(const MultiTag &multi_tag);
+    bool deleteMultiTag(const MultiTag &multi_tag) {
+        if (!util::checkEntityInput(multi_tag, false)) {
+            return false;
+        }
+        return backend()->removeEntity(multi_tag);
+    }
 
     //--------------------------------------------------
     // Methods concerning groups

--- a/include/nix/Block.hpp
+++ b/include/nix/Block.hpp
@@ -314,6 +314,9 @@ public:
      * @return The data array at the specified index.
      */
     DataArray getDataArray(ndsize_t index) const {
+        if (index >= dataArrayCount()) {
+            throw OutOfBounds("Block::getDataArray: index is out of bounds!");
+        }
         return backend()->getEntity<base::IDataArray>(index);
     }
 

--- a/include/nix/Block.hpp
+++ b/include/nix/Block.hpp
@@ -304,6 +304,9 @@ public:
      * @return The data array at the specified index.
      */
     DataArray getDataArray(ndsize_t index) const {
+        if (index >= dataArrayCount()) {
+            throw OutOfBounds("Block::getDataArray: index is out of bounds!");
+        }
         return getEntity<base::IDataArray>(index);
     }
 

--- a/include/nix/Block.hpp
+++ b/include/nix/Block.hpp
@@ -292,7 +292,7 @@ public:
      *         doesn't exist, an exception will be thrown.
      */
     DataArray getDataArray(const std::string &name_or_id) const {
-        return getEntity<base::IDataArray>(name_or_id);
+        return backend()->getEntity<base::IDataArray>(name_or_id);
     }
 
 
@@ -307,7 +307,7 @@ public:
         if (index >= dataArrayCount()) {
             throw OutOfBounds("Block::getDataArray: index is out of bounds!");
         }
-        return getEntity<base::IDataArray>(index);
+        return backend()->getEntity<base::IDataArray>(index);
     }
 
     /**
@@ -743,19 +743,6 @@ public:
      * @brief Output operator
      */
     NIXAPI friend std::ostream &operator<<(std::ostream &out, const Block &ent);
-
- private:
-    template<typename T>
-    std::shared_ptr<T> getEntity(const std::string &name_or_id) const {
-        ObjectType ot = objectToType<T>::value;
-        return std::dynamic_pointer_cast<T>(backend()->getEntity({name_or_id, ot}));
-    }
-
-    template<typename T>
-    std::shared_ptr<T> getEntity(ndsize_t index) const {
-        ObjectType ot = objectToType<T>::value;
-        return std::dynamic_pointer_cast<T>(backend()->getEntity(ot, index));
-    }
 };
 
 template<>

--- a/include/nix/Block.hpp
+++ b/include/nix/Block.hpp
@@ -314,9 +314,6 @@ public:
      * @return The data array at the specified index.
      */
     DataArray getDataArray(ndsize_t index) const {
-        if (index >= dataArrayCount()) {
-            throw OutOfBounds("Block::getDataArray: index is out of bounds!");
-        }
         return backend()->getEntity<base::IDataArray>(index);
     }
 

--- a/include/nix/Block.hpp
+++ b/include/nix/Block.hpp
@@ -664,7 +664,7 @@ public:
     * @return True if the group exists, false otherwise.
     */
     bool hasGroup(const std::string &name_or_id) const {
-        return backend()->hasGroup(name_or_id);
+        return backend()->hasEntity({name_or_id, ObjectType::Group});
     }
 
     /**
@@ -674,7 +674,12 @@ public:
     *
     * @return True if the group exists, false otherwise.
     */
-    bool hasGroup(const Group &group) const;
+    bool hasGroup(const Group &group) const {
+        if (!util::checkEntityInput(group, false)) {
+            return false;
+        }
+        return backend()->hasEntity(group);
+    }
 
     /**
      * @brief Retrieves a specific group from the block by its id.
@@ -685,7 +690,7 @@ public:
      *         an exception will be thrown.
      */
     Group getGroup(const std::string &name_or_id) const {
-        return backend()->getGroup(name_or_id);
+        return backend()->getEntity<base::IGroup>(name_or_id);
     }
 
     /**
@@ -696,7 +701,10 @@ public:
      * @return The group at the specified index.
      */
     Group getGroup(ndsize_t index) const {
-        return backend()->getGroup(index);
+        if (index >= groupCount()) {
+            throw OutOfBounds("Block::getGroup: index is out of bounds!");
+        }
+        return backend()->getEntity<base::IGroup>(index);
     }
 
     /**
@@ -718,7 +726,7 @@ public:
      * @return The number of groups.
      */
     ndsize_t groupCount() const {
-        return backend()->groupCount();
+        return backend()->entityCount(ObjectType::Group);
     }
 
     /**
@@ -742,7 +750,7 @@ public:
      * @return True if the group was removed, false otherwise.
      */
     bool deleteGroup(const std::string &name_or_id) {
-        return backend()->deleteGroup(name_or_id);
+        return backend()->removeEntity({name_or_id, ObjectType::Group});
     }
 
     /**
@@ -755,7 +763,12 @@ public:
     *
     * @return True if the group was removed, false otherwise.
     */
-    bool deleteGroup(const Group &multi_tag);
+    bool deleteGroup(const Group &group) {
+        if (!util::checkEntityInput(group, false)) {
+            return false;
+        }
+        return backend()->removeEntity(group);
+    }
 
     //------------------------------------------------------
     // Operators and other functions

--- a/include/nix/Block.hpp
+++ b/include/nix/Block.hpp
@@ -728,6 +728,11 @@ public:
      */
     NIXAPI friend std::ostream &operator<<(std::ostream &out, const Block &ent);
 
+
+template<>
+struct objectToType<Block> {
+    static const bool isValid = true;
+    static const ObjectType value = ObjectType::Block;
 };
 
 }

--- a/include/nix/DataArray.hpp
+++ b/include/nix/DataArray.hpp
@@ -498,6 +498,7 @@ template<>
 struct objectToType<nix::DataArray> {
     static const bool isValid = true;
     static const ObjectType value = ObjectType::DataArray;
+    typedef nix::base::IDataArray backendType;
 };
 
 

--- a/include/nix/DataArray.hpp
+++ b/include/nix/DataArray.hpp
@@ -493,6 +493,14 @@ protected:
                  const NDSize &offset);
 };
 
+
+template<>
+struct objectToType<nix::DataArray> {
+    static const bool isValid = true;
+    static const ObjectType value = ObjectType::DataArray;
+};
+
+
 } // namespace nix
 
 #endif // NIX_DATA_ARRAY_H

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -839,6 +839,7 @@ template<>
 struct objectToType<nix::SetDimension> {
     static const bool isValid = true;
     static const ObjectType value = ObjectType::SetDimension;
+    typedef nix::base::ISetDimension backendType;
 };
 
 
@@ -846,6 +847,7 @@ template<>
 struct objectToType<nix::SampledDimension> {
     static const bool isValid = true;
     static const ObjectType value = ObjectType::SampledDimension;
+    typedef nix::base::ISampledDimension backendType;
 };
 
 
@@ -854,6 +856,7 @@ template<>
 struct objectToType<nix::RangeDimension> {
     static const bool isValid = true;
     static const ObjectType value = ObjectType::RangeDimension;
+    typedef nix::base::IRangeDimension backendType;
 };
 
 } // namespace nix

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -835,6 +835,27 @@ public:
 
 };
 
+template<>
+struct objectToType<nix::SetDimension> {
+    static const bool isValid = true;
+    static const ObjectType value = ObjectType::SetDimension;
+};
+
+
+template<>
+struct objectToType<nix::SampledDimension> {
+    static const bool isValid = true;
+    static const ObjectType value = ObjectType::SampledDimension;
+};
+
+
+
+template<>
+struct objectToType<nix::RangeDimension> {
+    static const bool isValid = true;
+    static const ObjectType value = ObjectType::RangeDimension;
+};
+
 } // namespace nix
 
 #endif // NIX_DIMENSIONS_H

--- a/include/nix/Feature.hpp
+++ b/include/nix/Feature.hpp
@@ -191,6 +191,7 @@ template<>
 struct objectToType<nix::Feature> {
     static const bool isValid = true;
     static const ObjectType value = ObjectType::Feature;
+    typedef nix::base::IFeature backendType;
 };
 
 } // namespace nix

--- a/include/nix/Feature.hpp
+++ b/include/nix/Feature.hpp
@@ -12,6 +12,7 @@
 #include <nix/base/Entity.hpp>
 #include <nix/base/IFeature.hpp>
 #include <nix/DataArray.hpp>
+#include <nix/ObjectType.hpp>
 
 #include <nix/Platform.hpp>
 
@@ -184,6 +185,13 @@ NIXAPI std::string link_type_to_string(LinkType ltype);
  * @return The output stream.
  */
 NIXAPI std::ostream& operator<<(std::ostream &out, const LinkType ltype);
+
+
+template<>
+struct objectToType<nix::Feature> {
+    static const bool isValid = true;
+    static const ObjectType value = ObjectType::Feature;
+};
 
 } // namespace nix
 

--- a/include/nix/File.hpp
+++ b/include/nix/File.hpp
@@ -489,6 +489,7 @@ template<>
 struct objectToType<nix::File> {
     static const bool isValid = true;
     static const ObjectType value = ObjectType::File;
+    typedef nix::base::IFile backendType;
 };
 
 

--- a/include/nix/File.hpp
+++ b/include/nix/File.hpp
@@ -14,6 +14,7 @@
 #include <nix/Block.hpp>
 #include <nix/Section.hpp>
 #include <nix/Platform.hpp>
+#include <nix/ObjectType.hpp>
 
 #include <nix/valid/validate.hpp>
 
@@ -482,6 +483,12 @@ public:
 
     valid::Result validate() const;
 
+};
+
+template<>
+struct objectToType<nix::File> {
+    static const bool isValid = true;
+    static const ObjectType value = ObjectType::File;
 };
 
 

--- a/include/nix/Group.hpp
+++ b/include/nix/Group.hpp
@@ -479,6 +479,7 @@ template<>
 struct objectToType<nix::Group> {
     static const bool isValid = true;
     static const ObjectType value = ObjectType::Group;
+    typedef nix::base::IGroup backendType;
 };
 
 } // namespace nix

--- a/include/nix/Group.hpp
+++ b/include/nix/Group.hpp
@@ -14,6 +14,7 @@
 #include <nix/DataArray.hpp>
 #include <nix/Platform.hpp>
 #include <nix/ObjectType.hpp>
+#include <nix/util/util.hpp>
 
 
 namespace nix {
@@ -84,8 +85,8 @@ public:
      *
      * @return True if the data array is referenced, false otherwise.
      */
-    bool hasDataArray(const std::string &id) const {
-        return backend()->hasDataArray(id);
+    bool hasDataArray(const std::string &name_or_id) const {
+        return backend()->hasEntity({name_or_id, ObjectType::DataArray});
     }
 
     /**
@@ -95,7 +96,12 @@ public:
      *
      * @return True if the data array is referenced, false otherwise.
      */
-    bool hasDataArray(const DataArray &data_array) const;
+    bool hasDataArray(const DataArray &data_array) const {
+        if (!util::checkEntityInput(data_array, false)) {
+            return false;
+        }
+        return backend()->hasEntity(data_array);
+    }
 
     /**
      * @brief Gets the number of referenced DataArray entities of the tag.
@@ -103,7 +109,7 @@ public:
      * @return The number of referenced data arrays.
      */
     ndsize_t dataArrayCount() const {
-        return backend()->dataArrayCount();
+        return backend()->entityCount(ObjectType::DataArray);
     }
 
     /**
@@ -113,8 +119,8 @@ public:
      *
      * @return The referenced data array.
      */
-    DataArray getDataArray(const std::string &id) const {
-        return backend()->getDataArray(id);
+    DataArray getDataArray(const std::string &name_or_id) const {
+        return backend()->getEntity<base::IDataArray>(name_or_id);
     }
 
     /**
@@ -124,22 +130,31 @@ public:
      *
      * @return The referenced data array.
      */
-    DataArray getDataArray(size_t index) const;
+    DataArray getDataArray(size_t index) const {
+        if (index >= backend()->entityCount(ObjectType::DataArray)) {
+            throw OutOfBounds("No DataArray at given index", index);
+        }
+        return backend()->getEntity<base::IDataArray>(index);
+    }
 
     /**
      * @brief Add a DataArray to the list of referenced data of the group.
      *
      * @param data_array The DataArray to add.
      */
-    void addDataArray(const DataArray &data_array);
-
+    void addDataArray(const DataArray &data_array) {
+        if (util::checkEntityInput(data_array, true)) {
+            backend()->addEntity(data_array);
+        }
+    }
     /**
      * @brief Add a DataArray to the list of referenced data of the group.
      *
      * @param id        The id of the DataArray to add.
      */
-    void addDataArray(const std::string &id);
-
+    void addDataArray(const std::string &name_or_id) {
+        backend()->addEntity({name_or_id, ObjectType::DataArray});
+    }
     /**
      * @brief Remove a DataArray from the list of referenced data of the group.
      *
@@ -150,8 +165,12 @@ public:
      *
      * @returns True if the DataArray was removed, false otherwise.
      */
-    bool removeDataArray(const DataArray &data_array);
-
+    bool removeDataArray(const DataArray &data_array) {
+        if (!util::checkEntityInput(data_array, false)) {
+            return false;
+        }
+        return backend()->removeEntity(data_array);
+    }
     /**
      * @brief Remove a DataArray from the list of referenced data of the group.
      *
@@ -162,8 +181,8 @@ public:
      *
      * @returns True if the DataArray was removed, false otherwise.
      */
-    bool removeDataArray(const std::string &id) {
-        return backend()->removeDataArray(id);
+    bool removeDataArray(const std::string &name_or_id) {
+        return backend()->removeEntity({name_or_id, ObjectType::DataArray});
     }
 
     /**

--- a/include/nix/Group.hpp
+++ b/include/nix/Group.hpp
@@ -115,7 +115,8 @@ public:
     /**
      * @brief Gets a specific referenced DataArray from the tag.
      *
-     * @param id        The id of the referenced DataArray.
+     * @param name_or_id           The name or id of the referenced
+     *                             DataArray (using the id is faster).
      *
      * @return The referenced data array.
      */
@@ -150,7 +151,7 @@ public:
     /**
      * @brief Add a DataArray to the list of referenced data of the group.
      *
-     * @param id        The id of the DataArray to add.
+     * @param name_or_id        The name or id of the DataArray to add.
      */
     void addDataArray(const std::string &name_or_id) {
         backend()->addEntity({name_or_id, ObjectType::DataArray});
@@ -177,7 +178,8 @@ public:
      * This method just removes the association between the data array and the
      * tag, the data array itself will not be removed from the file.
      *
-     * @param id        The id of the DataArray to remove.
+     * @param name_or_id        The name or the id of the DataArray to
+     *                          remove. (using the id is faster)
      *
      * @returns True if the DataArray was removed, false otherwise.
      */
@@ -217,9 +219,7 @@ public:
      *
      * @param data_arrays    All referenced arrays.
      */
-    void dataArrays(const std::vector<DataArray> &data_arrays) {
-        backend()->dataArrays(data_arrays);
-    }
+    void dataArrays(const std::vector<DataArray> &data_arrays);
 
     //--------------------------------------------------
     // Methods concerning tags.

--- a/include/nix/Group.hpp
+++ b/include/nix/Group.hpp
@@ -228,12 +228,12 @@ public:
     /**
      * @brief Checks whether a Tag is referenced by the group.
      *
-     * @param id        The id of the Tag to check.
+     * @param name_or_id      The name or id of the Tag to check.
      *
      * @return True if the tag is referenced, false otherwise.
      */
-    bool hasTag(const std::string &id) const {
-        return backend()->hasTag(id);
+    bool hasTag(const std::string &name_or_id) const {
+        return backend()->hasEntity({name_or_id, ObjectType::Tag});
     }
 
     /**
@@ -243,7 +243,12 @@ public:
      *
      * @return True if the tag is referenced, false otherwise.
      */
-    bool hasTag(const Tag &tag) const;
+    bool hasTag(const Tag &tag) const {
+        if (!util::checkEntityInput(tag, false)) {
+            return false;
+        }
+        return backend()->hasEntity(tag);
+    }
 
     /**
      * @brief Gets the number of referenced Tag entities of the tag.
@@ -251,18 +256,18 @@ public:
      * @return The number of referenced tags.
      */
     ndsize_t tagCount() const {
-        return backend()->tagCount();
+        return backend()->entityCount(ObjectType::Tag);
     }
 
     /**
      * @brief Gets a specific referenced Tag from the tag.
      *
-     * @param id        The id of the referenced Tag.
+     * @param name_or_id      The name or id of the referenced Tag.
      *
      * @return The referenced tag.
      */
-    Tag getTag(const std::string &id) const {
-        return backend()->getTag(id);
+    Tag getTag(const std::string &name_or_id) const {
+        return backend()->getEntity<base::ITag>(name_or_id);
     }
 
     /**
@@ -272,21 +277,32 @@ public:
      *
      * @return The referenced tag.
      */
-    Tag getTag(size_t index) const;
+    Tag getTag(size_t index) const {
+        if (index >= backend()->entityCount(ObjectType::Tag)) {
+            throw OutOfBounds("No Tag at given index", index);
+        }
+        return backend()->getEntity<base::ITag>(index);
+    }
 
     /**
      * @brief Add a Tag to the list of referenced data of the group.
      *
      * @param data_array The Tag to add.
      */
-    void addTag(const Tag &tag);
+    void addTag(const Tag &tag) {
+        if (util::checkEntityInput(tag, true)) {
+            backend()->addEntity(tag);
+        }
+    }
 
     /**
      * @brief Add a Tag to the list of referenced data of the group.
      *
-     * @param id        The id of the Tag to add.
+     * @param name_or_id        The name or id of the Tag to add.
      */
-    void addTag(const std::string &id);
+    void addTag(const std::string &name_or_id) {
+        backend()->addEntity({name_or_id, ObjectType::Tag});
+    }
 
     /**
      * @brief Remove a Tag from the list of referenced tags of the group.
@@ -298,7 +314,12 @@ public:
      *
      * @returns True if the Tag was removed, false otherwise.
      */
-    bool removeTag(const Tag &tag);
+    bool removeTag(const Tag &tag) {
+          if (!util::checkEntityInput(tag, false)) {
+            return false;
+        }
+        return backend()->removeEntity(tag);
+    }
 
     /**
      * @brief Remove a Tag from the list of referenced tags of the group.
@@ -306,12 +327,12 @@ public:
      * This method just removes the association between the tag and the
      * group, the tag itself will not be removed from the file.
      *
-     * @param id        The id of the Tag to remove.
+     * @param name_or_id        The name or id of the Tag to remove.
      *
      * @returns True if the Tag was removed, false otherwise.
      */
-    bool removeTag(const std::string &id) {
-        return backend()->removeTag(id);
+    bool removeTag(const std::string &name_or_id) {
+        return backend()->removeEntity({name_or_id, ObjectType::Tag});
     }
 
     /**
@@ -346,10 +367,7 @@ public:
      *
      * @param tags    All tags.
      */
-    void tags(const std::vector<Tag> &tags) {
-        backend()->tags(tags);
-    }
-
+    void tags(const std::vector<Tag> &tags);
     //--------------------------------------------------
     // Methods concerning multi tags.
     //--------------------------------------------------

--- a/include/nix/Group.hpp
+++ b/include/nix/Group.hpp
@@ -354,8 +354,7 @@ public:
      *
      * @return The filtered Tags as a vector
      */
-    std::vector<Tag> tags() const
-    {
+    std::vector<Tag> tags() const {
         return tags(util::AcceptAll<Tag>());
     }
 
@@ -375,12 +374,12 @@ public:
     /**
      * @brief Checks whether a MultiTag is referenced by the group.
      *
-     * @param id        The id of the MultiTag to check.
+     * @param name or id        The name or id of the MultiTag to check.
      *
      * @return True if the MultiTag is referenced, false otherwise.
      */
-    bool hasMultiTag(const std::string &id) const {
-        return backend()->hasMultiTag(id);
+    bool hasMultiTag(const std::string &name_or_id) const {
+        return backend()->hasEntity({name_or_id, ObjectType::MultiTag});
     }
 
     /**
@@ -390,7 +389,13 @@ public:
      *
      * @return True if the MultiTag is referenced, false otherwise.
      */
-    bool hasMultiTag(const MultiTag &tag) const;
+    bool hasMultiTag(const MultiTag &tag) const {
+        if (!util::checkEntityInput(tag, false)) {
+            return false;
+        }
+        return backend()->hasEntity(tag);
+    }
+
 
     /**
      * @brief Gets the number of referenced MultiTag entities of the group.
@@ -398,18 +403,18 @@ public:
      * @return The number of referenced MultiTags.
      */
     ndsize_t multiTagCount() const {
-        return backend()->multiTagCount();
+        return backend()->entityCount(ObjectType::MultiTag);
     }
 
     /**
      * @brief Gets a specific referenced MultiTag from the group.
      *
-     * @param id        The id of the referenced MultiTag.
+     * @param name_or_id        The name or id of the referenced MultiTag.
      *
      * @return The referenced MultiTag.
      */
-    MultiTag getMultiTag(const std::string &id) const {
-        return backend()->getMultiTag(id);
+    MultiTag getMultiTag(const std::string &name_or_id) const {
+        return backend()->getEntity<base::IMultiTag>(name_or_id);
     }
 
     /**
@@ -419,21 +424,32 @@ public:
      *
      * @return The referenced MultiTag.
      */
-    MultiTag getMultiTag(size_t index) const;
+    MultiTag getMultiTag(size_t index) const {
+        if (index >= backend()->entityCount(ObjectType::MultiTag)) {
+            throw OutOfBounds("No MultiTag at given index", index);
+        }
+        return backend()->getEntity<base::IMultiTag>(index);
+    }
 
     /**
      * @brief Add a MultiTag to the list of referenced tags of the group.
      *
      * @param mutlti_tag The MultiTag to add.
      */
-    void addMultiTag(const MultiTag &multi_tag);
+    void addMultiTag(const MultiTag &multi_tag) {
+        if (util::checkEntityInput(multi_tag, true)) {
+            backend()->addEntity(multi_tag);
+        }
+    }
 
     /**
      * @brief Add a MultiTag to the list of referenced tags of the group.
      *
-     * @param id        The id of the MultiTag to add.
+     * @param name_or_id    The name or id  of the MultiTag to add.
      */
-    void addMultiTag(const std::string &id);
+    void addMultiTag(const std::string &name_or_id) {
+        backend()->addEntity({name_or_id, ObjectType::MultiTag});
+    }
 
     /**
      * @brief Remove a MultiTag from the list of referenced tags of the group.
@@ -445,7 +461,12 @@ public:
      *
      * @returns True if the MultiTag was removed, false otherwise.
      */
-    bool removeMultiTag(const MultiTag &mulit_tag);
+    bool removeMultiTag(const MultiTag &multi_tag) {
+        if (!util::checkEntityInput(multi_tag, false)) {
+            return false;
+        }
+        return backend()->removeEntity(multi_tag);
+    }
 
     /**
      * @brief Remove a MultiTag from the list of referenced tags of the group.
@@ -453,12 +474,12 @@ public:
      * This method just removes the association between the tag and the
      * group, the MultiTag itself will not be removed from the file.
      *
-     * @param id        The id of the MultiTag to remove.
+     * @param name_or_id      The name or the id of the MultiTag to remove.
      *
      * @returns True if the MultiTag was removed, false otherwise.
      */
-    bool removeMultiTag(const std::string &id) {
-        return backend()->removeMultiTag(id);
+    bool removeMultiTag(const std::string &name_or_id) {
+        return backend()->removeEntity({name_or_id, ObjectType::MultiTag});
     }
 
     /**
@@ -480,8 +501,7 @@ public:
      *
      * @return The filtered MultiTags as a vector
      */
-    std::vector<MultiTag> multiTags() const
-    {
+    std::vector<MultiTag> multiTags() const {
         return multiTags(util::AcceptAll<MultiTag>());
     }
 
@@ -493,9 +513,7 @@ public:
      *
      * @param mulit_tags    All MultiTags.
      */
-    void multiTags(const std::vector<MultiTag> &multi_tags) {
-        backend()->multiTags(multi_tags);
-    }
+    void multiTags(const std::vector<MultiTag> &multi_tags);
 
 
     /**

--- a/include/nix/Group.hpp
+++ b/include/nix/Group.hpp
@@ -528,6 +528,10 @@ public:
      * @brief Output operator
      */
     NIXAPI friend std::ostream &operator<<(std::ostream &out, const Group &ent);
+
+ private:
+    template<typename T>
+    void replaceEntities(const std::vector<T> &entitties);
 };
 
 template<>

--- a/include/nix/Group.hpp
+++ b/include/nix/Group.hpp
@@ -13,6 +13,7 @@
 #include <nix/base/IGroup.hpp>
 #include <nix/DataArray.hpp>
 #include <nix/Platform.hpp>
+#include <nix/ObjectType.hpp>
 
 
 namespace nix {
@@ -472,6 +473,12 @@ public:
      * @brief Output operator
      */
     NIXAPI friend std::ostream &operator<<(std::ostream &out, const Group &ent);
+};
+
+template<>
+struct objectToType<nix::Group> {
+    static const bool isValid = true;
+    static const ObjectType value = ObjectType::Group;
 };
 
 } // namespace nix

--- a/include/nix/Identity.hpp
+++ b/include/nix/Identity.hpp
@@ -33,6 +33,10 @@ public:
     Identity(const base::Entity<T> &e)
         : myName(""), myId(e.id()), myType(objectToType<T>::value) { }
 
+    template<typename T>
+    Identity(const std::shared_ptr<T> &e)
+        : myName(e->name()), myId(e->id()), myType(objectToType<T>::value) { }
+
     const std::string & id() const { return myId; }
     const std::string & name() const { return myName; }
     const ObjectType type() const { return myType; }

--- a/include/nix/Identity.hpp
+++ b/include/nix/Identity.hpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2017, German Neuroinformatics Node (G-Node)
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted under the terms of the BSD License. See
+// LICENSE file in the root of the Project.
+
+#ifndef NIX_IDENTITY_H
+#define NIX_IDENTITY_H
+
+#include <string>
+#include <nix/base/NamedEntity.hpp>
+
+namespace nix {
+
+class NIXAPI Identity {
+public:
+    Identity(std::string name, std::string id)
+        : myName(std::move(name)), myId(std::move(id)) { }
+
+    template<typename T>
+    Identity(const base::NamedEntity<T> &e)
+        : myName(e.name()), myId(e.id()) { }
+
+    template<typename T>
+    Identity(const base::Entity<T> &e)
+        : myName(""), myId(e.id()) { }
+
+    const std::string & id() const { return myId; };
+    const std::string & name() const { return myName; };
+
+private:
+     std::string myName;
+     std::string myId;
+};
+
+} //nix::
+
+#endif //NIX_IDENTITY_H

--- a/include/nix/Identity.hpp
+++ b/include/nix/Identity.hpp
@@ -17,6 +17,8 @@ namespace nix {
 
 class NIXAPI Identity {
 public:
+    Identity(const std::string &name_or_id, ObjectType type);
+
     Identity(std::string name, std::string id)
         : myName(std::move(name)), myId(std::move(id)) { }
 

--- a/include/nix/Identity.hpp
+++ b/include/nix/Identity.hpp
@@ -11,6 +11,7 @@
 
 #include <string>
 #include <nix/base/NamedEntity.hpp>
+#include <nix/ObjectType.hpp>
 
 namespace nix {
 
@@ -19,20 +20,25 @@ public:
     Identity(std::string name, std::string id)
         : myName(std::move(name)), myId(std::move(id)) { }
 
+    Identity(std::string name, std::string id, ObjectType type)
+        : myName(std::move(name)), myId(std::move(id)), myType(type) { }
+
     template<typename T>
     Identity(const base::NamedEntity<T> &e)
-        : myName(e.name()), myId(e.id()) { }
+        : myName(e.name()), myId(e.id()), myType(objectToType<T>::value) { }
 
     template<typename T>
     Identity(const base::Entity<T> &e)
-        : myName(""), myId(e.id()) { }
+        : myName(""), myId(e.id()), myType(objectToType<T>::value) { }
 
-    const std::string & id() const { return myId; };
-    const std::string & name() const { return myName; };
+    const std::string & id() const { return myId; }
+    const std::string & name() const { return myName; }
+    const ObjectType type() const { return myType; }
 
-private:
-     std::string myName;
-     std::string myId;
+ private:
+    std::string myName;
+    std::string myId;
+    ObjectType  myType;
 };
 
 } //nix::

--- a/include/nix/MultiTag.hpp
+++ b/include/nix/MultiTag.hpp
@@ -514,6 +514,7 @@ template<>
 struct objectToType<nix::MultiTag> {
     static const bool isValid = true;
     static const ObjectType value = ObjectType::MultiTag;
+    typedef nix::base::IMultiTag backendType;
 };
 
 } // namespace nix

--- a/include/nix/MultiTag.hpp
+++ b/include/nix/MultiTag.hpp
@@ -14,6 +14,7 @@
 #include <nix/Feature.hpp>
 #include <nix/Platform.hpp>
 #include <nix/DataView.hpp>
+#include <nix/ObjectType.hpp>
 
 #include <algorithm>
 #include <memory>
@@ -509,6 +510,11 @@ public:
 
 };
 
+template<>
+struct objectToType<nix::MultiTag> {
+    static const bool isValid = true;
+    static const ObjectType value = ObjectType::MultiTag;
+};
 
 } // namespace nix
 

--- a/include/nix/ObjectType.hpp
+++ b/include/nix/ObjectType.hpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2017, German Neuroinformatics Node (G-Node)
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted under the terms of the BSD License. See
+// LICENSE file in the root of the Project.
+
+#ifndef NIX_OBJECT_TYPE_H
+#define NIX_OBJECT_TYPE_H
+
+namespace nix {
+
+enum class ObjectType {
+    Unknown     = 0,
+
+    File        = 1,
+    Block,
+    DataArray,
+    Tag,
+    Source,
+    Feature,
+    MultiTag,
+    Section,
+    Property,
+    Group,
+
+    // Use value > 0x80 for entities that do NOT
+    // inherit from nix::base::IEntity
+
+    SetDimension      = 0x81,
+    SampledDimension,
+    RangeDimension
+};
+
+
+template<typename T>
+struct objectToType { };
+
+}
+
+#endif //NIX_OBJECT_TYPE_H

--- a/include/nix/Property.hpp
+++ b/include/nix/Property.hpp
@@ -283,6 +283,7 @@ template<>
 struct objectToType<nix::Property> {
     static const bool isValid = true;
     static const ObjectType value = ObjectType::Property;
+    typedef nix::base::IProperty backendType;
 };
 
 

--- a/include/nix/Property.hpp
+++ b/include/nix/Property.hpp
@@ -12,6 +12,7 @@
 #include <nix/base/Entity.hpp>
 #include <nix/base/IProperty.hpp>
 #include <nix/Value.hpp>
+#include <nix/ObjectType.hpp>
 
 #include <nix/Platform.hpp>
 
@@ -276,6 +277,12 @@ public:
      */
     virtual ~Property() {}
 
+};
+
+template<>
+struct objectToType<nix::Property> {
+    static const bool isValid = true;
+    static const ObjectType value = ObjectType::Property;
 };
 
 

--- a/include/nix/Section.hpp
+++ b/include/nix/Section.hpp
@@ -550,6 +550,7 @@ template<>
 struct objectToType<nix::Section> {
     static const bool isValid = true;
     static const ObjectType value = ObjectType::Section;
+    typedef nix::base::ISection backendType;
 };
 
 } // namespace nix

--- a/include/nix/Section.hpp
+++ b/include/nix/Section.hpp
@@ -16,6 +16,8 @@
 #include <nix/DataType.hpp>
 #include <nix/Platform.hpp>
 #include <nix/types.hpp>
+#include <nix/ObjectType.hpp>
+
 #include <memory>
 #include <functional>
 #include <string>
@@ -544,6 +546,11 @@ private:
     size_t tree_depth() const;
 };
 
+template<>
+struct objectToType<nix::Section> {
+    static const bool isValid = true;
+    static const ObjectType value = ObjectType::Section;
+};
 
 } // namespace nix
 

--- a/include/nix/Source.hpp
+++ b/include/nix/Source.hpp
@@ -253,6 +253,7 @@ template<>
 struct objectToType<nix::Source> {
     static const bool isValid = true;
     static const ObjectType value = ObjectType::Source;
+    typedef nix::base::ISource backendType;
 };
 
 } // namespace nix

--- a/include/nix/Source.hpp
+++ b/include/nix/Source.hpp
@@ -13,6 +13,7 @@
 #include <nix/types.hpp>
 #include <nix/base/EntityWithMetadata.hpp>
 #include <nix/base/ISource.hpp>
+#include <nix/ObjectType.hpp>
 
 #include <nix/Platform.hpp>
 
@@ -248,6 +249,11 @@ public:
 
 };
 
+template<>
+struct objectToType<nix::Source> {
+    static const bool isValid = true;
+    static const ObjectType value = ObjectType::Source;
+};
 
 } // namespace nix
 

--- a/include/nix/Tag.hpp
+++ b/include/nix/Tag.hpp
@@ -491,6 +491,7 @@ template<>
 struct objectToType<nix::Tag> {
     static const bool isValid = true;
     static const ObjectType value = ObjectType::Tag;
+    typedef nix::base::ITag backendType;
 };
 
 

--- a/include/nix/Tag.hpp
+++ b/include/nix/Tag.hpp
@@ -15,6 +15,7 @@
 #include <nix/Feature.hpp>
 #include <nix/DataView.hpp>
 #include <nix/Platform.hpp>
+#include <nix/ObjectType.hpp>
 
 #include <algorithm>
 
@@ -483,6 +484,13 @@ public:
      */
     NIXAPI friend std::ostream& operator<<(std::ostream &out, const Tag &ent);
 
+};
+
+
+template<>
+struct objectToType<nix::Tag> {
+    static const bool isValid = true;
+    static const ObjectType value = ObjectType::Tag;
 };
 
 

--- a/include/nix/base/IBlock.hpp
+++ b/include/nix/base/IBlock.hpp
@@ -102,24 +102,9 @@ public:
     // Methods concerning multi tags.
     //--------------------------------------------------
 
-    virtual bool hasMultiTag(const std::string &name_or_id) const = 0;
-
-
-    virtual std::shared_ptr<base::IMultiTag> getMultiTag(const std::string &name_or_id) const = 0;
-
-
-    virtual std::shared_ptr<base::IMultiTag> getMultiTag(ndsize_t index) const = 0;
-
-
-    virtual ndsize_t multiTagCount() const = 0;
-
-
     // TODO evaluate if DataArray can be replaced by shared_ptr<IDataArray>
     virtual std::shared_ptr<base::IMultiTag> createMultiTag(const std::string &name, const std::string &type,
                                                             const DataArray &positions) = 0;
-
-
-    virtual bool deleteMultiTag(const std::string &name_or_id) = 0;
 
     //--------------------------------------------------
     // Methods concerning groups.

--- a/include/nix/base/IBlock.hpp
+++ b/include/nix/base/IBlock.hpp
@@ -34,6 +34,9 @@ class NIXAPI IBlock : virtual public base::IEntityWithMetadata {
 
 public:
 
+
+    virtual std::string resolveEntityId(const nix::Identity &ident) const = 0;
+
     virtual bool hasEntity(const nix::Identity &ident) const = 0;
 
     virtual std::shared_ptr<base::IEntity> getEntity(const nix::Identity &ident) const = 0;

--- a/include/nix/base/IBlock.hpp
+++ b/include/nix/base/IBlock.hpp
@@ -47,6 +47,23 @@ public:
 
     virtual bool removeEntity(const nix::Identity &ident) = 0;
 
+    template<typename T>
+    std::shared_ptr<T> getEntity(const nix::Identity &ident) const {
+        return std::dynamic_pointer_cast<T>(this->getEntity(ident));
+    }
+
+    template<typename T>
+    std::shared_ptr<T> getEntity(const std::string &name_or_id) const {
+        ObjectType ot = objectToType<T>::value;
+        return std::dynamic_pointer_cast<T>(this->getEntity({name_or_id, ot}));
+    }
+
+    template<typename T>
+    std::shared_ptr<T> getEntity(ndsize_t index) const {
+        ObjectType ot = objectToType<T>::value;
+        return std::dynamic_pointer_cast<T>(this->getEntity(ot, index));
+    }
+
     //--------------------------------------------------
 
     virtual bool hasSource(const std::string &name_or_id) const = 0;

--- a/include/nix/base/IBlock.hpp
+++ b/include/nix/base/IBlock.hpp
@@ -34,6 +34,17 @@ class NIXAPI IBlock : virtual public base::IEntityWithMetadata {
 
 public:
 
+    virtual bool hasEntity(const nix::Identity &ident) const = 0;
+
+    virtual std::shared_ptr<base::IEntity> getEntity(const nix::Identity &ident) const = 0;
+
+    virtual std::shared_ptr<base::IEntity> getEntity(ObjectType type, ndsize_t index) const = 0;
+
+    virtual ndsize_t entityCount(ObjectType type) const = 0;
+
+    virtual bool removeEntity(const nix::Identity &ident) = 0;
+
+    //--------------------------------------------------
 
     virtual bool hasSource(const std::string &name_or_id) const = 0;
 

--- a/include/nix/base/IBlock.hpp
+++ b/include/nix/base/IBlock.hpp
@@ -110,22 +110,7 @@ public:
     // Methods concerning groups.
     //--------------------------------------------------
 
-    virtual bool hasGroup(const std::string &name_or_id) const = 0;
-
-
-    virtual std::shared_ptr<base::IGroup> getGroup(const std::string &name_or_id) const = 0;
-
-
-    virtual std::shared_ptr<base::IGroup> getGroup(ndsize_t index) const = 0;
-
-
-    virtual ndsize_t groupCount() const = 0;
-
-
     virtual std::shared_ptr<base::IGroup> createGroup(const std::string &name, const std::string &type) = 0;
-
-
-    virtual bool deleteGroup(const std::string &name_or_id) = 0;
 
 
     virtual ~IBlock() {}

--- a/include/nix/base/IBlock.hpp
+++ b/include/nix/base/IBlock.hpp
@@ -66,18 +66,6 @@ public:
 
     //--------------------------------------------------
 
-    virtual bool hasSource(const std::string &name_or_id) const = 0;
-
-
-    virtual std::shared_ptr<base::ISource> getSource(const std::string &name_or_id) const = 0;
-
-
-    virtual std::shared_ptr<base::ISource> getSource(ndsize_t index) const = 0;
-
-
-    virtual ndsize_t sourceCount() const = 0;
-
-
     virtual std::shared_ptr<base::ISource> createSource(const std::string &name, const std::string &type) = 0;
 
 

--- a/include/nix/base/IBlock.hpp
+++ b/include/nix/base/IBlock.hpp
@@ -87,23 +87,9 @@ public:
     // Methods concerning data arrays
     //--------------------------------------------------
 
-    virtual bool hasDataArray(const std::string &name_or_id) const = 0;
-
-
-    virtual std::shared_ptr<base::IDataArray> getDataArray(const std::string &name_or_id) const = 0;
-
-
-    virtual std::shared_ptr<base::IDataArray> getDataArray(ndsize_t index) const = 0;
-
-
-    virtual ndsize_t dataArrayCount() const = 0;
-
-
     virtual std::shared_ptr<base::IDataArray> createDataArray(const std::string &name, const std::string &type,
                                                               nix::DataType data_type, const NDSize &shape) = 0;
 
-
-    virtual bool deleteDataArray(const std::string &name_or_id) = 0;
 
     //--------------------------------------------------
     // Methods concerning tags.

--- a/include/nix/base/IBlock.hpp
+++ b/include/nix/base/IBlock.hpp
@@ -16,6 +16,7 @@
 #include <nix/base/IMultiTag.hpp>
 #include <nix/base/IGroup.hpp>
 #include <nix/NDSize.hpp>
+#include <nix/Identity.hpp>
 
 #include <string>
 #include <vector>
@@ -144,6 +145,12 @@ public:
 };
 
 } // namespace base
+
+template<>
+struct objectToType<base::IBlock> {
+    static const bool isValid = true;
+    static const ObjectType value = ObjectType::Block;
+};
 } // namespace nix
 
 

--- a/include/nix/base/IBlock.hpp
+++ b/include/nix/base/IBlock.hpp
@@ -95,23 +95,8 @@ public:
     // Methods concerning tags.
     //--------------------------------------------------
 
-    virtual bool hasTag(const std::string &name_or_id) const = 0;
-
-
-    virtual std::shared_ptr<base::ITag> getTag(const std::string &name_or_id) const = 0;
-
-
-    virtual std::shared_ptr<base::ITag> getTag(ndsize_t index) const = 0;
-
-
-    virtual ndsize_t tagCount() const = 0;
-
-
     virtual std::shared_ptr<base::ITag> createTag(const std::string &name, const std::string &type,
                                                               const std::vector<double> &position) = 0;
-
-
-    virtual bool deleteTag(const std::string &name_or_id) = 0;
 
     //--------------------------------------------------
     // Methods concerning multi tags.

--- a/include/nix/base/IDataArray.hpp
+++ b/include/nix/base/IDataArray.hpp
@@ -13,6 +13,7 @@
 #include <nix/base/IDimensions.hpp>
 #include <nix/DataType.hpp>
 #include <nix/NDSize.hpp>
+#include <nix/ObjectType.hpp>
 
 #include <string>
 #include <vector>
@@ -163,6 +164,13 @@ public:
 
 
 } // namespace base
+
+template<>
+struct objectToType<nix::base::IDataArray> {
+    static const bool isValid = true;
+    static const ObjectType value = ObjectType::DataArray;
+};
+
 } // namespace nix
 
 #endif // NIX_I_DATA_ARRAY_H

--- a/include/nix/base/IDimensions.hpp
+++ b/include/nix/base/IDimensions.hpp
@@ -17,6 +17,7 @@
 
 #include <boost/optional.hpp>
 #include <nix/NDSize.hpp>
+#include <nix/ObjectType.hpp>
 
 namespace nix {
 
@@ -169,6 +170,26 @@ public:
 
 
 } // namespace base
+
+template<>
+struct objectToType<nix::base::ISetDimension> {
+    static const bool isValid = true;
+    static const ObjectType value = ObjectType::SetDimension;
+};
+
+template<>
+struct objectToType<nix::base::ISampledDimension> {
+    static const bool isValid = true;
+    static const ObjectType value = ObjectType::SampledDimension;
+};
+
+
+template<>
+struct objectToType<nix::base::IRangeDimension> {
+    static const bool isValid = true;
+    static const ObjectType value = ObjectType::RangeDimension;
+};
+
 } // namespace nix
 
 #endif // NIX_I_DIMENSIONS_H

--- a/include/nix/base/IFeature.hpp
+++ b/include/nix/base/IFeature.hpp
@@ -10,6 +10,7 @@
 #define NIX_I_FEATURE_H
 
 #include <nix/base/IDataArray.hpp>
+#include <nix/ObjectType.hpp>
 
 #include <string>
 #include <memory>
@@ -57,6 +58,13 @@ public:
 
 
 } // namespace base
+
+template<>
+struct objectToType<nix::base::IFeature> {
+    static const bool isValid = true;
+    static const ObjectType value = ObjectType::Feature;
+};
+
 } // namespace nix
 
 #endif // NIX_I_FEATURE_H

--- a/include/nix/base/IFile.hpp
+++ b/include/nix/base/IFile.hpp
@@ -12,6 +12,7 @@
 #include <nix/base/ISection.hpp>
 #include <nix/base/IBlock.hpp>
 #include <nix/Platform.hpp>
+#include <nix/ObjectType.hpp>
 
 #include <string>
 #include <vector>
@@ -131,6 +132,13 @@ public:
 
 
 } // namespace base
+
+template<>
+struct objectToType<nix::base::IFile> {
+    static const bool isValid = true;
+    static const ObjectType value = ObjectType::File;
+};
+
 } // namespace nix
 
 #endif

--- a/include/nix/base/IGroup.hpp
+++ b/include/nix/base/IGroup.hpp
@@ -64,36 +64,6 @@ public:
     }
 
     //--------------------------------------------------
-    // Methods concerning data arrays.
-    //--------------------------------------------------
-
-    //virtual void dataArrays(const std::vector<DataArray> &data_arrays) = 0;
-
-    //--------------------------------------------------
-    // Methods concerning tags.
-    //--------------------------------------------------
-
-    virtual bool hasTag(const std::string &id) const = 0;
-
-
-    virtual ndsize_t tagCount() const = 0;
-
-
-    virtual std::shared_ptr<ITag> getTag(const std::string &id) const = 0;
-
-
-    virtual std::shared_ptr<ITag> getTag(ndsize_t index) const = 0;
-
-
-    virtual void addTag(const std::string &id) = 0;
-
-
-    virtual bool removeTag(const std::string &id) = 0;
-
-
-    virtual void tags(const std::vector<Tag> &tags) = 0;
-
-    //--------------------------------------------------
     // Methods concerning multi tags.
     //--------------------------------------------------
 

--- a/include/nix/base/IGroup.hpp
+++ b/include/nix/base/IGroup.hpp
@@ -18,6 +18,7 @@
 #include <nix/NDSize.hpp>
 #include <nix/Tag.hpp>
 #include <nix/MultiTag.hpp>
+#include <nix/ObjectType.hpp>
 
 
 namespace nix {
@@ -111,6 +112,13 @@ public:
 };
 
 } // namespace base
+
+template<>
+struct objectToType<nix::base::IGroup> {
+    static const bool isValid = true;
+    static const ObjectType value = ObjectType::Group;
+};
+
 } // namespace nix
 
 #endif //NIX_IGROUP_HPP

--- a/include/nix/base/IGroup.hpp
+++ b/include/nix/base/IGroup.hpp
@@ -19,6 +19,7 @@
 #include <nix/Tag.hpp>
 #include <nix/MultiTag.hpp>
 #include <nix/ObjectType.hpp>
+#include <nix/Identity.hpp>
 
 
 namespace nix {
@@ -33,29 +34,40 @@ class NIXAPI IGroup : virtual public IEntityWithSources {
 
 public:
 
+    virtual bool hasEntity(const nix::Identity &ident) const = 0;
+
+    virtual std::shared_ptr<base::IEntity> getEntity(const nix::Identity &ident) const = 0;
+
+    virtual std::shared_ptr<base::IEntity> getEntity(ObjectType type, ndsize_t index) const = 0;
+
+    virtual ndsize_t entityCount(ObjectType type) const = 0;
+
+    virtual bool removeEntity(const nix::Identity &ident) = 0;
+
+    virtual void addEntity(const nix::Identity &ident) = 0;
+
+    template<typename T>
+    std::shared_ptr<T> getEntity(const nix::Identity &ident) const {
+        return std::dynamic_pointer_cast<T>(this->getEntity(ident));
+    }
+
+    template<typename T>
+    std::shared_ptr<T> getEntity(const std::string &name_or_id) const {
+        ObjectType ot = objectToType<T>::value;
+        return std::dynamic_pointer_cast<T>(this->getEntity({name_or_id, ot}));
+    }
+
+    template<typename T>
+    std::shared_ptr<T> getEntity(ndsize_t index) const {
+        ObjectType ot = objectToType<T>::value;
+        return std::dynamic_pointer_cast<T>(this->getEntity(ot, index));
+    }
+
     //--------------------------------------------------
     // Methods concerning data arrays.
     //--------------------------------------------------
 
-    virtual bool hasDataArray(const std::string &id) const = 0;
-
-
-    virtual ndsize_t dataArrayCount() const = 0;
-
-
-    virtual std::shared_ptr<IDataArray> getDataArray(const std::string &id) const = 0;
-
-
-    virtual std::shared_ptr<IDataArray> getDataArray(ndsize_t index) const = 0;
-
-
-    virtual void addDataArray(const std::string &id) = 0;
-
-
-    virtual bool removeDataArray(const std::string &id) = 0;
-
-
-    virtual void dataArrays(const std::vector<DataArray> &data_arrays) = 0;
+    //virtual void dataArrays(const std::vector<DataArray> &data_arrays) = 0;
 
     //--------------------------------------------------
     // Methods concerning tags.

--- a/include/nix/base/IGroup.hpp
+++ b/include/nix/base/IGroup.hpp
@@ -63,30 +63,6 @@ public:
         return std::dynamic_pointer_cast<T>(this->getEntity(ot, index));
     }
 
-    //--------------------------------------------------
-    // Methods concerning multi tags.
-    //--------------------------------------------------
-
-    virtual bool hasMultiTag(const std::string &id) const = 0;
-
-
-    virtual ndsize_t multiTagCount() const = 0;
-
-
-    virtual std::shared_ptr<IMultiTag> getMultiTag(const std::string &id) const = 0;
-
-
-    virtual std::shared_ptr<IMultiTag> getMultiTag(ndsize_t index) const = 0;
-
-
-    virtual void addMultiTag(const std::string &id) = 0;
-
-
-    virtual bool removeMultiTag(const std::string &id) = 0;
-
-
-    virtual void multiTags(const std::vector<MultiTag> &tags) = 0;
-
     /**
     * @brief Destructor
     */

--- a/include/nix/base/IMultiTag.hpp
+++ b/include/nix/base/IMultiTag.hpp
@@ -14,6 +14,7 @@
 #include <nix/base/IFeature.hpp>
 #include <nix/base/IBaseTag.hpp>
 #include <nix/None.hpp>
+#include <nix/ObjectType.hpp>
 
 #include <vector>
 #include <string>
@@ -71,6 +72,13 @@ public:
 };
 
 } // namespace base
+
+template<>
+struct objectToType<nix::base::IMultiTag> {
+    static const bool isValid = true;
+    static const ObjectType value = ObjectType::MultiTag;
+};
+
 } // namespace nix
 
 #endif // NIX_I_MULTI_TAG_H

--- a/include/nix/base/IProperty.hpp
+++ b/include/nix/base/IProperty.hpp
@@ -11,6 +11,7 @@
 
 #include <nix/Value.hpp>
 #include <nix/base/INamedEntity.hpp>
+#include <nix/ObjectType.hpp>
 
 #include <nix/NDSize.hpp>
 
@@ -83,6 +84,13 @@ public:
 
 
 } // namespace base
+
+template<>
+struct objectToType<nix::base::IProperty> {
+    static const bool isValid = true;
+    static const ObjectType value = ObjectType::Property;
+};
+
 } // namespace nix
 
 #endif // NIX_I_PROPERTY_H

--- a/include/nix/base/ISection.hpp
+++ b/include/nix/base/ISection.hpp
@@ -16,6 +16,7 @@
 #include <nix/DataType.hpp>
 #include <nix/Value.hpp>
 #include <nix/NDSize.hpp>
+#include <nix/ObjectType.hpp>
 
 #include <string>
 #include <vector>
@@ -127,6 +128,13 @@ public:
 
 
 } // namespace base
+
+template<>
+struct objectToType<nix::base::ISection> {
+    static const bool isValid = true;
+    static const ObjectType value = ObjectType::Section;
+};
+
 } // namespace nix
 
 #endif // NIX_I_SECTION_H

--- a/include/nix/base/ISource.hpp
+++ b/include/nix/base/ISource.hpp
@@ -11,6 +11,8 @@
 
 
 #include <nix/base/IEntityWithMetadata.hpp>
+#include <nix/ObjectType.hpp>
+
 #include <string>
 #include <memory>
 
@@ -58,6 +60,13 @@ public:
 
 
 } // namespace base
+
+template<>
+struct objectToType<nix::base::ISource> {
+    static const bool isValid = true;
+    static const ObjectType value = ObjectType::Source;
+};
+
 } // namespace nix
 
 #endif // NIX_I_SOURCE_H

--- a/include/nix/base/ITag.hpp
+++ b/include/nix/base/ITag.hpp
@@ -13,6 +13,7 @@
 #include <nix/base/IDataArray.hpp>
 #include <nix/base/IFeature.hpp>
 #include <nix/base/IBaseTag.hpp>
+#include <nix/ObjectType.hpp>
 
 #include <string>
 #include <vector>
@@ -62,6 +63,13 @@ public:
 
 
 } // namespace base
+
+template<>
+struct objectToType<nix::base::ITag> {
+    static const bool isValid = true;
+    static const ObjectType value = ObjectType::Tag;
+};
+
 } // namespace nix
 
 #endif // NIX_I_TAG_H

--- a/src/Block.cpp
+++ b/src/Block.cpp
@@ -69,24 +69,9 @@ DataArray Block::createDataArray(const std::string &name, const std::string &typ
     return backend()->createDataArray(name, type, data_type, shape);
 }
 
-bool Block::hasDataArray(const DataArray &data_array) const {
-    if (!util::checkEntityInput(data_array, false)) {
-        return false;
-    }
-    DataArray da = backend()->getDataArray(data_array.name());
-    return  da && da.id() == data_array.id();
-}
-
 std::vector<DataArray> Block::dataArrays(const util::AcceptAll<DataArray>::type &filter) const {
     auto f = [this] (size_t i) { return getDataArray(i); };
     return getEntities<DataArray>(f, dataArrayCount(), filter);
-}
-
-bool Block::deleteDataArray(const DataArray &data_array) {
-    if (!util::checkEntityInput(data_array, false)) {
-        return false;
-    }
-    return backend()->deleteDataArray(data_array.name());
 }
 
 Tag Block::createTag(const std::string &name, const std::string &type, const std::vector<double> &position) {

--- a/src/Block.cpp
+++ b/src/Block.cpp
@@ -106,18 +106,10 @@ std::vector<MultiTag> Block::multiTags(const util::AcceptAll<MultiTag>::type &fi
 
 Group Block::createGroup(const std::string &name, const std::string &type) {
     util::checkEntityNameAndType(name, type);
-    if (backend()->hasGroup(name)) {
+    if (hasGroup(name)) {
         throw DuplicateName("createGroup");
     }
     return backend()->createGroup(name, type);
-}
-
-bool Block::hasGroup(const Group &group) const {
-    if (!util::checkEntityInput(group, false)) {
-        return false;
-    }
-    Group g = backend()->getGroup(group.name());
-    return g && g.id() == group.id();
 }
 
 std::vector<Group> Block::groups(const util::AcceptAll<Group>::type &filter) const {
@@ -125,12 +117,6 @@ std::vector<Group> Block::groups(const util::AcceptAll<Group>::type &filter) con
     return getEntities<Group>(f, groupCount(), filter);
 }
 
-bool Block::deleteGroup(const Group &group) {
-    if (!util::checkEntityInput(group, false)) {
-        return false;
-    }
-    return backend()->deleteGroup(group.name());
-}
 
 std::ostream &operator<<(std::ostream &out, const Block &ent) {
     out << "Block: {name = " << ent.name();

--- a/src/Block.cpp
+++ b/src/Block.cpp
@@ -93,37 +93,15 @@ MultiTag Block::createMultiTag(const std::string &name, const std::string &type,
     if(!positions.isValidEntity()) {
         throw UninitializedEntity();
     }
-    if (backend()->hasMultiTag(name)) {
+    if (hasMultiTag(name)) {
         throw DuplicateName("createMultiTag");
     }
     return backend()->createMultiTag(name, type, positions);
 }
 
-MultiTag Block::getMultiTag(ndsize_t index) const {
-    if (index >= backend()->multiTagCount()) {
-        throw nix::OutOfBounds("Block::getMultiTag: index is out of bounds!");
-    }
-    return backend()->getMultiTag(index);
-}
-
-bool Block::hasMultiTag(const MultiTag &multi_tag) const {
-    if (!util::checkEntityInput(multi_tag, false)) {
-        return false;
-    }
-    MultiTag mt = backend()->getMultiTag(multi_tag.name());
-    return mt && mt.id() == multi_tag.id();
-}
-
 std::vector<MultiTag> Block::multiTags(const util::AcceptAll<MultiTag>::type &filter) const {
     auto f = [this] (ndsize_t i) { return getMultiTag(i); };
     return getEntities<MultiTag>(f, multiTagCount(), filter);
-}
-
-bool Block::deleteMultiTag(const MultiTag &multi_tag) {
-    if (!util::checkEntityInput(multi_tag, false)) {
-        return false;
-    }
-    return backend()->deleteMultiTag(multi_tag.name());
 }
 
 Group Block::createGroup(const std::string &name, const std::string &type) {

--- a/src/Block.cpp
+++ b/src/Block.cpp
@@ -13,7 +13,7 @@ namespace nix {
 
 Source Block::createSource(const std::string &name, const std::string &type){
     util::checkEntityNameAndType(name, type);
-    if (backend()->hasSource(name)) {
+    if (hasSource(name)) {
         throw DuplicateName("createSource");
     }
     return backend()->createSource(name, type);
@@ -31,21 +31,6 @@ std::vector<Source> Block::findSources(const util::Filter<Source>::type &filter,
     }
 
     return result;
-}
-
-bool Block::hasSource(const Source &source) const {
-    if (!util::checkEntityInput(source, false)) {
-        return false;
-    }
-    Source s = backend()->getSource(source.name());
-    return s && s.id() == source.id();
-}
-
-Source Block::getSource(ndsize_t index) const {
-    if (index >= backend()->sourceCount()) {
-        throw OutOfBounds("Block::getSource: index is out of bounds!");
-    }
-    return backend()->getSource(index);
 }
 
 std::vector<Source> Block::sources(const util::Filter<Source>::type &filter) const {

--- a/src/Block.cpp
+++ b/src/Block.cpp
@@ -63,7 +63,7 @@ bool Block::deleteSource(const Source &source) {
 DataArray Block::createDataArray(const std::string &name, const std::string &type, nix::DataType data_type,
                                  const NDSize &shape) {
     util::checkEntityNameAndType(name, type);
-    if (backend()->hasDataArray(name)){
+    if (hasDataArray(name)){
         throw DuplicateName("create DataArray");
     }
     return backend()->createDataArray(name, type, data_type, shape);

--- a/src/Block.cpp
+++ b/src/Block.cpp
@@ -76,37 +76,15 @@ std::vector<DataArray> Block::dataArrays(const util::AcceptAll<DataArray>::type 
 
 Tag Block::createTag(const std::string &name, const std::string &type, const std::vector<double> &position) {
     util::checkEntityNameAndType(name, type);
-    if (backend()->hasTag(name)){
+    if (hasTag(name)){
         throw DuplicateName("create Tag");
     }
     return backend()->createTag(name, type, position);
 }
 
-bool Block::hasTag(const Tag &tag) const {
-    if (!util::checkEntityInput(tag, false)) {
-        return false;
-    }
-    Tag t = backend()->getTag(tag.name());
-    return  t && t.id() == tag.id();
-}
-
-Tag Block::getTag(ndsize_t index) const {
-    if (index >= backend()->tagCount()) {
-        throw nix::OutOfBounds("Block::getTag: Index is out of Bounds!");
-    }
-    return backend()->getTag(index);
-}
-
 std::vector<Tag> Block::tags(const util::Filter<Tag>::type &filter) const {
     auto f = [this] (ndsize_t i) { return getTag(i); };
     return getEntities<Tag>(f, tagCount(), filter);
-}
-
-bool Block::deleteTag(const Tag &tag) {
-    if (!util::checkEntityInput(tag, false)) {
-        return false;
-    }
-    return backend()->deleteTag(tag.name());
 }
 
 MultiTag Block::createMultiTag(const std::string &name, const std::string &type, const DataArray &positions) {

--- a/src/Group.cpp
+++ b/src/Group.cpp
@@ -11,41 +11,17 @@
 
 using namespace nix;
 
-bool Group::hasDataArray(const DataArray &data_array) const {
-    if (!util::checkEntityInput(data_array, false)) {
-        return false;
+
+
     }
-    return backend()->hasDataArray(data_array.id());
-}
-
-
-DataArray Group::getDataArray(size_t index) const {
-    if(index >= backend()->dataArrayCount()) {
-        throw OutOfBounds("No dataArray at given index", index);
-    }
-    return backend()->getDataArray(index);
-}
-
-
-void Group::addDataArray(const DataArray &data_array) {
-    if (!util::checkEntityInput(data_array)) {
-        throw UninitializedEntity();
     }
     backend()->addDataArray(data_array.id());
 }
 
 
-void Group::addDataArray(const std::string &id) {
-    util::checkNameOrId(id);
-    backend()->addDataArray(id);
-}
-
-
-bool Group::removeDataArray(const DataArray &data_array) {
-    if (!util::checkEntityInput(data_array, false)) {
-        return false;
+    for (const auto &da : rem) {
+        removeDataArray(da);
     }
-    return backend()->removeDataArray(data_array.id());
 }
 
 

--- a/src/Group.cpp
+++ b/src/Group.cpp
@@ -11,13 +11,29 @@
 
 using namespace nix;
 
+void Group::dataArrays(const std::vector<DataArray> &data_arrays) {
+    auto cmp = [](const DataArray &a, const DataArray& b) { return a.name() < b.name(); };
 
+    std::vector<DataArray> new_arrays(data_arrays);
+    size_t array_count = nix::check::fits_in_size_t(dataArrayCount(), "dataArrayCount() failed; count > size_t.");
+    std::vector<DataArray> old_arrays(array_count);
 
+    for (size_t i = 0; i < old_arrays.size(); i++) {//check if this can be replaced
+        old_arrays[i] = getDataArray(i);
     }
-    }
-    backend()->addDataArray(data_array.id());
-}
+    std::sort(new_arrays.begin(), new_arrays.end(), cmp);
+    std::sort(old_arrays.begin(), old_arrays.end(), cmp);
+    std::vector<DataArray> add;
+    std::vector<DataArray> rem;
 
+    std::set_difference(new_arrays.begin(), new_arrays.end(), old_arrays.begin(),
+                        old_arrays.end(), std::inserter(add, add.begin()), cmp);
+    std::set_difference(old_arrays.begin(), old_arrays.end(), new_arrays.begin(),
+                        new_arrays.end(), std::inserter(rem, rem.begin()), cmp);
+
+    for (const auto &da : add) {
+        addDataArray(da);
+    }
 
     for (const auto &da : rem) {
         removeDataArray(da);

--- a/src/Group.cpp
+++ b/src/Group.cpp
@@ -11,33 +11,46 @@
 
 using namespace nix;
 
-void Group::dataArrays(const std::vector<DataArray> &data_arrays) {
-    auto cmp = [](const DataArray &a, const DataArray& b) { return a.name() < b.name(); };
+template<typename T>
+void Group::replaceEntities(const std::vector<T> &entities)
+{
+    base::IGroup *ig = backend();
+    ObjectType ot = objectToType<T>::value;
 
-    std::vector<DataArray> new_arrays(data_arrays);
-    size_t array_count = nix::check::fits_in_size_t(dataArrayCount(), "dataArrayCount() failed; count > size_t.");
-    std::vector<DataArray> old_arrays(array_count);
+    auto cmp = [](const T &a, const T& b) { return a.name() < b.name(); };
 
-    for (size_t i = 0; i < old_arrays.size(); i++) {//check if this can be replaced
-        old_arrays[i] = getDataArray(i);
+    std::vector<T> new_arrays(entities);
+
+    ndsize_t current = ig->entityCount(ot);
+    size_t count = nix::check::fits_in_size_t(current, "entityCount() failed; count > size_t.");
+    std::vector<T> old_arrays(count);
+
+    //check if this can be replaced
+    for (size_t i = 0; i < old_arrays.size(); i++) {
+        old_arrays[i] = ig->getEntity<typename objectToType<T>::backendType>(i);
     }
+
     std::sort(new_arrays.begin(), new_arrays.end(), cmp);
     std::sort(old_arrays.begin(), old_arrays.end(), cmp);
-    std::vector<DataArray> add;
-    std::vector<DataArray> rem;
+    std::vector<T> add;
+    std::vector<T> rem;
 
     std::set_difference(new_arrays.begin(), new_arrays.end(), old_arrays.begin(),
                         old_arrays.end(), std::inserter(add, add.begin()), cmp);
     std::set_difference(old_arrays.begin(), old_arrays.end(), new_arrays.begin(),
                         new_arrays.end(), std::inserter(rem, rem.begin()), cmp);
 
-    for (const auto &da : add) {
-        addDataArray(da);
+    for (const auto &e : add) {
+        ig->addEntity(e);
     }
 
-    for (const auto &da : rem) {
-        removeDataArray(da);
+    for (const auto &e : rem) {
+        ig->removeEntity(e);
     }
+}
+
+void Group::dataArrays(const std::vector<DataArray> &data_arrays) {
+    replaceEntities(data_arrays);
 }
 
 
@@ -50,32 +63,7 @@ std::vector<DataArray> Group::dataArrays(const util::Filter<DataArray>::type &fi
 
 
 void Group::tags(const std::vector<Tag> &tags) {
-    auto cmp = [](const Tag &a, const Tag& b) { return a.name() < b.name(); };
-
-    std::vector<Tag> new_tags(tags);
-    size_t tag_count = nix::check::fits_in_size_t(tagCount(), "tagCount() failed; count > size_t.");
-    std::vector<Tag> old_tags(tag_count);
-
-    for (size_t i = 0; i < old_tags.size(); i++) {//check if this can be replaced
-        old_tags[i] = getTag(i);
-    }
-    std::sort(new_tags.begin(), new_tags.end(), cmp);
-    std::sort(old_tags.begin(), old_tags.end(), cmp);
-    std::vector<Tag> add;
-    std::vector<Tag> rem;
-
-    std::set_difference(new_tags.begin(), new_tags.end(), old_tags.begin(),
-                        old_tags.end(), std::inserter(add, add.begin()), cmp);
-    std::set_difference(old_tags.begin(), old_tags.end(), new_tags.begin(),
-                        new_tags.end(), std::inserter(rem, rem.begin()), cmp);
-
-    for (const auto &t : add) {
-        addTag(t);
-    }
-
-    for (const auto &t : rem) {
-        removeTag(t);
-    }
+    replaceEntities(tags);
 }
 
 std::vector<Tag> Group::tags(const util::Filter<Tag>::type &filter) const {
@@ -91,32 +79,7 @@ std::vector<MultiTag> Group::multiTags(const util::Filter<MultiTag>::type &filte
 
 
 void Group::multiTags(const std::vector<MultiTag> &tags) {
-    auto cmp = [](const MultiTag &a, const MultiTag& b) { return a.name() < b.name(); };
-
-    std::vector<MultiTag> new_tags(tags);
-    size_t tag_count = nix::check::fits_in_size_t(multiTagCount(), "multiTagCount() failed; count > size_t.");
-    std::vector<MultiTag> old_tags(tag_count);
-
-    for (size_t i = 0; i < old_tags.size(); i++) {//check if this can be replaced
-        old_tags[i] = getMultiTag(i);
-    }
-    std::sort(new_tags.begin(), new_tags.end(), cmp);
-    std::sort(old_tags.begin(), old_tags.end(), cmp);
-    std::vector<MultiTag> add;
-    std::vector<MultiTag> rem;
-
-    std::set_difference(new_tags.begin(), new_tags.end(), old_tags.begin(),
-                        old_tags.end(), std::inserter(add, add.begin()), cmp);
-    std::set_difference(old_tags.begin(), old_tags.end(), new_tags.begin(),
-                        new_tags.end(), std::inserter(rem, rem.begin()), cmp);
-
-    for (const auto &t : add) {
-        addMultiTag(t);
-    }
-
-    for (const auto &t : rem) {
-        removeMultiTag(t);
-    }
+    replaceEntities(tags);
 }
 
 

--- a/src/Identity.cpp
+++ b/src/Identity.cpp
@@ -1,0 +1,16 @@
+#include <nix/Identity.hpp>
+#include <nix/util/util.hpp>
+
+namespace nix {
+
+Identity::Identity(const std::string &name_or_id, ObjectType type)
+    : myType(type) {
+
+    if (util::looksLikeUUID(name_or_id)) {
+        myId = name_or_id;
+    } else {
+        myName = name_or_id;
+    }
+}
+
+} //nix::

--- a/test/BaseTestBlock.cpp
+++ b/test/BaseTestBlock.cpp
@@ -123,6 +123,7 @@ void BaseTestBlock::testDataArrayAccess() {
     CPPUNIT_ASSERT(block.dataArrayCount() == 0);
     CPPUNIT_ASSERT(block.dataArrays().size() == 0);
     CPPUNIT_ASSERT(block.getDataArray("invalid_id") == false);
+    CPPUNIT_ASSERT_THROW(block.getDataArray(block.dataArrayCount() + 10), OutOfBounds);
 
     std::vector<std::string> ids;
     for (const auto &name : names) {
@@ -139,6 +140,7 @@ void BaseTestBlock::testDataArrayAccess() {
     CPPUNIT_ASSERT(!block.hasDataArray(a));
     CPPUNIT_ASSERT(block.dataArrayCount() == names.size());
     CPPUNIT_ASSERT(block.dataArrays().size() == names.size());
+    CPPUNIT_ASSERT_THROW(block.getDataArray(block.dataArrayCount() + 10), OutOfBounds);
 
     for (const auto &name : names) {
         DataArray da_name = block.getDataArray(name);
@@ -187,6 +189,7 @@ void BaseTestBlock::testTagAccess() {
     CPPUNIT_ASSERT(block.tags().size() == 0);
     CPPUNIT_ASSERT(block.getTag("invalid_id") == false);
     CPPUNIT_ASSERT(!block.hasTag(t));
+    CPPUNIT_ASSERT_THROW(block.getTag(block.tagCount() + 10), OutOfBounds);
 
     std::vector<std::string> ids;
     for (auto it = names.begin(); it != names.end(); ++it) {
@@ -201,6 +204,7 @@ void BaseTestBlock::testTagAccess() {
 
     CPPUNIT_ASSERT(block.tagCount() == names.size());
     CPPUNIT_ASSERT(block.tags().size() == names.size());
+    CPPUNIT_ASSERT_THROW(block.getTag(block.tagCount() + 10), OutOfBounds);
 
     for (auto it = ids.begin(); it != ids.end(); ++it) {
         tag = block.getTag(*it);
@@ -232,6 +236,8 @@ void BaseTestBlock::testMultiTagAccess() {
     CPPUNIT_ASSERT(block.multiTags().size() == 0);
     CPPUNIT_ASSERT(block.getMultiTag("invalid_id") == false);
     CPPUNIT_ASSERT(!block.hasMultiTag(m));
+    CPPUNIT_ASSERT_THROW(block.getMultiTag(block.multiTagCount() + 10), OutOfBounds);
+
     std::vector<std::string> ids;
     for (auto it = names.begin(); it != names.end(); it++) {
         mtag = block.createMultiTag(*it, "segment", positions);
@@ -244,6 +250,7 @@ void BaseTestBlock::testMultiTagAccess() {
 
     CPPUNIT_ASSERT(block.multiTagCount() == names.size());
     CPPUNIT_ASSERT(block.multiTags().size() == names.size());
+    CPPUNIT_ASSERT_THROW(block.getMultiTag(block.multiTagCount() + 10), OutOfBounds);
 
     for (auto it = ids.begin(); it != ids.end(); it++) {
         mtag = block.getMultiTag(*it);
@@ -270,6 +277,7 @@ void BaseTestBlock::testGroupAccess() {
     CPPUNIT_ASSERT(block.groups().size() == 0);
     CPPUNIT_ASSERT(block.getGroup("invalid_id") == false);
     CPPUNIT_ASSERT(!block.hasGroup("invalid_id"));
+    CPPUNIT_ASSERT_THROW(block.getGroup(block.groupCount() + 10), OutOfBounds);
 
     std::vector<std::string> ids;
     for (const auto &name : names) {
@@ -285,6 +293,7 @@ void BaseTestBlock::testGroupAccess() {
 
     CPPUNIT_ASSERT(block.groupCount() == names.size());
     CPPUNIT_ASSERT(block.groups().size() == names.size());
+    CPPUNIT_ASSERT_THROW(block.getGroup(block.groupCount() + 10), OutOfBounds);
 
     for (const auto &id : ids) {
         Group gr = block.getGroup(id);
@@ -341,7 +350,7 @@ void BaseTestBlock::testUpdatedAt() {
 void BaseTestBlock::testCompare() {
     std::string other_name = block_other.name();
     std::string block_name = block.name();
-        
+
     CPPUNIT_ASSERT(block.compare(block) == 0);
     CPPUNIT_ASSERT(block.compare(block_other) ==  block_name.compare(other_name));
 }


### PR DESCRIPTION
Instead of having specialised {has,get,count,remove}XYZ methods defined on `IBlock`,
we now have  generic methods; this removes code duplication in the backend.
This is also step one to generalise the bulk replacement of entities.
Additionally a new Identity class is used for these methods that should solve issue #673.
The current PR does it for `Block` and the `hdf5` backend. Will break the `filesystem`
backend.