### PR TITLE
[dataAccess] bind position and count dimension to the array extent ...

### DIFF
--- a/src/util/dataAccess.cpp
+++ b/src/util/dataAccess.cpp
@@ -247,8 +247,9 @@ void getOffsetAndCount(const MultiTag &tag, const DataArray &array, const vector
     }
 
     size_t dimcount_sizet = check::fits_in_size_t(dimension_count, "getOffsetAndCount() failed; dimension count > size_t.");
-    NDSize temp_offset(dimcount_sizet, static_cast<NDSize::value_type>(0));
-    NDSize temp_count(dimcount_sizet, static_cast<NDSize::value_type>(1));
+
+    NDSize temp_offset(positions.dataExtent().size(), static_cast<NDSize::value_type>(0));
+    NDSize temp_count(positions.dataExtent().size(), static_cast<NDSize::value_type>(1));
 
     int dim_index = dimension_count > 1 ? 1 : 0;
     temp_count[dim_index] = static_cast<NDSize::value_type>(dimension_count);


### PR DESCRIPTION
this solves an issue in which a {1,1} dataset could not be read