### PR TITLE
Fix findRelated 

### DIFF
--- a/include/nix/Section.hpp
+++ b/include/nix/Section.hpp
@@ -539,7 +539,7 @@ private:
 
     std::vector<Section> findDownstream(const std::function<bool(Section)> &filter) const;
 
-    std::vector<Section> findUpstream(const std::function<bool(Section)> &filter) const;
+    std::vector<Section> findAmongParents(const std::function<bool(Section)> &filter) const;
 
     std::vector<Section> findSideways(const std::function<bool(Section)> &filter, const std::string &caller_id) const;
 

--- a/src/Section.cpp
+++ b/src/Section.cpp
@@ -127,6 +127,7 @@ static inline auto erase_section_with_id(std::vector<Section> &sections, const s
     return sections.size();
 }
 
+
 std::vector<Section> Section::findRelated(const util::Filter<Section>::type &filter) const
 {
     std::vector<Section> results = findDownstream(filter);
@@ -134,13 +135,11 @@ std::vector<Section> Section::findRelated(const util::Filter<Section>::type &fil
 
     //This checking of results can be removed if we decide not to include this in findSection
     auto results_size = erase_section_with_id(results, my_id);
-
     if (results_size == 0) {
-        results = findUpstream(filter);
+        results = findAmongParents(filter);
     }
-    //This checking of results can be removed if we decide not to include this in findSection
-    results_size = erase_section_with_id(results, my_id);
 
+    results_size = erase_section_with_id(results, my_id);
     if (results_size == 0) {
         results = findSideways(filter, id());
     }
@@ -174,7 +173,6 @@ bool Section::deleteProperty(const Property &property) {
 }
 
 std::vector<Property> Section::inheritedProperties() const {
-
     std::vector<Property> own = properties();
 
     if (link() == none)
@@ -212,7 +210,7 @@ size_t Section::tree_depth() const{
 }
 
 
-std::vector<Section> Section::findDownstream(const std::function<bool(Section)> &filter) const{
+std::vector<Section> Section::findDownstream(const std::function<bool(Section)> &filter) const {
     std::vector<Section> results;
     size_t max_depth = tree_depth();
     size_t actual_depth = 1;
@@ -224,18 +222,18 @@ std::vector<Section> Section::findDownstream(const std::function<bool(Section)> 
 }
 
 
-std::vector<Section> Section::findUpstream(const std::function<bool(Section)> &filter) const{
+std::vector<Section> Section::findAmongParents(const std::function<bool(Section)> &filter) const {
     std::vector<Section> results;
     Section p = parent();
-
-    if (p != none) {
-        results = p.findSections(filter,1);
-        if (results.size() > 0) {
-            return results;
-        }
-        return p.findUpstream(filter);
+    if (p == none) {
+        return results;
     }
-    return results;
+    if (filter(p)) {
+        results.push_back(p);
+        return results;
+    } else {
+        return p.findAmongParents(filter);
+    }
 }
 
 

--- a/test/BaseTestSection.cpp
+++ b/test/BaseTestSection.cpp
@@ -110,8 +110,65 @@ void BaseTestSection::testLink() {
     CPPUNIT_ASSERT(section.link().id() == section_other.id());
     // test deleter removing link too
     section.link(section);
+     /* We create the following tree:
+     *
+     * section---l1n1---l2n1---l3n1------------
+     *            |      |                    |
+     *            ------l2n2---l3n2---l4n1---l5n1
+     *                   |      |      |
+     *                   ------l3n3---l4n2
+     * section_other------------|
+     */
+    Section l1n1 = section.createSection("l1n1", "typ1");
+
+    Section l2n1 = l1n1.createSection("l2n1", "t1");
+    Section l2n2 = l1n1.createSection("l2n2", "t2");
+    Section l3n1 = l2n1.createSection("l3n1", "t3");
+    Section l3n2 = l2n2.createSection("l3n2", "t3");
+    Section l3n3 = l2n2.createSection("l3n3", "t4");
+    Section l4n1 = l3n2.createSection("l4n1", "typ2");
+    Section l4n2 = l3n3.createSection("l4n2", "typ2");
+    Section l5n1 = l4n1.createSection("l5n1", "typ2");
+
+    l2n1.link(l2n2.id());
+    l3n1.link(l5n1.id());
+    l3n2.link(l3n3.id());
+    l4n1.link(l4n2.id());
+    section_other.link(l3n3.id());
+    /* Chop the tree to:
+     *
+     * section---l1n1---l2n1---l3n1
+     * section_other
+     *
+     */
+    l1n1.deleteSection(l2n2.id());
+    CPPUNIT_ASSERT(section.findSections().size() == 3);
+
+    // test that all (horizontal) links are gone too:
+    CPPUNIT_ASSERT(!l2n1.link());
+    CPPUNIT_ASSERT(!l3n1.link());
+    CPPUNIT_ASSERT(!l3n2.link());
+    CPPUNIT_ASSERT(!l4n1.link());
+
+    CPPUNIT_ASSERT(!section_other.link());
+    CPPUNIT_ASSERT(!l1n1.hasSection(l2n2));
+
+    /* Extend the tree to:
+     *
+     * section---l1n1---l2n1---l3n1
+     * section_other-----|
+     *
+     * and then chop it down to:
+     *
+     * section_other
+     *
+     */
+    section_other.link(l2n1.id());
     file.deleteSection(section.id());
-    CPPUNIT_ASSERT(!section.link());
+    CPPUNIT_ASSERT(section_other.findSections().size() == 0);
+    CPPUNIT_ASSERT(!section_other.link());
+    // re-create section
+    section = file.createSection("section", "metadata");
 }
 
 
@@ -205,91 +262,9 @@ void BaseTestSection::testFindSection() {
     CPPUNIT_ASSERT(section.findSections(filter_typ2).size() == 8);
 }
 
-void BaseTestSection::testFindRelated() {
-    /* We create the following tree:
-     *
-     * section---l1n1---l2n1---l3n1------------
-     *            |      |                    |
-     *            ------l2n2---l3n2---l4n1---l5n1
-     *                   |      |      |
-     *                   ------l3n3---l4n2
-     * section_other------------|
-     */
-    Section l1n1 = section.createSection("l1n1", "typ1");
 
-    Section l2n1 = l1n1.createSection("l2n1", "t1");
-    Section l2n2 = l1n1.createSection("l2n2", "t2");
-    Section l3n1 = l2n1.createSection("l3n1", "t3");
-    Section l3n2 = l2n2.createSection("l3n2", "t3");
-    Section l3n3 = l2n2.createSection("l3n3", "t4");
-    Section l4n1 = l3n2.createSection("l4n1", "typ2");
-    Section l4n2 = l3n3.createSection("l4n2", "typ2");
-    Section l5n1 = l4n1.createSection("l5n1", "typ2");
 
-    l2n1.link(l2n2.id());
-    l3n1.link(l5n1.id());
-    l3n2.link(l3n3.id());
-    l4n1.link(l4n2.id());
-    section_other.link(l3n3.id());
 
-    std::string t1 = "t1";
-    std::string t3 = "t3";
-    std::string t4 = "t4";
-    std::string typ2 = "typ2";
-    std::string typ1 = "typ1";
-
-    std::vector<Section> related = l1n1.findRelated(util::TypeFilter<Section>(t1));
-    CPPUNIT_ASSERT(related.size() == 1);
-    related = l1n1.findRelated(util::TypeFilter<Section>(t3));
-    CPPUNIT_ASSERT(related.size() == 2);
-    related = l1n1.findRelated(util::TypeFilter<Section>(t4));
-    CPPUNIT_ASSERT(related.size() == 1);
-    related = l1n1.findRelated(util::TypeFilter<Section>(typ2));
-    CPPUNIT_ASSERT(related.size() == 2);
-    related = l4n1.findRelated(util::TypeFilter<Section>(typ1));
-    CPPUNIT_ASSERT(related.size() == 1);
-    related = l4n1.findRelated(util::TypeFilter<Section>(t1));
-    CPPUNIT_ASSERT(related.size() == 1);
-    related = l3n2.findRelated(util::TypeFilter<Section>(t1));
-    CPPUNIT_ASSERT(related.size() == 1);
-    related = l3n2.findRelated(util::TypeFilter<Section>(t3));
-    CPPUNIT_ASSERT(related.size() == 0);
-
-    /* Chop the tree to:
-     *
-     * section---l1n1---l2n1---l3n1
-     * section_other
-     *
-     */
-    l1n1.deleteSection(l2n2.id());
-
-    CPPUNIT_ASSERT(section.findSections().size() == 3);
-
-    // test that all (horizontal) links are gone too:
-    CPPUNIT_ASSERT(!l2n1.link());
-    CPPUNIT_ASSERT(!l3n1.link());
-    CPPUNIT_ASSERT(!l3n2.link());
-    CPPUNIT_ASSERT(!l4n1.link());
-
-    CPPUNIT_ASSERT(!section_other.link());
-    CPPUNIT_ASSERT(!l1n1.hasSection(l2n2));
-
-    /* Extend the tree to:
-     *
-     * section---l1n1---l2n1---l3n1
-     * section_other-----|
-     *
-     * and then chop it down to:
-     *
-     * section_other
-     *
-     */
-    section_other.link(l2n1.id());
-    file.deleteSection(section.id());
-    CPPUNIT_ASSERT(section_other.findSections().size() == 0);
-    CPPUNIT_ASSERT(!section_other.link());
-    // re-create section
-    section = file.createSection("section", "metadata");
 }
 
 

--- a/test/BaseTestSection.cpp
+++ b/test/BaseTestSection.cpp
@@ -294,7 +294,7 @@ void BaseTestSection::testFindRelated() {
                       |-- l3n4 [t1]
                            |-- l4n3 [t3]
     */
-    Section l1n1 = file.createSection("L1N1", "t1");
+    Section l1n1 = section.createSection("L1N1", "t1");
 
     Section l2n1 = l1n1.createSection("L2N1", "t2");
     Section l2n2 = l1n1.createSection("L2N2", "t3");
@@ -332,9 +332,9 @@ void BaseTestSection::testFindRelated() {
     CPPUNIT_ASSERT(results.size() == 2);
     CPPUNIT_ASSERT(findSectionsInVector(results, {"L4N1", "L4N2"}));
     // ----------- l2n1 -------------
-    results = l2n1.findRelated(nix::util::TypeFilter<nix::Section>("t1")); //fails
-    //    CPPUNIT_ASSERT(results.size() == 1);
-    // CPPUNIT_ASSERT(findSectionsInVector(results, {"L1N1"}));
+    results = l2n1.findRelated(nix::util::TypeFilter<nix::Section>("t1"));
+    CPPUNIT_ASSERT(results.size() == 1);
+    CPPUNIT_ASSERT(findSectionsInVector(results, {"L1N1"}));
 
     results = l2n1.findRelated(nix::util::TypeFilter<nix::Section>("t2"));
     CPPUNIT_ASSERT(results.size() == 1);
@@ -353,7 +353,7 @@ void BaseTestSection::testFindRelated() {
     CPPUNIT_ASSERT(findSectionsInVector(results, {"L4N1"}));
 
     // ----------- l2n2 -------------
-    results = l2n2.findRelated(nix::util::TypeFilter<nix::Section>("t3")); //fails
+    results = l2n2.findRelated(nix::util::TypeFilter<nix::Section>("t3"));
     CPPUNIT_ASSERT(results.size() == 1);
     CPPUNIT_ASSERT(findSectionsInVector(results, {"L2N4"}));
 
@@ -362,10 +362,10 @@ void BaseTestSection::testFindRelated() {
     CPPUNIT_ASSERT(findSectionsInVector(results, {"L2N1", "L2N3"}));
 
     results = l2n2.findRelated(nix::util::TypeFilter<nix::Section>("t4"));
-    //CPPUNIT_ASSERT(results.size() == 0); // fails finds L5N1?!
+    CPPUNIT_ASSERT(results.size() == 0);
 
     results = l2n2.findRelated(nix::util::TypeFilter<nix::Section>("t5"));
-    //CPPUNIT_ASSERT(results.size() == 0); // fails finds L4N2!?
+    CPPUNIT_ASSERT(results.size() == 0);
 
     // ----------- l2n4 -------------
     results = l2n4.findRelated(nix::util::TypeFilter<nix::Section>("t1"));
@@ -390,8 +390,8 @@ void BaseTestSection::testFindRelated() {
 
     // ----------- l3n1 -------------
     results = l3n1.findRelated(nix::util::TypeFilter<nix::Section>("t1"));
-    // CPPUNIT_ASSERT(results.size() == 1);
-    // CPPUNIT_ASSERT(findSectionsInVector(results, {"L1N1"}));
+    CPPUNIT_ASSERT(results.size() == 1);
+    CPPUNIT_ASSERT(findSectionsInVector(results, {"L1N1"}));
 
     results = l3n1.findRelated(nix::util::TypeFilter<nix::Section>("t2"));
     CPPUNIT_ASSERT(results.size() == 1);
@@ -410,15 +410,12 @@ void BaseTestSection::testFindRelated() {
 
     // ----------- l4n1 --------------
     results = l4n1.findRelated(nix::util::TypeFilter<nix::Section>("t1"));
-    //fails! not found if absolute parent since this is no longer in found list!
-    //    CPPUNIT_ASSERT(results.size() == 1);
-    // CPPUNIT_ASSERT(findSectionsInVector(results, {"L1N1"}));
+    CPPUNIT_ASSERT(results.size() == 1);
+    CPPUNIT_ASSERT(findSectionsInVector(results, {"L1N1"}));
 
     results = l4n1.findRelated(nix::util::TypeFilter<nix::Section>("t2"));
-    // fails! probably also since this is not in result set, will then only be found if parent is checked...
-    // CPPUNIT_ASSERT(results.size() == 1);
-    // CPPUNIT_ASSERT(findSectionsInVector(results, {"L2N1"}));
-
+    CPPUNIT_ASSERT(results.size() == 1);
+    CPPUNIT_ASSERT(findSectionsInVector(results, {"L2N1"}));
     section.deleteSection(l1n1);
 }
 


### PR DESCRIPTION
Due to our recent changes in findSection (exclude of the root section) the findRelated did not work properly in all cases (not caught by the tests :( ).
Extended the test cases and simplified findRelated, should fix #691