### PR TITLE
Add default Compression::Auto to Block constructor

### DIFF
--- a/backend/fs/BlockFS.cpp
+++ b/backend/fs/BlockFS.cpp
@@ -16,7 +16,7 @@ namespace nix {
 namespace file {
 
 BlockFS::BlockFS(const std::shared_ptr<base::IFile> &file, const std::string &loc)
-    : EntityWithMetadataFS(file, loc)
+    : EntityWithMetadataFS(file, loc), compr(Compression::Auto)
 {
     createSubFolders(file);
 }

--- a/backend/hdf5/BlockHDF5.cpp
+++ b/backend/hdf5/BlockHDF5.cpp
@@ -27,7 +27,7 @@ namespace hdf5 {
 
 
 BlockHDF5::BlockHDF5(const std::shared_ptr<base::IFile> &file, const H5Group &group)
-        : EntityWithMetadataHDF5(file, group) {
+        : EntityWithMetadataHDF5(file, group), compr(Compression::Auto) {
     data_array_group = this->group().openOptGroup("data_arrays");
     data_frame_group = this->group().openOptGroup("data_frames");
     tag_group = this->group().openOptGroup("tags");


### PR DESCRIPTION
The Block constructor used for existing blocks, i.e., when a Block is
created through getBlock(), did not have a default 'compr' value, which
would cause issues with uninitialised values.

It's now initialised to Compression::Auto.