### PR TITLE
[cmake/pkg-config] nix.pc -> nixio.pc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,8 +247,8 @@ install(DIRECTORY include/ DESTINATION ${INCLUDE_INSTALL_DIR})
 install(DIRECTORY ${CMAKE_BINARY_DIR}/include/ DESTINATION ${INCLUDE_INSTALL_DIR})
 
 #pkg-config support
-configure_file(${CMAKE_SOURCE_DIR}/nix.pc.in ${CMAKE_BINARY_DIR}/nix.pc)
-install(FILES ${CMAKE_BINARY_DIR}/nix.pc DESTINATION ${LIB_INSTALL_DIR}/pkgconfig)
+configure_file(${CMAKE_SOURCE_DIR}/nixio.pc.in ${CMAKE_BINARY_DIR}/nixio.pc)
+install(FILES ${CMAKE_BINARY_DIR}/nixio.pc DESTINATION ${LIB_INSTALL_DIR}/pkgconfig)
 
 
 ########################################

--- a/nixio.pc.in
+++ b/nixio.pc.in
@@ -3,7 +3,7 @@ exec_prefix=${CMAKE_INSTALL_PREFIX}
 libdir=${CMAKE_INSTALL_PREFIX}/lib
 includedir=${CMAKE_INSTALL_PREFIX}/include
 
-Name: nix
+Name: nixio
 Description: IO-library for nix datafiles
 Version: ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}
 Libs: -L${CMAKE_INSTALL_PREFIX}/lib -lnix


### PR DESCRIPTION
In accordance to the long term plan to rename many components
of NIX to nixio to avoid name clashing we should also be called
nixio.pc for pkg-config files.

This is issue #626