### PR TITLE
[Test] Failing test for read only group creation

### DIFF
--- a/test/BaseTestFile.cpp
+++ b/test/BaseTestFile.cpp
@@ -189,3 +189,15 @@ void BaseTestFile::testReopen() {
 
     CPPUNIT_ASSERT(file_open.fileMode() == FileMode::Overwrite);
 }
+
+
+void BaseTestFile::testReopenReadOnly() {
+    Block b = file_open.createBlock("a", "a");
+    b = none;
+    file_open.close();
+
+    file_open = nix::File::open("test_file_ro.h5", FileMode::ReadOnly);
+    b = file_open.getBlock("b");
+
+    CPPUNIT_ASSERT(b.dataArrayCount() == 0);
+}

--- a/test/BaseTestFile.hpp
+++ b/test/BaseTestFile.hpp
@@ -46,6 +46,7 @@ public:
     void testSectionAccess();
     void testOperators();
     void testReopen();
+    void testReopenReadOnly();
     void testCheckHeader();
     void testCompare();
 

--- a/test/fs/TestFileFS.hpp
+++ b/test/fs/TestFileFS.hpp
@@ -25,6 +25,7 @@ class TestFileFS: public BaseTestFile {
     CPPUNIT_TEST(testSectionAccess);
     CPPUNIT_TEST(testOperators);
     CPPUNIT_TEST(testReopen);
+    CPPUNIT_TEST(testReopenReadOnly);
     CPPUNIT_TEST(testCheckHeader);
     CPPUNIT_TEST(testNonNix);
 

--- a/test/hdf5/TestFileHDF5.hpp
+++ b/test/hdf5/TestFileHDF5.hpp
@@ -22,6 +22,7 @@ class TestFileHDF5: public BaseTestFile {
     CPPUNIT_TEST(testSectionAccess);
     CPPUNIT_TEST(testOperators);
     CPPUNIT_TEST(testReopen);
+    CPPUNIT_TEST(testReopenReadOnly);
     CPPUNIT_TEST_SUITE_END ();
 
 public:


### PR DESCRIPTION
New test for retrieving information (count) for groups that do not exist and the file is open Read Only.

Test fails when requesting the number of items in a container group that
doesn't exit and the file is in open RO.