### PR TITLE
Unit handling

### DIFF
--- a/include/nix/DataArray.hpp
+++ b/include/nix/DataArray.hpp
@@ -17,6 +17,7 @@
 #include <nix/Hydra.hpp>
 
 #include <nix/Platform.hpp>
+#include <nix/util/util.hpp>
 
 
 namespace nix {
@@ -323,15 +324,22 @@ public:
     RangeDimension appendAliasRangeDimension() {
         if (this->dataExtent().size() > 1) {
             throw nix::InvalidDimension("AliasRangeDimensions only allowed for 1D numeric DataArrays!",
-                                        "DataArray::createAliasRangeDimension");
+                                        "DataArray::appendAliasRangeDimension");
         }
         if (!nix::data_type_is_numeric(this->dataType())) {
             throw nix::InvalidDimension("AliasRangeDimensions are only allowed for 1D numeric DataArrays!",
-                                        "DataArray::createAliasRangeDimension");
+                                        "DataArray::appendAliasRangeDimension");
         }
         if (dimensionCount() > 0) {
             throw nix::InvalidDimension("Cannot append additional alias dimension. There must only be one!",
-                                        "DataArray::createAliasRangeDimension");
+                                        "DataArray::appendAliasRangeDimension");
+        }
+        if (this->unit()) {
+            std::string unit = *this->unit();
+            if(!(util::isSIUnit(unit) || util::isCompoundSIUnit(unit))) {
+                throw nix:: InvalidUnit("AliasRangeDimensions are only allowed when SI or composites of SI units are used.",
+                                        "DataArray::appendAliasRangeDimension");
+            }
         }
         return backend()->createAliasRangeDimension();
     }

--- a/src/DataArray.cpp
+++ b/src/DataArray.cpp
@@ -8,7 +8,6 @@
 
 #include <nix/DataArray.hpp>
 
-#include <nix/util/util.hpp>
 #include "hdf5/h5x/H5DataType.hpp"
 
 #include <cstring>
