### PR TITLE
[cmake] fix compilation for hdf5 1.10.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ set(HDF5_USE_STATIC_LIBRARIES ${BUILD_STATIC})
 find_package (HDF5 REQUIRED COMPONENTS C)
 include_directories (${HDF5_INCLUDE_DIRS})
 set (LINK_LIBS ${LINK_LIBS} ${HDF5_LIBRARIES})
-
+add_definitions(-DH5_USE_110_API=1)
 
 ########################################
 # Boost


### PR DESCRIPTION
So, HDF5 1.10.3 introduced some breaking API change with a minor
version update. Lets blame us for not specifying that we want
indeed the 1.10. API; We do this now (H5_USE_110_API) which should
fix the issue and hopefully prevent future API breaks. Hands up
for everyone who thinks that you need to specify H5_USE_110_API
to not break when upgrading from 1.10.2 to 1.10.3 is confusing,
to put it mildly.
TLDR: assert we want the 1.10 API by specify H5_USE_110_API.