### PR TITLE
Small h5x::DataType improvements

### DIFF
--- a/backend/hdf5/h5x/H5DataType.cpp
+++ b/backend/hdf5/h5x/H5DataType.cpp
@@ -16,6 +16,11 @@ namespace nix {
 namespace hdf5 {
 namespace h5x {
 
+bool DataType::equal(const DataType &other) const {
+    HTri res = H5Tequal(hid, other.hid);
+    res.check("DataType::equal(): H5Tequal failed");
+    return res.result();
+}
 
 DataType DataType::copy(hid_t source) {
     DataType hi_copy = H5Tcopy(source);

--- a/backend/hdf5/h5x/H5DataType.cpp
+++ b/backend/hdf5/h5x/H5DataType.cpp
@@ -130,6 +130,10 @@ DataType DataType::member_type(unsigned int index) const {
     return res;
 }
 
+DataType DataType::member_type(const std::string &name) const {
+    const unsigned idx = member_index(name);
+    return member_type(idx);
+}
 
 void DataType::insert(const std::string &name, size_t offset, const DataType &dtype) {
     HErr res = H5Tinsert(hid, name.c_str(), offset, dtype.hid);

--- a/backend/hdf5/h5x/H5DataType.cpp
+++ b/backend/hdf5/h5x/H5DataType.cpp
@@ -115,6 +115,15 @@ size_t DataType::member_offset(unsigned int index) const {
     return H5Tget_member_offset(hid, index);
 }
 
+unsigned int DataType::member_index(const std::string &name) const {
+    int res = H5Tget_member_index(hid, name.c_str());
+    if (res < 0) {
+        throw H5Exception("DataType::member_index(): H5Tget_member_index failed");
+    }
+
+    return static_cast<unsigned>(res);
+}
+
 DataType DataType::member_type(unsigned int index) const {
     h5x::DataType res = H5Tget_member_type(hid, index);
     res.check("DataType::member_type(): H5Tget_member_type failed");

--- a/backend/hdf5/h5x/H5DataType.hpp
+++ b/backend/hdf5/h5x/H5DataType.hpp
@@ -31,6 +31,9 @@ public:
     DataType(const DataType &other) : H5Object(other) { }
 
     bool equal(const DataType &other) const;
+    bool operator ==(const DataType &other) const {
+        return equal(other);
+    }
 
     //Basically the same as DataType(hid_t, true)
     // but more explicit, so it is easier in the code

--- a/backend/hdf5/h5x/H5DataType.hpp
+++ b/backend/hdf5/h5x/H5DataType.hpp
@@ -60,6 +60,7 @@ public:
     std::string member_name(unsigned int index) const;
     std::vector<std::string> member_names() const;
     size_t member_offset(unsigned int index) const;
+    unsigned int member_index(const std::string &name) const;
 
     void insert(const std::string &name, size_t offset, const DataType &dtype);
     void insert(const std::string &name, void *value);

--- a/backend/hdf5/h5x/H5DataType.hpp
+++ b/backend/hdf5/h5x/H5DataType.hpp
@@ -30,6 +30,7 @@ public:
     DataType(hid_t hid, bool is_copy) : H5Object(hid, is_copy) { }
     DataType(const DataType &other) : H5Object(other) { }
 
+    bool equal(const DataType &other) const;
 
     //Basically the same as DataType(hid_t, true)
     // but more explicit, so it is easier in the code

--- a/backend/hdf5/h5x/H5DataType.hpp
+++ b/backend/hdf5/h5x/H5DataType.hpp
@@ -55,6 +55,7 @@ public:
     bool isCompound() const;
     unsigned int member_count() const;
     DataType member_type(unsigned int index) const;
+    DataType member_type(const std::string &name) const;
 
     H5T_class_t member_class(unsigned int index) const;
     std::string member_name(unsigned int index) const;

--- a/test/hdf5/TestH5.cpp
+++ b/test/hdf5/TestH5.cpp
@@ -191,6 +191,9 @@ void TestH5::testDataType() {
 
     CPPUNIT_ASSERT_EQUAL(H5T_SGN_2, dt_int.sign());
 
+    CPPUNIT_ASSERT(dt_int.equal(H5T_NATIVE_INT));
+    CPPUNIT_ASSERT(!dt_int.equal(H5T_NATIVE_DOUBLE));
+
     h5x::DataType v_str = h5x::DataType::makeStrType();
     CPPUNIT_ASSERT_EQUAL(true, v_str.isVariableString());
 

--- a/test/hdf5/TestH5.cpp
+++ b/test/hdf5/TestH5.cpp
@@ -225,6 +225,10 @@ void TestH5::testDataType() {
     CPPUNIT_ASSERT_EQUAL(offsetof(TestStruct, i), cmpd.member_offset(1));
     CPPUNIT_ASSERT_EQUAL(H5T_FLOAT, cmpd.member_class(0));
     CPPUNIT_ASSERT_EQUAL(H5T_INTEGER, cmpd.member_class(1));
+    CPPUNIT_ASSERT(cmpd.member_type(0).equal(cmpd.member_type("d")));
+    CPPUNIT_ASSERT(cmpd.member_type(1).equal(cmpd.member_type("i")));
+    CPPUNIT_ASSERT(cmpd.member_type(0).equal(H5T_NATIVE_DOUBLE));
+    CPPUNIT_ASSERT(cmpd.member_type(1).equal(H5T_NATIVE_INT));
 
     {
         CPPUNIT_ASSERT_EQUAL(0, H5Iget_ref(H5T_NATIVE_DOUBLE));

--- a/test/hdf5/TestH5.cpp
+++ b/test/hdf5/TestH5.cpp
@@ -216,6 +216,8 @@ void TestH5::testDataType() {
     CPPUNIT_ASSERT_EQUAL(2U, cmpd.member_count());
     CPPUNIT_ASSERT_EQUAL(std::string("d"), cmpd.member_name(0));
     CPPUNIT_ASSERT_EQUAL(std::string("i"), cmpd.member_name(1));
+    CPPUNIT_ASSERT_EQUAL(cmpd.member_index("d"), unsigned(0));
+    CPPUNIT_ASSERT_EQUAL(cmpd.member_index("i"), unsigned(1));
     CPPUNIT_ASSERT_EQUAL(offsetof(TestStruct, d), cmpd.member_offset(0));
     CPPUNIT_ASSERT_EQUAL(offsetof(TestStruct, i), cmpd.member_offset(1));
     CPPUNIT_ASSERT_EQUAL(H5T_FLOAT, cmpd.member_class(0));

--- a/test/hdf5/TestH5.cpp
+++ b/test/hdf5/TestH5.cpp
@@ -229,6 +229,8 @@ void TestH5::testDataType() {
     CPPUNIT_ASSERT(cmpd.member_type(1).equal(cmpd.member_type("i")));
     CPPUNIT_ASSERT(cmpd.member_type(0).equal(H5T_NATIVE_DOUBLE));
     CPPUNIT_ASSERT(cmpd.member_type(1).equal(H5T_NATIVE_INT));
+    CPPUNIT_ASSERT(cmpd.member_type(0) == H5T_NATIVE_DOUBLE);
+    CPPUNIT_ASSERT(cmpd.member_type(1) == H5T_NATIVE_INT);
 
     {
         CPPUNIT_ASSERT_EQUAL(0, H5Iget_ref(H5T_NATIVE_DOUBLE));


### PR DESCRIPTION
Split out from the DataFrame branch, to keep that PR as small as possible.