### PR TITLE
remove Values, move uncertainty to property fixes #550

### DIFF
--- a/backend/fs/PropertyFS.cpp
+++ b/backend/fs/PropertyFS.cpp
@@ -202,13 +202,13 @@ ndsize_t PropertyFS::valueCount() const {
 }
 
 
-void PropertyFS::values(const std::vector<Value> &values) {
+void PropertyFS::values(const std::vector<Variant> &values) {
     // FIXME
 }
 
 
-std::vector<Value> PropertyFS::values(void) const {
-    std::vector<Value> values;
+std::vector<Variant> PropertyFS::values(void) const {
+    std::vector<Variant> values;
     // FIXME
     return values;
 }

--- a/backend/fs/PropertyFS.cpp
+++ b/backend/fs/PropertyFS.cpp
@@ -138,34 +138,6 @@ DataType PropertyFS::dataType() const {
 }
 
 
-void PropertyFS::mapping(const std::string &mapping) {
-    if (mapping.empty()) {
-        throw EmptyString("mapping");
-    }
-    setAttr("mapping", mapping);
-    forceUpdatedAt();
-}
-
-
-boost::optional<std::string> PropertyFS::mapping() const {
-    boost::optional<std::string> ret;
-    std::string mapping;
-    if (hasAttr("mapping")) {
-        getAttr("mapping", mapping);
-        ret = mapping;
-    }
-    return ret;
-}
-
-
-void PropertyFS::mapping(const nix::none_t t) {
-    if (hasAttr("mapping")) {
-        removeAttr("mapping");
-        forceUpdatedAt();
-    }
-}
-
-
 void PropertyFS::unit(const std::string &unit) {
     if (unit.empty()) {
         throw EmptyString("unit");

--- a/backend/fs/PropertyFS.cpp
+++ b/backend/fs/PropertyFS.cpp
@@ -166,6 +166,31 @@ void PropertyFS::unit(const nix::none_t t) {
 }
 
 
+void PropertyFS::uncertainty(double uncertainty) {
+    setAttr("uncertainty", uncertainty);
+    forceUpdatedAt();
+}
+
+
+boost::optional<double> PropertyFS::uncertainty() const {
+    boost::optional<double> ret;
+    double error;
+    if (hasAttr("uncertainty")) {
+        getAttr("uncertainty", error);
+        ret = error;
+    }
+    return ret;
+}
+
+
+void PropertyFS::uncertainty(const nix::none_t t) {
+    if (hasAttr("uncertainty")) {
+        removeAttr("uncertainty");
+    }
+    forceUpdatedAt();
+}
+
+
 void PropertyFS::deleteValues() {
     // FIXME
 }

--- a/backend/fs/PropertyFS.hpp
+++ b/backend/fs/PropertyFS.hpp
@@ -94,10 +94,10 @@ public:
     ndsize_t valueCount() const;
 
 
-    void values(const std::vector<Value> &values);
+    void values(const std::vector<Variant> &values);
 
 
-    std::vector<Value> values(void) const;
+    std::vector<Variant> values(void) const;
 
 
     void values(const boost::none_t t);

--- a/backend/fs/PropertyFS.hpp
+++ b/backend/fs/PropertyFS.hpp
@@ -79,6 +79,15 @@ public:
     void unit(const none_t t);
 
 
+    void uncertainty(double uncertainty);
+
+
+    boost::optional<double> uncertainty() const;
+
+
+    void uncertainty(const none_t t);
+
+
     void deleteValues();
 
 

--- a/backend/fs/PropertyFS.hpp
+++ b/backend/fs/PropertyFS.hpp
@@ -67,15 +67,6 @@ public:
     void definition(const none_t t);
 
 
-    void mapping(const std::string &mapping);
-
-
-    boost::optional<std::string> mapping() const;
-
-
-    void mapping(const none_t t);
-
-
     DataType dataType() const;
 
 

--- a/backend/fs/SectionFS.cpp
+++ b/backend/fs/SectionFS.cpp
@@ -142,35 +142,6 @@ void SectionFS::link(const none_t t) {
     forceUpdatedAt();
 }
 
-
-void SectionFS::mapping(const std::string &mapping) {
-    if (mapping.empty()) {
-        throw EmptyString("mapping");
-    } else {
-        setAttr("mapping", mapping);
-        forceUpdatedAt();
-    }
-}
-
-
-boost::optional<std::string> SectionFS::mapping() const {
-    boost::optional<std::string> ret;
-    std::string mapping;
-    if (hasAttr("mapping")) {
-        getAttr("mapping", mapping);
-        ret = mapping;
-    }
-    return ret;
-}
-
-
-void SectionFS::mapping(const none_t t) {
-    if (hasAttr("mapping")) {
-        removeAttr("mapping");
-    }
-    forceUpdatedAt();
-}
-
 //--------------------------------------------------
 // Methods for parent access
 //--------------------------------------------------

--- a/backend/fs/SectionFS.cpp
+++ b/backend/fs/SectionFS.cpp
@@ -260,15 +260,15 @@ std::shared_ptr<base::IProperty> SectionFS::createProperty(const std::string &na
 }
 
 
-std::shared_ptr<base::IProperty> SectionFS::createProperty(const std::string &name, const Value &value) {
+std::shared_ptr<base::IProperty> SectionFS::createProperty(const std::string &name, const Variant &value) {
     std::shared_ptr<base::IProperty> p = createProperty(name, value.type());
-    std::vector<Value> val{value};
+    std::vector<Variant> val{value};
     p->values(val);
     return p;
 }
 
 
-std::shared_ptr<base::IProperty> SectionFS::createProperty(const std::string &name, const std::vector<Value> &values) {
+std::shared_ptr<base::IProperty> SectionFS::createProperty(const std::string &name, const std::vector<Variant> &values) {
     if (values.size() < 1)
         throw std::runtime_error("Trying to create a property without a value!");
 

--- a/backend/fs/SectionFS.hpp
+++ b/backend/fs/SectionFS.hpp
@@ -89,17 +89,6 @@ public:
 
 
     void link(const none_t t);
-
-
-    void mapping(const std::string &mapping);
-
-
-    boost::optional<std::string> mapping() const;
-
-
-    void mapping(const none_t t);
-
-
     //--------------------------------------------------
     // Methods for parent access
     //--------------------------------------------------

--- a/backend/fs/SectionFS.hpp
+++ b/backend/fs/SectionFS.hpp
@@ -137,10 +137,10 @@ public:
     std::shared_ptr<base::IProperty> createProperty(const std::string &name, const DataType &dtype);
 
 
-    std::shared_ptr<base::IProperty> createProperty(const std::string &name, const Value &value);
+    std::shared_ptr<base::IProperty> createProperty(const std::string &name, const Variant &value);
 
 
-    std::shared_ptr<base::IProperty> createProperty(const std::string &name, const std::vector<Value> &values);
+    std::shared_ptr<base::IProperty> createProperty(const std::string &name, const std::vector<Variant> &values);
 
 
     bool deleteProperty(const std::string &name_or_id);

--- a/backend/hdf5/PropertyHDF5.cpp
+++ b/backend/hdf5/PropertyHDF5.cpp
@@ -62,7 +62,7 @@ namespace hdf5 {
         dataset.setAttr("name", name);
         forceUpdatedAt();
     }
-    
+
     dataset.setAttr("entity_id", id);
     setUpdatedAt();
     forceCreatedAt(time);
@@ -71,14 +71,14 @@ namespace hdf5 {
 
 string PropertyHDF5::id() const {
     string t;
-    
+
     if (dataset().hasAttr("entity_id")) {
         dataset().getAttr("entity_id", t);
     }
     else {
         throw runtime_error("Entity has no id!");
     }
-    
+
     return t;
 }
 
@@ -163,30 +163,6 @@ void PropertyHDF5::definition(const nix::none_t t) {
 DataType PropertyHDF5::dataType() const {
     const h5x::DataType dtype = dataset().dataType();
     return data_type_from_h5(dtype);
-}
-
-
-void PropertyHDF5::mapping(const string &mapping) {
-    dataset().setAttr("mapping", mapping);
-    forceUpdatedAt();
-}
-
-
-boost::optional<string> PropertyHDF5::mapping() const {
-    boost::optional<string> ret;
-    string mapping;
-    if (dataset().getAttr("mapping", mapping)) {
-        ret = mapping;
-    }
-    return ret;
-}
-
-
-void PropertyHDF5::mapping(const nix::none_t t) {
-    if (dataset().hasAttr("mapping")) {
-        dataset().removeAttr("mapping");
-        forceUpdatedAt();
-    }
 }
 
 

--- a/backend/hdf5/PropertyHDF5.cpp
+++ b/backend/hdf5/PropertyHDF5.cpp
@@ -243,8 +243,6 @@ struct NIX_PACKED FileValue  {
 template<typename T>
 h5x::DataType h5_type_for_value(bool for_memory)
 {
-    typedef FileValue<T> file_value_t;
-
     h5x::DataType value_type = data_type_to_h5(to_data_type<T>::value, for_memory);
     return value_type;
 }

--- a/backend/hdf5/PropertyHDF5.cpp
+++ b/backend/hdf5/PropertyHDF5.cpp
@@ -190,6 +190,30 @@ void PropertyHDF5::unit(const nix::none_t t) {
 }
 
 
+void PropertyHDF5::uncertainty(double uncertainty) {
+    dataset().setAttr("uncertainty", uncertainty);
+    forceUpdatedAt();
+}
+
+
+boost::optional<double> PropertyHDF5::uncertainty() const {
+    boost::optional<double> ret;
+    double error;
+    if (dataset().getAttr("uncertainty", error)) {
+        ret = error;
+    }
+    return ret;
+}
+
+
+void PropertyHDF5::uncertainty(const nix::none_t t) {
+    if (dataset().hasAttr("uncertainty")) {
+        dataset().removeAttr("uncertainty");
+    }
+    forceUpdatedAt();
+}
+
+
 bool PropertyHDF5::isValidEntity() const {
     return dataset().referenceCount() > 0;
 }

--- a/backend/hdf5/PropertyHDF5.cpp
+++ b/backend/hdf5/PropertyHDF5.cpp
@@ -246,21 +246,8 @@ h5x::DataType h5_type_for_value(bool for_memory)
 {
     typedef FileValue<T> file_value_t;
 
-    h5x::DataType ct = h5x::DataType::makeCompound(sizeof(file_value_t));
-    // h5x::DataType strType = h5x::DataType::makeStrType();
-
     h5x::DataType value_type = data_type_to_h5(to_data_type<T>::value, for_memory);
-    /*
-    h5x::DataType double_type = data_type_to_h5(DataType::Double, for_memory);
-
-    ct.insert("value", HOFFSET(file_value_t, value), value_type);
-    ct.insert("uncertainty", HOFFSET(file_value_t, uncertainty), double_type);
-    ct.insert("reference", HOFFSET(file_value_t, reference), strType);
-    ct.insert("filename", HOFFSET(file_value_t, filename), strType);
-    ct.insert("encoder", HOFFSET(file_value_t, encoder), strType);
-    ct.insert("checksum", HOFFSET(file_value_t, checksum), strType);
-    */
-    return ct;
+    return value_type;
 }
 
 #if 0 //set to one to check that all supported DataTypes are handled
@@ -459,24 +446,21 @@ std::vector<Variant> PropertyHDF5::values(void) const
     if (shape.size() < 1 || shape[0] < 1) {
         return values;
     }
-
     assert(shape.size() == 1);
     size_t nvalues = nix::check::fits_in_size_t(shape[0], "Can't resize: data to big for memory");
 
     switch (dtype) {
-        case DataType::Bool:   do_read_value<bool>(dset, nvalues, values);     break;
-        case DataType::Int32:  do_read_value<int32_t>(dset, nvalues, values);  break;
+        case DataType::Bool: do_read_value<bool>(dset, nvalues, values); break;
+        case DataType::Int32: do_read_value<int32_t>(dset, nvalues, values); break;
         case DataType::UInt32: do_read_value<uint32_t>(dset, nvalues, values); break;
         case DataType::Int64:  do_read_value<int64_t>(dset, nvalues, values);  break;
         case DataType::UInt64: do_read_value<uint64_t>(dset, nvalues, values); break;
         case DataType::String: do_read_value<char *>(dset, nvalues, values);   break;
         case DataType::Double: do_read_value<double>(dset, nvalues, values);   break;
 #ifndef CHECK_SUPOORTED_VALUES
-        default: assert(DATATYPE_SUPPORT_NOT_IMPLEMENTED);
+    default: assert(DATATYPE_SUPPORT_NOT_IMPLEMENTED);
 #endif
     }
-
-
     return values;
 }
 

--- a/backend/hdf5/PropertyHDF5.hpp
+++ b/backend/hdf5/PropertyHDF5.hpp
@@ -23,7 +23,7 @@ namespace hdf5 {
 
 
 class PropertyHDF5 : virtual public base::IProperty {
-    
+
     std::shared_ptr<base::IFile>  entity_file;
     DataSet                       entity_dataset;
 
@@ -79,15 +79,6 @@ public:
 
 
     void definition(const none_t t);
-
-
-    void mapping(const std::string &mapping);
-
-
-    boost::optional<std::string> mapping() const;
-
-
-    void mapping(const none_t t);
 
 
     DataType dataType() const;

--- a/backend/hdf5/PropertyHDF5.hpp
+++ b/backend/hdf5/PropertyHDF5.hpp
@@ -108,10 +108,10 @@ public:
     ndsize_t valueCount() const;
 
 
-    void values(const std::vector<Value> &values);
+    void values(const std::vector<Variant> &values);
 
 
-    std::vector<Value> values(void) const;
+    std::vector<Variant> values(void) const;
 
 
     void values(const boost::none_t t);

--- a/backend/hdf5/PropertyHDF5.hpp
+++ b/backend/hdf5/PropertyHDF5.hpp
@@ -93,6 +93,15 @@ public:
     void unit(const none_t t);
 
 
+    void uncertainty(double uncertainty);
+
+
+    boost::optional<double> uncertainty() const;
+
+
+    void uncertainty(const none_t t);
+
+
     void deleteValues();
 
 

--- a/backend/hdf5/SectionHDF5.cpp
+++ b/backend/hdf5/SectionHDF5.cpp
@@ -254,7 +254,7 @@ shared_ptr<IProperty> SectionHDF5::getProperty(ndsize_t index) const {
 shared_ptr<IProperty> SectionHDF5::createProperty(const string &name, const DataType &dtype) {
     string new_id = util::createId();
     boost::optional<H5Group> g = property_group(true);
-    DataSet ds = g->createData("values", data_type_to_h5_filetype(dtype), {0});
+    DataSet ds = g->createData(name, data_type_to_h5_filetype(dtype), {0});
     return make_shared<PropertyHDF5>(file(), ds, new_id, name);
 }
 

--- a/backend/hdf5/SectionHDF5.cpp
+++ b/backend/hdf5/SectionHDF5.cpp
@@ -26,7 +26,7 @@ SectionHDF5::SectionHDF5(const std::shared_ptr<base::IFile> &file, const H5Group
     : SectionHDF5(file, nullptr, group)
 {
 }
-    
+
 
 SectionHDF5::SectionHDF5(const std::shared_ptr<base::IFile> &file, const std::shared_ptr<base::ISection> &parent, const H5Group &group)
     : NamedEntityHDF5(file, group), parent_section(parent)
@@ -96,12 +96,12 @@ void SectionHDF5::repository(const none_t t) {
 void SectionHDF5::link(const std::string &id) {
     if (group().hasGroup("link"))
         link(none);
-        
+
     File tmp = file();
     auto found = tmp.findSections(util::IdFilter<Section>(id));
     if (found.empty())
         throw std::runtime_error("SectionHDF5::link: Section not found in file!");
-    
+
     auto target = dynamic_pointer_cast<SectionHDF5>(found.front().impl());
 
     group().createLink(target->group(), "link");
@@ -132,29 +132,6 @@ void SectionHDF5::link(const none_t t) {
     forceUpdatedAt();
 }
 
-
-void SectionHDF5::mapping(const string &mapping) {
-    group().setAttr("mapping", mapping);
-    forceUpdatedAt();
-}
-
-
-boost::optional<string> SectionHDF5::mapping() const {
-    boost::optional<string> ret;
-    string mapping;
-    if (group().getAttr("mapping", mapping)) {
-        ret = mapping;
-    }
-    return ret;
-}
-
-
-void SectionHDF5::mapping(const none_t t) {
-    if (group().hasAttr("mapping")) {
-        group().removeAttr("mapping");
-    }
-    forceUpdatedAt();
-}
 
 //--------------------------------------------------
 // Methods for parent access

--- a/backend/hdf5/SectionHDF5.cpp
+++ b/backend/hdf5/SectionHDF5.cpp
@@ -254,23 +254,20 @@ shared_ptr<IProperty> SectionHDF5::getProperty(ndsize_t index) const {
 shared_ptr<IProperty> SectionHDF5::createProperty(const string &name, const DataType &dtype) {
     string new_id = util::createId();
     boost::optional<H5Group> g = property_group(true);
-
-    h5x::DataType fileType = PropertyHDF5::fileTypeForValue(dtype);
-    DataSet dataset = g->createData(name, fileType, {0});
-
-    return make_shared<PropertyHDF5>(file(), dataset, new_id, name);
+    DataSet ds = g->createData("values", data_type_to_h5_filetype(dtype), {0});
+    return make_shared<PropertyHDF5>(file(), ds, new_id, name);
 }
 
 
-shared_ptr<IProperty> SectionHDF5::createProperty(const string &name, const Value &value) {
+shared_ptr<IProperty> SectionHDF5::createProperty(const string &name, const Variant &value) {
     shared_ptr<IProperty> p = createProperty(name, value.type());
-    vector<Value> val{value};
+    vector<Variant> val{value};
     p->values(val);
     return p;
 }
 
 
-shared_ptr<IProperty> SectionHDF5::createProperty(const string &name, const vector<Value> &values) {
+shared_ptr<IProperty> SectionHDF5::createProperty(const string &name, const vector<Variant> &values) {
     shared_ptr<IProperty> p = createProperty(name, values[0].type());
     p->values(values);
     return p;

--- a/backend/hdf5/SectionHDF5.hpp
+++ b/backend/hdf5/SectionHDF5.hpp
@@ -137,10 +137,10 @@ public:
     std::shared_ptr<base::IProperty> createProperty(const std::string &name, const DataType &dtype);
 
 
-    std::shared_ptr<base::IProperty> createProperty(const std::string &name, const Value &value);
+    std::shared_ptr<base::IProperty> createProperty(const std::string &name, const Variant &value);
 
 
-    std::shared_ptr<base::IProperty> createProperty(const std::string &name, const std::vector<Value> &values);
+    std::shared_ptr<base::IProperty> createProperty(const std::string &name, const std::vector<Variant> &values);
 
 
     bool deleteProperty(const std::string &name_or_id);

--- a/backend/hdf5/SectionHDF5.hpp
+++ b/backend/hdf5/SectionHDF5.hpp
@@ -34,7 +34,7 @@ public:
      * Standard constructor for existing entity
      */
     SectionHDF5(const std::shared_ptr<base::IFile> &file, const H5Group &group);
-    
+
     /**
      * Standard constructor for existing entity
      */
@@ -85,15 +85,6 @@ public:
 
 
     void link(const none_t t);
-
-
-    void mapping(const std::string &mapping);
-
-
-    boost::optional<std::string> mapping() const;
-
-
-    void mapping(const none_t t);
 
 
     //--------------------------------------------------

--- a/cli/modules/Dump.cpp
+++ b/cli/modules/Dump.cpp
@@ -165,13 +165,12 @@ yamlstream& yamlstream::operator<<(const nix::Property &property) {
     if (!property) {
         return *this; // unset entity protection
     }
-        
+
     (*this)[level] << item() << "property &" << property.id();
     ++(*this)
         << static_cast<nix::base::Entity<nix::base::IProperty>>(property)
         << "dataType" << scalar_start << property.dataType() << scalar_end
         << "definition" << scalar_start << property.definition() << scalar_end
-        << "mapping" << scalar_start << property.mapping() << scalar_end
         << "name" << scalar_start << property.name() << scalar_end
         << "unit" << scalar_start << property.unit() << scalar_end
         << "valueCount" << scalar_start << property.valueCount() << scalar_end;
@@ -181,7 +180,7 @@ yamlstream& yamlstream::operator<<(const nix::Property &property) {
         ++(*this);
             auto values = property.values();
             for (auto &value : values) {
-                *this << value; 
+                *this << value;
             }
         --(*this);
     --(*this);
@@ -203,7 +202,7 @@ yamlstream& yamlstream::operator<<(const nix::Source &source) {
         ++(*this);
             auto sources = source.sources();
             for (auto &source : sources) {
-                *this << source;            
+                *this << source;
             }
         --(*this);
     --(*this);
@@ -237,7 +236,7 @@ yamlstream& yamlstream::operator<<(const nix::Section &section) {
         ++(*this);
             auto sections = section.sections();
             for (auto &section : sections) {
-                *this << section;            
+                *this << section;
             }
         --(*this);
     --(*this);
@@ -248,7 +247,7 @@ yamlstream& yamlstream::operator<<(const nix::SetDimension &dim) {
     if (!dim) {
         return *this; // unset entity protection
     }
-    
+
     (*this)[level] << item() << "dimension " << dim.index();
     ++(*this)
         << "index" << scalar_start << dim.index() << scalar_end
@@ -262,7 +261,7 @@ yamlstream& yamlstream::operator<<(const nix::SampledDimension &dim) {
     if (!dim) {
         return *this; // unset entity protection
     }
-    
+
     (*this)[level] << item() << "dimension " << dim.index();
     ++(*this)
         << "index" << scalar_start << dim.index() << scalar_end
@@ -279,7 +278,7 @@ yamlstream& yamlstream::operator<<(const nix::RangeDimension &dim) {
     if (!dim) {
         return *this; // unset entity protection
     }
-    
+
     (*this)[level] << item() << "dimension " << dim.index();
     ++(*this)
         << "index" << scalar_start << dim.index() << scalar_end
@@ -295,7 +294,7 @@ yamlstream& yamlstream::operator<<(const nix::Dimension &dim) {
     if (!dim) {
         return *this; // unset entity protection
     }
-    
+
     if (dim.dimensionType() == nix::DimensionType::Range) {
         (*this) << dim.asRangeDimension();
     }
@@ -305,7 +304,7 @@ yamlstream& yamlstream::operator<<(const nix::Dimension &dim) {
     if (dim.dimensionType() == nix::DimensionType::Sample) {
         (*this) << dim.asSampledDimension();
     }
-    
+
     return *this;
 }
 
@@ -313,7 +312,7 @@ yamlstream& yamlstream::operator<<(const nix::DataArray &data_array) {
     if (!data_array) {
         return *this; // unset entity protection
     }
-    
+
     (*this)[level] << item() << "data_array &" << data_array.id();
     ++(*this)
         << static_cast<nix::base::EntityWithSources<nix::base::IDataArray>>(data_array)
@@ -340,7 +339,7 @@ yamlstream& yamlstream::operator<<(const nix::Feature &feature) {
     if (!feature) {
         return *this; // unset entity protection
     }
-    
+
     (*this)[level] << item() << "feature &" << feature.id();
     ++(*this)
         << static_cast<nix::base::Entity<nix::base::IFeature>>(feature)
@@ -354,7 +353,7 @@ yamlstream& yamlstream::operator<<(const nix::Tag &tag) {
     if (!tag) {
         return *this; // unset entity protection
     }
-    
+
     (*this)[level] << item() << "tag &" << tag.id();
     ++(*this)
         << static_cast<nix::base::EntityWithSources<nix::base::ITag>>(tag)
@@ -387,7 +386,7 @@ yamlstream& yamlstream::operator<<(const nix::MultiTag &multi_tag) {
     if (!multi_tag) {
         return *this; // unset entity protection
     }
-    
+
     (*this)[level] << item() << "multi_tag &" << multi_tag.id();
     ++(*this)
         << static_cast<nix::base::EntityWithSources<nix::base::IMultiTag>>(multi_tag)
@@ -420,7 +419,7 @@ yamlstream& yamlstream::operator<<(const nix::Block &block) {
     if (!block) {
         return *this; // unset entity protection
     }
-    
+
     (*this)[level] << item() << "block &" << block.id();
     ++(*this)
         << static_cast<nix::base::EntityWithMetadata<nix::base::IBlock>>(block)
@@ -457,7 +456,7 @@ yamlstream& yamlstream::operator<<(const nix::Block &block) {
         ++(*this);
             auto sources = block.sources();
             for (auto &source : sources) {
-                *this << source;            
+                *this << source;
             }
         --(*this);
     --(*this);
@@ -468,7 +467,7 @@ yamlstream& yamlstream::operator<<(const nix::File &file) {
     if (!file) {
         return *this; // unset entity protection
     }
-    
+
     (*this)[level] << item() << "file &" << file.location();
     ++(*this)
         << "location" << scalar_start << file.location() << scalar_end
@@ -492,18 +491,18 @@ yamlstream& yamlstream::operator<<(const nix::File &file) {
         ++(*this);
             auto sections = file.sections();
             for (auto &section : sections) {
-                *this << section;            
+                *this << section;
             }
         --(*this);
     --(*this);
-    
+
     return *this;
 }
 
 
 void Dump::load(po::options_description &desc) const {
     // declare purpose
-    desc.add(po::options_description("nix-tool " + std::string(module_name) + ":\n\n\t" + 
+    desc.add(po::options_description("nix-tool " + std::string(module_name) + ":\n\n\t" +
                                      "Dump data-contents of a given nix file as yaml to std out.\n\nSupported options"));
     // declare supported options
     po::options_description opt;
@@ -524,7 +523,7 @@ std::string Dump::call(const po::variables_map &vm, const po::options_descriptio
     double A_max = std::numeric_limits<double>::min();
     typedef boost::multi_array<double, 2> array_type;
     typedef array_type::index index;
-    
+
     // --help
     if (vm.count(HELP_OPTION)) {
         po::options_description temp;
@@ -601,7 +600,7 @@ std::string Dump::call(const po::variables_map &vm, const po::options_descriptio
     else {
         throw NoInputFile();
     }
-    
+
     return out.str();
 }
 

--- a/cli/modules/Dump.cpp
+++ b/cli/modules/Dump.cpp
@@ -219,7 +219,6 @@ yamlstream& yamlstream::operator<<(const nix::Section &section) {
         << static_cast<nix::base::NamedEntity<nix::base::ISection>>(section)
         << "propertyCount" << scalar_start << section.propertyCount() << scalar_end
         << "sectionCount" << scalar_start << section.sectionCount() << scalar_end
-        << "mapping" << scalar_start << section.mapping() << scalar_end
         << "repository" << scalar_start << section.repository() << scalar_end
         << "link"; ++(*this) << section.link(); --(*this);
 

--- a/cli/modules/Dump.cpp
+++ b/cli/modules/Dump.cpp
@@ -173,6 +173,7 @@ yamlstream& yamlstream::operator<<(const nix::Property &property) {
         << "definition" << scalar_start << property.definition() << scalar_end
         << "name" << scalar_start << property.name() << scalar_end
         << "unit" << scalar_start << property.unit() << scalar_end
+        << "uncertainty" << scalar_start << property.uncertainty() << scalar_end
         << "valueCount" << scalar_start << property.valueCount() << scalar_end;
 
         // Values

--- a/include/nix/Property.hpp
+++ b/include/nix/Property.hpp
@@ -30,8 +30,7 @@ namespace nix {
  * the type of the stored Value entities (e.g. double or integer).
  *
  * The {@link unit} is the unit of the stored values. Similar
- * to the {@link nix::Section} entity, mapping information can be provided
- * using the {@link mapping} field.
+ * to the {@link nix::Section} entity
  */
 class NIXAPI Property : public base::Entity<base::IProperty> {
 
@@ -135,35 +134,6 @@ public:
      */
     void definition(const none_t t) {
         backend()->definition(t);
-    }
-
-    /**
-     * @brief Set the mapping information for this Property.
-     *
-     * The mapping defines how this Property should be treated in a mapping procedure. The mapping
-     * is provided in form of an url pointing to the definition of a section into which this
-     * property should be mapped.
-     *
-     * @param mapping   The mapping information.
-     */
-    void mapping(const std::string &mapping);
-
-    /**
-     * @brief Getter for the mapping information stored in this Property.
-     *
-     * @return The mapping for the Property.
-     */
-    boost::optional<std::string> mapping() const {
-        return backend()->mapping();
-    }
-
-    /**
-     * @brief Deletes the mapping information.
-     *
-     * @param t         None
-     */
-    void mapping(const boost::none_t t) {
-        backend()->mapping(t);
     }
 
     /**

--- a/include/nix/Property.hpp
+++ b/include/nix/Property.hpp
@@ -146,6 +146,35 @@ public:
     }
 
     /**
+     * @brief Set the uncertainty (e.g. the standard deviation) related to the
+     * stored values.
+     *
+     * @param uncertainty      The uncertainty
+     */
+    void uncertainty(double uncertainty) {
+        backend()->uncertainty(uncertainty);
+    }
+
+    /**
+     * @brief Returns the uncertainty (e.g . the standard deviation) of the
+     * stored value.
+     *
+     * @return The uncertainty.
+     */
+    boost::optional<double> uncertainty() const {
+        return backend()->uncertainty();
+    }
+
+    /**
+     * @brief Remove the uncertainty.
+     *
+     * @param t         None
+     */
+    void uncertainty(const boost::none_t t) {
+        return backend()->uncertainty(t);
+    }
+
+    /**
      * @brief Set the unit for all stored values.
      *
      * @param unit      The unit for all values.

--- a/include/nix/Property.hpp
+++ b/include/nix/Property.hpp
@@ -11,7 +11,7 @@
 
 #include <nix/base/Entity.hpp>
 #include <nix/base/IProperty.hpp>
-#include <nix/Value.hpp>
+#include <nix/Variant.hpp>
 #include <nix/ObjectType.hpp>
 
 #include <nix/Platform.hpp>
@@ -224,7 +224,7 @@ public:
      *
      * @param values    The values to set.
      */
-    void values(const std::vector<Value> &values) {
+    void values(const std::vector<Variant> &values) {
         backend()->values(values);
     }
 
@@ -233,7 +233,7 @@ public:
      *
      * @return The values of the property.
      */
-    std::vector<Value> values(void) const {
+    std::vector<Variant> values(void) const {
         return backend()->values();
     }
 

--- a/include/nix/Section.hpp
+++ b/include/nix/Section.hpp
@@ -117,6 +117,7 @@ public:
      * Properties of the same name are overridden.
      *
      * @param id        The id of the section that should be linked.
+1
      */
     void link(const std::string &id);
 
@@ -382,7 +383,7 @@ public:
      *
      * @return The newly created property.
      */
-    Property createProperty(const std::string &name, const Value &value);
+    Property createProperty(const std::string &name, const Variant &value);
 
     /**
      * @brief Add a new Property with values to the Section.
@@ -392,7 +393,7 @@ public:
      *
      * @return The newly created property.
      */
-    Property createProperty(const std::string &name, const std::vector<Value> &values);
+    Property createProperty(const std::string &name, const std::vector<Variant> &values);
 
     /**
      * @brief Delete the Property identified by its name or id.

--- a/include/nix/Section.hpp
+++ b/include/nix/Section.hpp
@@ -152,33 +152,6 @@ public:
         backend()->link(t);
     }
 
-    /**
-     * @brief Sets the mapping information for this section.
-     *
-     * The mapping is provided as a path or URL to another section.
-     *
-     * @param mapping   The mapping information to this section.
-     */
-    void mapping(const std::string &mapping);
-
-    /**
-     * @brief Gets the mapping information.
-     *
-     * @return The mapping information.
-     */
-    boost::optional<std::string> mapping() const {
-        return backend()->mapping();
-    }
-
-    /**
-     * @brief Deleter for the mapping information.
-     *
-     * @param t         None
-     */
-    void mapping(const boost::none_t t) {
-        backend()->mapping(t);
-    }
-
     //--------------------------------------------------
     // Methods for parent access
     //--------------------------------------------------

--- a/include/nix/base/IProperty.hpp
+++ b/include/nix/base/IProperty.hpp
@@ -43,15 +43,6 @@ public:
     virtual void definition(const none_t t) = 0;
 
 
-    virtual void mapping(const std::string &mapping) = 0;
-
-
-    virtual boost::optional<std::string> mapping() const = 0;
-
-
-    virtual void mapping(const none_t t) = 0;
-
-
     virtual DataType dataType() const = 0;
 
 

--- a/include/nix/base/IProperty.hpp
+++ b/include/nix/base/IProperty.hpp
@@ -9,7 +9,8 @@
 #ifndef NIX_I_PROPERTY_H
 #define NIX_I_PROPERTY_H
 
-#include <nix/Value.hpp>
+//#include <nix/Value.hpp>
+#include <nix/Variant.hpp>
 #include <nix/base/INamedEntity.hpp>
 #include <nix/ObjectType.hpp>
 
@@ -70,10 +71,10 @@ public:
     virtual ndsize_t valueCount() const = 0;
 
 
-    virtual void values(const std::vector<Value> &values) = 0;
+    virtual void values(const std::vector<Variant> &values) = 0;
 
 
-    virtual std::vector<Value> values(void) const = 0;
+    virtual std::vector<Variant> values(void) const = 0;
 
 
     virtual void values(const boost::none_t t) = 0;

--- a/include/nix/base/IProperty.hpp
+++ b/include/nix/base/IProperty.hpp
@@ -55,6 +55,15 @@ public:
     virtual void unit(const none_t t) = 0;
 
 
+    virtual void uncertainty(double uncertainty) = 0;
+
+
+    virtual boost::optional<double> uncertainty() const = 0;
+
+
+    virtual void uncertainty(const none_t t) = 0;
+
+
     virtual void deleteValues() = 0;
 
 

--- a/include/nix/base/ISection.hpp
+++ b/include/nix/base/ISection.hpp
@@ -14,7 +14,7 @@
 #include <nix/base/INamedEntity.hpp>
 #include <nix/base/IProperty.hpp>
 #include <nix/DataType.hpp>
-#include <nix/Value.hpp>
+#include <nix/Variant.hpp>
 #include <nix/NDSize.hpp>
 #include <nix/ObjectType.hpp>
 
@@ -101,10 +101,10 @@ public:
     virtual std::shared_ptr<IProperty> createProperty(const std::string &name, const DataType &dtype) = 0;
 
 
-    virtual std::shared_ptr<IProperty> createProperty(const std::string &name, const Value &value) = 0;
+    virtual std::shared_ptr<IProperty> createProperty(const std::string &name, const Variant &value) = 0;
 
 
-    virtual std::shared_ptr<IProperty> createProperty(const std::string &name, const std::vector<Value> &values) = 0;
+    virtual std::shared_ptr<IProperty> createProperty(const std::string &name, const std::vector<Variant> &values) = 0;
 
 
     virtual bool deleteProperty(const std::string &name_or_id) = 0;

--- a/include/nix/base/ISection.hpp
+++ b/include/nix/base/ISection.hpp
@@ -55,15 +55,6 @@ public:
 
     virtual void link(const none_t t) = 0;
 
-
-    virtual void mapping(const std::string &mapping) = 0;
-
-
-    virtual boost::optional<std::string> mapping() const = 0;
-
-
-    virtual void mapping(const none_t t) = 0;
-
     //--------------------------------------------------
     // Methods for parent access
     //--------------------------------------------------

--- a/src/Property.cpp
+++ b/src/Property.cpp
@@ -42,9 +42,4 @@ void Property::definition(const std::string &definition) {
     backend()->definition(definition);
 }
 
-void Property::mapping(const std::string &mapping) {
-    util::checkEmptyString(mapping, "mapping");
-        backend()->mapping(mapping);
-}
-
 } // namespace nix

--- a/src/Section.cpp
+++ b/src/Section.cpp
@@ -292,7 +292,7 @@ Property Section::createProperty(const std::string &name, const DataType &dtype)
     return backend()->createProperty(name, dtype);
 }
 
-Property Section::createProperty(const std::string &name, const std::vector<Value> &values) {
+Property Section::createProperty(const std::string &name, const std::vector<Variant> &values) {
     if (values.size() < 1)
         throw std::runtime_error("Trying to create a property without a value!");
     util::checkEntityName(name);
@@ -302,7 +302,7 @@ Property Section::createProperty(const std::string &name, const std::vector<Valu
     return backend()->createProperty(name, values);
 }
 
-Property Section::createProperty(const std::string &name, const Value &value) {
+Property Section::createProperty(const std::string &name, const Variant &value) {
     util::checkEntityName(name);
     if (backend()->hasProperty(name)){
         throw DuplicateName("Property with that name already exists!");

--- a/src/Section.cpp
+++ b/src/Section.cpp
@@ -276,11 +276,6 @@ void Section::link(const std::string &id) {
     backend()->link(id);
 }
 
-void Section::mapping(const std::string &mapping) {
-    util::checkEmptyString(mapping, "mapping");
-    backend()->mapping(mapping);
-}
-
 Section Section::createSection(const std::string &name, const std::string &type) {
     util::checkEntityNameAndType(name, type);
     if (backend()->hasSection(name)) {

--- a/test/BaseTestProperty.cpp
+++ b/test/BaseTestProperty.cpp
@@ -63,16 +63,6 @@ void BaseTestProperty::testDefinition() {
 }
 
 
-void BaseTestProperty::testMapping() {
-    std::string map = "some_str";
-    CPPUNIT_ASSERT_THROW(property.mapping(""), EmptyString);
-    property.mapping(map);
-    CPPUNIT_ASSERT(*property.mapping() == map);
-    property.mapping(boost::none);
-    CPPUNIT_ASSERT(!property.mapping());
-}
-
-
 void BaseTestProperty::testValues()
 {
     nix::Section section = file.createSection("Area51", "Boolean");

--- a/test/BaseTestProperty.cpp
+++ b/test/BaseTestProperty.cpp
@@ -67,13 +67,13 @@ void BaseTestProperty::testValues()
 {
     nix::Section section = file.createSection("Area51", "Boolean");
     nix::Property p1 = section.createProperty("strProperty", str_dummy);
-    std::vector<nix::Value> strValues = { nix::Value("Freude"),
-                                          nix::Value("schoener"),
-                                          nix::Value("Goetterfunken") };
+    std::vector<nix::Variant> strValues = { nix::Variant("Freude"),
+                                          nix::Variant("schoener"),
+                                          nix::Variant("Goetterfunken") };
     p1.values(strValues);
     CPPUNIT_ASSERT_EQUAL(p1.valueCount(), static_cast<ndsize_t>(strValues.size()));
 
-    std::vector<nix::Value> ctrlValues = p1.values();
+    std::vector<nix::Variant> ctrlValues = p1.values();
     for(size_t i = 0; i < ctrlValues.size(); ++i) {
         CPPUNIT_ASSERT_EQUAL(strValues[i], ctrlValues[i]);
     }
@@ -107,17 +107,17 @@ void BaseTestProperty::testValues()
 
 void BaseTestProperty::testDataType() {
     nix::Section section = file.createSection("Area51", "Boolean");
-    std::vector<nix::Value> strValues = { nix::Value("Freude"),
-                                          nix::Value("schoener"),
-                                          nix::Value("Goetterfunken") };
-    std::vector<nix::Value> doubleValues = { nix::Value(1.0),
-                                             nix::Value(2.0),
-                                             nix::Value(-99.99) };
-    std::vector<nix::Value> intValues = {nix::Value(int32_t(1)), nix::Value(int32_t(2)), nix::Value(int32_t(3))};
-    std::vector<nix::Value> uintValues = {nix::Value(uint32_t(1)), nix::Value(uint32_t(2)), nix::Value(uint32_t(3))};
-    std::vector<nix::Value> int64Values = {nix::Value(int64_t(1)), nix::Value(int64_t(2)), nix::Value(int64_t(3))};
-    std::vector<nix::Value> uint64Values = {nix::Value(uint64_t(1)), nix::Value(uint64_t(2)), nix::Value(uint64_t(3))};
-    std::vector<nix::Value> boolValues = {nix::Value(true), nix::Value(false), nix::Value(true)};
+    std::vector<nix::Variant> strValues = { nix::Variant("Freude"),
+                                          nix::Variant("schoener"),
+                                          nix::Variant("Goetterfunken") };
+    std::vector<nix::Variant> doubleValues = { nix::Variant(1.0),
+                                             nix::Variant(2.0),
+                                             nix::Variant(-99.99) };
+    std::vector<nix::Variant> intValues = {nix::Variant(int32_t(1)), nix::Variant(int32_t(2)), nix::Variant(int32_t(3))};
+    std::vector<nix::Variant> uintValues = {nix::Variant(uint32_t(1)), nix::Variant(uint32_t(2)), nix::Variant(uint32_t(3))};
+    std::vector<nix::Variant> int64Values = {nix::Variant(int64_t(1)), nix::Variant(int64_t(2)), nix::Variant(int64_t(3))};
+    std::vector<nix::Variant> uint64Values = {nix::Variant(uint64_t(1)), nix::Variant(uint64_t(2)), nix::Variant(uint64_t(3))};
+    std::vector<nix::Variant> boolValues = {nix::Variant(true), nix::Variant(false), nix::Variant(true)};
 
 
     nix::Property p1 = section.createProperty("strProperty", strValues);
@@ -143,9 +143,9 @@ void BaseTestProperty::testDataType() {
 
 void BaseTestProperty::testUnit(){
     nix::Section section = file.createSection("testSection", "test");
-    nix::Value v(22.2);
-    v.uncertainty = 1.2;
-    std::vector<Value> values = {v};
+    nix::Variant v(22.2);
+    //v.uncertainty = 1.2;
+    std::vector<nix::Variant> values = {v};
     nix::Property p1 = section.createProperty("testProperty", int_dummy);
 
     std::string valid_unit = "mV*cm^-2";

--- a/test/BaseTestProperty.cpp
+++ b/test/BaseTestProperty.cpp
@@ -169,6 +169,22 @@ void BaseTestProperty::testUnit(){
 }
 
 
+void BaseTestProperty::testUncertainty() {
+    nix::Section section = file.createSection("testSection", "test");
+    nix::Property p1 = section.createProperty("testProperty", int_dummy);
+    double uncertainty = 1.2;
+
+    CPPUNIT_ASSERT(!p1.uncertainty());
+
+    p1.uncertainty(uncertainty);
+    CPPUNIT_ASSERT(p1.uncertainty());
+    CPPUNIT_ASSERT(p1.uncertainty() && *p1.uncertainty() == uncertainty);
+
+    p1.uncertainty(nix::none);
+    CPPUNIT_ASSERT(!p1.uncertainty());
+}
+
+
 void BaseTestProperty::testOperators() {
     CPPUNIT_ASSERT(property_null == false);
     CPPUNIT_ASSERT(property_null == none);

--- a/test/BaseTestProperty.hpp
+++ b/test/BaseTestProperty.hpp
@@ -30,7 +30,6 @@ public:
     void testId();
     void testName();
     void testDefinition();
-    void testMapping();
     void testDataType();
     void testValues();
     void testUnit();

--- a/test/BaseTestProperty.hpp
+++ b/test/BaseTestProperty.hpp
@@ -33,6 +33,7 @@ public:
     void testDataType();
     void testValues();
     void testUnit();
+    void testUncertainty();
     void testIsValidEntity();
 
     void testOperators();

--- a/test/BaseTestProperty.hpp
+++ b/test/BaseTestProperty.hpp
@@ -23,7 +23,7 @@ protected:
     nix::File file;
     nix::Section section;
     nix::Property property, property_other, property_null;
-    nix::Value int_dummy, str_dummy;
+    nix::Variant int_dummy, str_dummy;
 
 public:
     void testValidate();

--- a/test/BaseTestReadOnly.cpp
+++ b/test/BaseTestReadOnly.cpp
@@ -29,9 +29,9 @@ using namespace valid;
 void BaseTestReadOnly::setUp() {
     nix::File file = openFile("test_read_only", FileMode::Overwrite);
     startup_time = time(NULL);
-    std::vector<nix::Value> values = { nix::Value(1.0),
-                                       nix::Value(2.0),
-                                       nix::Value(-99.99) };
+    std::vector<nix::Variant> values = { nix::Variant(1.0),
+                                         nix::Variant(2.0),
+                                         nix::Variant(-99.99) };
     std::vector<double> ticks = {1.0, 2.0, 3.4, 42.0};
 
     Section section = file.createSection("foo_section", "metadata");

--- a/test/BaseTestSection.cpp
+++ b/test/BaseTestSection.cpp
@@ -455,7 +455,7 @@ void BaseTestSection::testPropertyAccess() {
     CPPUNIT_ASSERT(!section.hasProperty(p));
     CPPUNIT_ASSERT(!section.deleteProperty(p));
 
-    Value dummy(10);
+    Variant dummy(10);
     prop = section.createProperty("single value", dummy);
     CPPUNIT_ASSERT(section.hasProperty("single value"));
     CPPUNIT_ASSERT(section.propertyCount() == 1);

--- a/test/BaseTestSection.cpp
+++ b/test/BaseTestSection.cpp
@@ -172,17 +172,6 @@ void BaseTestSection::testLink() {
 }
 
 
-void BaseTestSection::testMapping() {
-    CPPUNIT_ASSERT(!section.mapping());
-    std::string map = "http://foo.bar/" + util::createId();
-    section.mapping(map);
-    CPPUNIT_ASSERT(section.mapping() == map);
-    section.mapping(boost::none);
-    CPPUNIT_ASSERT(!section.mapping());
-    CPPUNIT_ASSERT_THROW(section.mapping(""), EmptyString);
-}
-
-
 void BaseTestSection::testSectionAccess() {
     std::vector<std::string> names = { "section_a", "section_b", "section_c", "section_d", "section_e" };
     Section null;

--- a/test/BaseTestSection.hpp
+++ b/test/BaseTestSection.hpp
@@ -31,7 +31,6 @@ public:
     void testParent();
     void testRepository();
     void testLink();
-    void testMapping();
     void testSectionAccess();
     void testFindSection();
     void testFindRelated();

--- a/test/TestOptionalObligatory.cpp
+++ b/test/TestOptionalObligatory.cpp
@@ -437,18 +437,6 @@ void TestOptionalObligatory::testSectionLink() {
                    test::isValidObligatory(is_opt, is_set, accepts_none));
 }
 
-void TestOptionalObligatory::testSectionMapping() {
-    static const bool accepts_none = test::accepts_noneT<nix::Section, test::mapping>::value;
-    is_opt   = std::conditional<std::is_class<decltype(section.mapping())>::value,
-                                std::integral_constant<bool, accepts_none>,
-                                std::integral_constant<bool, util::is_optional<decltype(section.mapping())>::value>
-                                >::type::value;
-    is_set   = test::TtoBool(util::deRef(section.mapping()));
-    summarize("Mapping::mapping", is_opt, is_set, accepts_none);
-    CPPUNIT_ASSERT(test::isValidOptional(is_opt, is_set, accepts_none) ||
-                   test::isValidObligatory(is_opt, is_set, accepts_none));
-}
-
 void TestOptionalObligatory::testSectionRepository() {
     static const bool accepts_none = test::accepts_noneT<nix::Section, test::repository>::value;
     is_opt   = std::conditional<std::is_class<decltype(section.repository())>::value,

--- a/test/TestOptionalObligatory.cpp
+++ b/test/TestOptionalObligatory.cpp
@@ -97,7 +97,7 @@ void TestOptionalObligatory::setUp() {
         refs.push_back(block.createDataArray(name, "reference", DataType::Double, nix::NDSize({ 0 })));
     }
     tag.references(refs);
-    
+
     // multiTag----------------------------------------------------------
     positions = block.createDataArray("positions_DataArray", "dataArray",
                                       DataType::Double, nix::NDSize({ 0 }));
@@ -377,18 +377,6 @@ void TestOptionalObligatory::testRangeDimensionUnit() {
                    test::isValidObligatory(is_opt, is_set, accepts_none));
 }
 
-void TestOptionalObligatory::testPropertyMapping() {
-    static const bool accepts_none = test::accepts_noneT<nix::Property, test::mapping>::value;
-    is_opt   = std::conditional<std::is_class<decltype(property.mapping())>::value,
-                                std::integral_constant<bool, accepts_none>,
-                                std::integral_constant<bool, util::is_optional<decltype(property.mapping())>::value>
-                                    >::type::value;
-    is_set   = test::TtoBool(util::deRef(property.mapping()));
-    summarize("Property::mapping", is_opt, is_set, accepts_none);
-    CPPUNIT_ASSERT(test::isValidOptional(is_opt, is_set, accepts_none) ||
-                   test::isValidObligatory(is_opt, is_set, accepts_none));
-}
-
 void TestOptionalObligatory::testPropertyUnit() {
     static const bool accepts_none = test::accepts_noneT<nix::Property, test::unit>::value;
     is_opt   = std::conditional<std::is_class<decltype(property.unit())>::value,
@@ -549,4 +537,3 @@ void TestOptionalObligatory::summarize(std::string name, bool is_opt, bool is_se
     }
     summary += "\n";
 }
-

--- a/test/TestOptionalObligatory.cpp
+++ b/test/TestOptionalObligatory.cpp
@@ -43,7 +43,7 @@ namespace test {
         return true; // LinkType as enum is always set
     }
     template<>
-    bool TtoBool<std::vector<nix::Value>>(std::vector<nix::Value> var) {
+    bool TtoBool<std::vector<nix::Variant>>(std::vector<nix::Variant> var) {
         return !(var.empty());
     }
     template<>
@@ -81,7 +81,7 @@ void TestOptionalObligatory::setUp() {
     block = file.createBlock("block_one", "dataset");
 
     // property---------------------------------------------------------
-    dummy = Value(10);
+    dummy = Variant(10);
     property = section.createProperty("prop", dummy);
 
     // dataAray---------------------------------------------------------

--- a/test/TestOptionalObligatory.cpp
+++ b/test/TestOptionalObligatory.cpp
@@ -389,6 +389,18 @@ void TestOptionalObligatory::testPropertyUnit() {
                    test::isValidObligatory(is_opt, is_set, accepts_none));
 }
 
+void TestOptionalObligatory::testPropertyUncertainty() {
+    static const bool accepts_none = test::accepts_noneT<nix::Property, test::uncertainty>::value;
+    is_opt   = std::conditional<std::is_class<decltype(property.uncertainty())>::value,
+                                std::integral_constant<bool, accepts_none>,
+                                std::integral_constant<bool, util::is_optional<decltype(property.uncertainty())>::value>
+                                    >::type::value;
+    is_set   = test::TtoBool(util::deRef(property.uncertainty()));
+    summarize("Property::uncertainty", is_opt, is_set, accepts_none);
+    CPPUNIT_ASSERT(test::isValidOptional(is_opt, is_set, accepts_none) ||
+                   test::isValidObligatory(is_opt, is_set, accepts_none));
+}
+
 void TestOptionalObligatory::testPropertyValues() {
     static const bool accepts_none = test::accepts_noneT<nix::Property, test::values>::value;
     is_opt   = std::conditional<std::is_class<decltype(property.values())>::value,

--- a/test/TestOptionalObligatory.hpp
+++ b/test/TestOptionalObligatory.hpp
@@ -152,7 +152,7 @@ private:
     nix::RangeDimension range_dim;
     nix::Feature feature;
     time_t startup_time;
-    nix::Value dummy;
+    nix::Variant dummy;
     bool is_opt;   // whether getter return value is boost::optional
     bool is_set;   // whether getter return value is set
     // bool accepts_none; // whether setter accepts boost::none (declared in place)

--- a/test/TestOptionalObligatory.hpp
+++ b/test/TestOptionalObligatory.hpp
@@ -93,7 +93,7 @@ namespace test {
     ACCEPTS(labels) ACCEPTS(unit) ACCEPTS(metadata) ACCEPTS(ticks) ACCEPTS(offset)
     ACCEPTS(extent) ACCEPTS(extents) ACCEPTS(position) ACCEPTS(positions)
     ACCEPTS(references) ACCEPTS(expansionOrigin) ACCEPTS(samplingInterval)
-    ACCEPTS(mapping) ACCEPTS(values) ACCEPTS(data) ACCEPTS(linkType) ACCEPTS(link)
+    ACCEPTS(values) ACCEPTS(data) ACCEPTS(linkType) ACCEPTS(link)
     ACCEPTS(repository) ACCEPTS(units) ACCEPTS(sources)
 
 } // namespace test
@@ -129,7 +129,6 @@ private:
     CPPUNIT_TEST(testFeatureData);
     CPPUNIT_TEST(testFeatureLinkType);
     CPPUNIT_TEST(testSectionLink);
-    CPPUNIT_TEST(testSectionMapping);
     CPPUNIT_TEST(testSectionRepository);
     CPPUNIT_TEST(testTagExtent);
     CPPUNIT_TEST(testTagPosition);
@@ -189,7 +188,6 @@ public:
     void testFeatureData();
     void testFeatureLinkType();
     void testSectionLink();
-    void testSectionMapping();
     void testSectionRepository();
     void testTagExtent();
     void testTagPosition();

--- a/test/TestOptionalObligatory.hpp
+++ b/test/TestOptionalObligatory.hpp
@@ -70,13 +70,13 @@ namespace test {
     // then 'acceptsNoneT = accepts_noneT<nix::parentClass, test::methodName>::value;'
     enum METHOD_NAME { FIRST };
     template<typename T, METHOD_NAME S>
-    class accepts_noneT 
-    { 
-        template <typename U, void (U::*)(boost::none_t)> struct Check; 
-        template <typename U> static char func(Check<U, &U::id> *); 
-        template <typename U> static int func(...); 
-    public: 
-        enum { value = sizeof(func<T>(0)) == sizeof(char) }; 
+    class accepts_noneT
+    {
+        template <typename U, void (U::*)(boost::none_t)> struct Check;
+        template <typename U> static char func(Check<U, &U::id> *);
+        template <typename U> static int func(...);
+    public:
+        enum { value = sizeof(func<T>(0)) == sizeof(char) };
     };
     #define ACCEPTS(M) \
         static const METHOD_NAME M = static_cast<METHOD_NAME>(__COUNTER__ + 1); \
@@ -91,7 +91,7 @@ namespace test {
         };
     ACCEPTS(id) ACCEPTS(index) ACCEPTS(type) ACCEPTS(name) ACCEPTS(definition) ACCEPTS(label)
     ACCEPTS(labels) ACCEPTS(unit) ACCEPTS(metadata) ACCEPTS(ticks) ACCEPTS(offset)
-    ACCEPTS(extent) ACCEPTS(extents) ACCEPTS(position) ACCEPTS(positions) 
+    ACCEPTS(extent) ACCEPTS(extents) ACCEPTS(position) ACCEPTS(positions)
     ACCEPTS(references) ACCEPTS(expansionOrigin) ACCEPTS(samplingInterval)
     ACCEPTS(mapping) ACCEPTS(values) ACCEPTS(data) ACCEPTS(linkType) ACCEPTS(link)
     ACCEPTS(repository) ACCEPTS(units) ACCEPTS(sources)
@@ -124,7 +124,6 @@ private:
     CPPUNIT_TEST(testRangeDimensionLabel);
     CPPUNIT_TEST(testRangeDimensionTicks);
     CPPUNIT_TEST(testRangeDimensionUnit);
-    CPPUNIT_TEST(testPropertyMapping);
     CPPUNIT_TEST(testPropertyUnit);
     CPPUNIT_TEST(testPropertyValues);
     CPPUNIT_TEST(testFeatureData);
@@ -185,7 +184,6 @@ public:
     void testRangeDimensionLabel();
     void testRangeDimensionTicks();
     void testRangeDimensionUnit();
-    void testPropertyMapping();
     void testPropertyUnit();
     void testPropertyValues();
     void testFeatureData();

--- a/test/TestOptionalObligatory.hpp
+++ b/test/TestOptionalObligatory.hpp
@@ -90,7 +90,7 @@ namespace test {
             enum { value = sizeof(func<T>(0)) == sizeof(char) }; \
         };
     ACCEPTS(id) ACCEPTS(index) ACCEPTS(type) ACCEPTS(name) ACCEPTS(definition) ACCEPTS(label)
-    ACCEPTS(labels) ACCEPTS(unit) ACCEPTS(metadata) ACCEPTS(ticks) ACCEPTS(offset)
+    ACCEPTS(labels) ACCEPTS(unit) ACCEPTS(uncertainty) ACCEPTS(metadata) ACCEPTS(ticks) ACCEPTS(offset)
     ACCEPTS(extent) ACCEPTS(extents) ACCEPTS(position) ACCEPTS(positions)
     ACCEPTS(references) ACCEPTS(expansionOrigin) ACCEPTS(samplingInterval)
     ACCEPTS(values) ACCEPTS(data) ACCEPTS(linkType) ACCEPTS(link)
@@ -125,6 +125,7 @@ private:
     CPPUNIT_TEST(testRangeDimensionTicks);
     CPPUNIT_TEST(testRangeDimensionUnit);
     CPPUNIT_TEST(testPropertyUnit);
+    CPPUNIT_TEST(testPropertyUncertainty);
     CPPUNIT_TEST(testPropertyValues);
     CPPUNIT_TEST(testFeatureData);
     CPPUNIT_TEST(testFeatureLinkType);
@@ -184,6 +185,7 @@ public:
     void testRangeDimensionTicks();
     void testRangeDimensionUnit();
     void testPropertyUnit();
+    void testPropertyUncertainty();
     void testPropertyValues();
     void testFeatureData();
     void testFeatureLinkType();

--- a/test/fs/TestPropertyFS.hpp
+++ b/test/fs/TestPropertyFS.hpp
@@ -34,8 +34,8 @@ public:
         startup_time = time(NULL);
         file = nix::File::open("test_property", nix::FileMode::Overwrite, "file");
         section = file.createSection("cool section", "metadata");
-        int_dummy = nix::Value(10);
-        str_dummy = nix::Value("test");
+        int_dummy = nix::Variant{10};
+        str_dummy = nix::Variant{"test"};
         property = section.createProperty("prop", int_dummy);
         property_other = section.createProperty("other", int_dummy);
         property_null = nix::none;

--- a/test/fs/TestPropertyFS.hpp
+++ b/test/fs/TestPropertyFS.hpp
@@ -18,7 +18,6 @@ class TestPropertyFS : public BaseTestProperty {
     CPPUNIT_TEST(testId);
     CPPUNIT_TEST(testName);
     CPPUNIT_TEST(testDefinition);
-    CPPUNIT_TEST(testMapping);
 
     CPPUNIT_TEST(testValues);
     CPPUNIT_TEST(testDataType);

--- a/test/fs/TestSectionFS.hpp
+++ b/test/fs/TestSectionFS.hpp
@@ -24,7 +24,6 @@ class TestSectionFS : public BaseTestSection {
     CPPUNIT_TEST(testParent);
     CPPUNIT_TEST(testRepository);
     CPPUNIT_TEST(testLink);
-    CPPUNIT_TEST(testMapping);
     CPPUNIT_TEST(testSectionAccess);
     CPPUNIT_TEST(testFindSection);
     CPPUNIT_TEST(testFindRelated);

--- a/test/hdf5/TestPropertyHDF5.hpp
+++ b/test/hdf5/TestPropertyHDF5.hpp
@@ -35,8 +35,8 @@ public:
         startup_time = time(NULL);
         file = nix::File::open("test_property.h5", nix::FileMode::Overwrite);
         section = file.createSection("cool section", "metadata");
-        int_dummy = nix::Value(10);
-        str_dummy = nix::Value("test");
+        int_dummy = nix::Variant(10);
+        str_dummy = nix::Variant("test");
         property = section.createProperty("prop", int_dummy);
         property_other = section.createProperty("other", int_dummy);
         property_null = nix::none;

--- a/test/hdf5/TestPropertyHDF5.hpp
+++ b/test/hdf5/TestPropertyHDF5.hpp
@@ -19,7 +19,6 @@ class TestPropertyHDF5 : public BaseTestProperty {
     CPPUNIT_TEST(testId);
     CPPUNIT_TEST(testName);
     CPPUNIT_TEST(testDefinition);
-    CPPUNIT_TEST(testMapping);
 
     CPPUNIT_TEST(testValues);
     CPPUNIT_TEST(testDataType);

--- a/test/hdf5/TestSectionHDF5.hpp
+++ b/test/hdf5/TestSectionHDF5.hpp
@@ -24,7 +24,6 @@ class TestSectionHDF5 : public BaseTestSection {
     CPPUNIT_TEST(testParent);
     CPPUNIT_TEST(testRepository);
     CPPUNIT_TEST(testLink);
-    CPPUNIT_TEST(testMapping);
     CPPUNIT_TEST(testSectionAccess);
     CPPUNIT_TEST(testFindSection);
     CPPUNIT_TEST(testFindRelated);


### PR DESCRIPTION
The property is now a dataset with a simple data type, no compound type anymore.

Implementation is based on the old value implementation. Maybe there are more elegant ways.
Value class still exists.
Feel free to speak your mind.