@@ -99,9 +98,15 @@ void DataArray::appendData(DataType dtype, const void *data, const NDSize &count
 }
 
 void DataArray::unit(const std::string &unit) {
-    util::checkEmptyString(unit, "unit");
-    if (!unit.empty() && !(util::isSIUnit(unit) || util::isCompoundSIUnit(unit))) {
-        throw InvalidUnit("Unit is not SI or composite of SI units.", "DataArray::unit(const string &unit)");
+    std::string dblnk_unit = util::deblankString(unit);
+    util::checkEmptyString(dblnk_unit, "unit");
+    if (this->dimensionCount() == 1 && this->getDimension(1).dimensionType() == nix::DimensionType::Range) {
+        nix::RangeDimension rd;
+        rd = this->getDimension(1);
+        if (rd.alias() && !(util::isSIUnit(dblnk_unit) || util::isCompoundSIUnit(dblnk_unit))) {
+                throw InvalidUnit("Non-SI units are not allowed if the DataArray has an AliasRangeDimension. Data retrieval might not work!",
+                                  "DataArray::unit(const string &unit)");
+        }
     }
     backend()->unit(unit);
 }
@@ -126,4 +131,3 @@ void DataArray::label(const std::string &label) {
     util::checkEmptyString(label, "label");
     backend()->label(label);
 }
-

--- a/src/Property.cpp
+++ b/src/Property.cpp
@@ -13,12 +13,12 @@
 namespace nix {
 
 void Property::unit(const std::string &unit) {
-    util::checkEmptyString(unit, "unit");
-    util::deblankString(unit);
-    if (!unit.empty() && !(util::isSIUnit(unit) || util::isCompoundSIUnit(unit))) {
-        throw InvalidUnit("Unit is not SI or composite of SI units.", "Property::unit(const string &unit)");
+    std::string dblnk_unit = util::deblankString(unit);
+    if (dblnk_unit.empty()) {
+        this->unit(nix::none);
+        return;
     }
-    backend()->unit(unit);
+    backend()->unit(dblnk_unit);
 }
 
 std::ostream& operator<<(std::ostream &out, const Property &ent) {
@@ -48,4 +48,3 @@ void Property::mapping(const std::string &mapping) {
 }
 
 } // namespace nix
-

--- a/test/BaseTestDataArray.cpp
+++ b/test/BaseTestDataArray.cpp
@@ -379,12 +379,21 @@ void BaseTestDataArray::testPolynomialSetter() {
 void BaseTestDataArray::testUnit() {
     std::string testStr = "somestring";
     std::string validUnit = "mV^2";
-    CPPUNIT_ASSERT_THROW(array1.unit(testStr), nix::InvalidUnit);
+
     CPPUNIT_ASSERT_NO_THROW(array1.unit(validUnit));
     CPPUNIT_ASSERT(*array1.unit() == validUnit);
-    CPPUNIT_ASSERT_NO_THROW(array1.unit(boost::none));
+    CPPUNIT_ASSERT_NO_THROW(array1.unit(nix::none));
     CPPUNIT_ASSERT(array1.unit() == nix::none);
-    CPPUNIT_ASSERT_THROW(array1.unit(""), EmptyString);
+    CPPUNIT_ASSERT_THROW(array1.unit(""), nix::EmptyString);
+
+    array1.unit(nix::none);
+    CPPUNIT_ASSERT_NO_THROW(array1.unit(testStr));
+    CPPUNIT_ASSERT_THROW(array1.createAliasRangeDimension(), nix::InvalidDimension);
+
+    nix::Dimension dim = array3.createAliasRangeDimension();
+    CPPUNIT_ASSERT_NO_THROW(array3.unit(validUnit));
+    array3.unit(nix::none);
+    CPPUNIT_ASSERT_THROW(array3.unit(testStr), nix::InvalidUnit);
 }
 
 

--- a/test/BaseTestProperty.cpp
+++ b/test/BaseTestProperty.cpp
@@ -146,7 +146,7 @@ void BaseTestProperty::testDataType() {
     CPPUNIT_ASSERT(p5.dataType() == DataType::Int64);
     CPPUNIT_ASSERT(p6.dataType() == DataType::UInt64);
     CPPUNIT_ASSERT(p7.dataType() == DataType::Bool);
-    
+
     file.deleteSection(section.id());
 }
 
@@ -158,14 +158,10 @@ void BaseTestProperty::testUnit(){
     std::vector<Value> values = {v};
     nix::Property p1 = section.createProperty("testProperty", int_dummy);
 
-    std::string inv_unit = "invalid unit";
     std::string valid_unit = "mV*cm^-2";
     std::string second_unit = "mV";
 
-    CPPUNIT_ASSERT_THROW(property.unit(""), nix::EmptyString);
-    CPPUNIT_ASSERT_THROW(property.unit(inv_unit), nix::InvalidUnit);
     CPPUNIT_ASSERT(!property.unit());
-
     property.unit(valid_unit);
     CPPUNIT_ASSERT(property.unit() && *property.unit() == valid_unit);
 
@@ -173,6 +169,13 @@ void BaseTestProperty::testUnit(){
     CPPUNIT_ASSERT(!property.unit());
     CPPUNIT_ASSERT_NO_THROW(property.unit(second_unit));
     CPPUNIT_ASSERT(property.unit() && *property.unit() == second_unit);
+
+    property.unit("  ");
+    CPPUNIT_ASSERT(!property.unit());
+
+    property.unit(second_unit);
+    property.unit("");
+    CPPUNIT_ASSERT(!property.unit());
 }
 
 
@@ -197,7 +200,7 @@ void BaseTestProperty::testOperators() {
 
     CPPUNIT_ASSERT(property_null == false);
     CPPUNIT_ASSERT(property_null == none);
-    
+
     std::stringstream s;
     s << property;
     CPPUNIT_ASSERT(s.str() == "Property: {name = " + property.name() + "}");


### PR DESCRIPTION
relaxed the unit handling at two places:

 1) ``Properties`` may have non-SI units. Passing an empty string, or one that consists of only blanks, will remove the unit from the property.
 2) ``DataArrays``: The value unit may be non-SI. In case the dimensionality of the ``DataArray`` is 1-D and the first dimension is an ``AliasRangeDimension`` setting an non-SI will lead to an exception.
In case a non-SI unit is set, the attempt of adding an ``AliasRangeDimension`` will lead to an exception.

Data retrieval functions behave as before: if there are units and theses can not be scaled, an exception will be thrown.