### PR TITLE
Fix ARM build: remove explicit tmpl instantiation

### DIFF
--- a/include/nix/base/types.hpp
+++ b/include/nix/base/types.hpp
@@ -22,19 +22,4 @@
 #include <nix/base/IMultiTag.hpp>
 #include <nix/base/IDataArray.hpp>
 
-namespace nix {
-namespace base {
-
-template class Entity<base::IProperty>;
-template class Entity<base::IFeature>;
-template class NamedEntity<base::ISection>;
-template class EntityWithMetadata<base::ISource>;
-template class EntityWithMetadata<base::IBlock>;
-template class EntityWithSources<base::ITag>;
-template class EntityWithSources<base::IMultiTag>;
-template class EntityWithSources<base::IDataArray>;
-
-}
-}
-
 #endif


### PR DESCRIPTION
For reasons lost to history some templates were explicitly
instantiated, most likely to fix some windows build issues.
This seems to be hopefully not necessary anymore, becasue it
breaks builds on ARM. It is also violating the C++ std (14.7
clause 5):
  "an explicit instantiation definition shall appear at
   most once in a program"