### PR TITLE
data slice can live with less information

### DIFF
--- a/src/util/dataAccess.cpp
+++ b/src/util/dataAccess.cpp
@@ -309,7 +309,8 @@ bool positionAndExtentInData(const DataArray &data, const NDSize &position, cons
 
 void fillPositionsExtentsAndUnits(const DataArray &array,
                                   std::vector<double> &starts,
-                                  std::vector<double> &ends, std::vector<std::string> &units) {
+                                  std::vector<double> &ends,
+                                  std::vector<std::string> &units) {
     std::vector<nix::Dimension> dims = array.dimensions();
     NDSize shape = array.dataExtent();
     for (size_t i = 0; i < dims.size(); ++i) {
@@ -353,7 +354,8 @@ void fillPositionsExtentsAndUnits(const DataArray &array,
 }
 
 
-DataView dataSlice(const DataArray &array, const std::vector<double> &start,
+DataView dataSlice(const DataArray &array,
+                   const std::vector<double> &start,
                    const std::vector<double> &end,
                    const std::vector<std::string> &units) {
     std::vector<double> my_start(start);
@@ -404,7 +406,8 @@ DataView retrieveData(const MultiTag &tag, ndsize_t position_index, const DataAr
 }
 
 
-vector<DataView> retrieveData(const MultiTag &tag, vector<ndsize_t> &position_indices,
+vector<DataView> retrieveData(const MultiTag &tag,
+                              vector<ndsize_t> &position_indices,
                               ndsize_t reference_index) {
     vector<DataArray> refs = tag.references();
     size_t ref_idx = check::fits_in_size_t(reference_index, "retrieveData() failed; reference_index > size_t.");
@@ -416,7 +419,8 @@ vector<DataView> retrieveData(const MultiTag &tag, vector<ndsize_t> &position_in
 }
 
 
-vector<DataView> retrieveData(const MultiTag &tag, vector<ndsize_t> &position_indices,
+vector<DataView> retrieveData(const MultiTag &tag,
+                              vector<ndsize_t> &position_indices,
                               const DataArray &array) {
     vector<NDSize> counts, offsets;
     vector<DataView> views;

--- a/src/util/dataAccess.cpp
+++ b/src/util/dataAccess.cpp
@@ -15,6 +15,7 @@
 #include <cmath>
 #include <algorithm>
 #include <numeric>
+#include <cfloat>
 
 #include <boost/optional.hpp>
 
@@ -344,6 +345,11 @@ void fillPositionsExtentsAndUnits(const DataArray &array,
                 starts.push_back(0.0);
             }
             if (i >= ends.size()) {
+                // TODO fix double cast for very large shapes
+                // issue might be theoretical, see https://github.com/G-Node/nix/issues/765
+                if (shape[i]-1 > pow(FLT_RADIX, std::numeric_limits<double>::digits)) {
+                    throw nix::OutOfBounds("dataAccess::fillPositionsExtents: shape cannot be cast to double without loss of precision. Please open an issue on github!");
+                }
                 ends.push_back(static_cast<double>(shape[i]-1));
             }
             if (i >= units.size()) {

--- a/src/util/dataAccess.cpp
+++ b/src/util/dataAccess.cpp
@@ -312,7 +312,7 @@ void fillPositionsExtentsAndUnits(const DataArray &array,
                                   std::vector<double> &ends, std::vector<std::string> &units) {
     std::vector<nix::Dimension> dims = array.dimensions();
     NDSize shape = array.dataExtent();
-    for (ndsize_t i = 0; i < dims.size(); ++i) {
+    for (size_t i = 0; i < dims.size(); ++i) {
         Dimension dim = dims[i];
         DimensionType dt = dim.dimensionType();
         if (dt == DimensionType::Sample) {
@@ -363,7 +363,7 @@ DataView dataSlice(const DataArray &array, const std::vector<double> &start,
     if (array == nix::none) {
         throw UninitializedEntity();
     }
-    size_t dim_count = array.dimensionCount();
+    ndsize_t dim_count = array.dimensionCount();
     if (start.size() > dim_count || end.size() > dim_count || units.size() > dim_count) {
         throw std::invalid_argument("More start/end/unit entries given than number of dimensions in the data!");
     }

--- a/src/util/dataAccess.cpp
+++ b/src/util/dataAccess.cpp
@@ -48,26 +48,6 @@ void scalePositions(const vector<double> &starts, const vector<double> &ends,
 }
 
 
-ndsize_t positionToIndex(double position, const string &unit, const Dimension &dimension) {
-    ndsize_t pos;
-    if (dimension.dimensionType() == DimensionType::Sample) {
-        SampledDimension dim;
-        dim = dimension;
-        pos = positionToIndex(position, unit, dim);
-    } else if (dimension.dimensionType() == DimensionType::Set) {
-        SetDimension dim;
-        dim = dimension;
-        pos = positionToIndex(position, unit, dim);
-    } else {
-        RangeDimension dim;
-        dim = dimension;
-        pos = positionToIndex(position, unit, dim);
-    }
-
-    return pos;
-}
-
-
 vector<pair<ndsize_t, ndsize_t>> positionToIndex(const vector<double> &start_positions,
                                                  const vector<double> end_positions,
                                                  const vector<string> &units,

--- a/src/util/dataAccess.cpp
+++ b/src/util/dataAccess.cpp
@@ -344,7 +344,7 @@ void fillPositionsExtentsAndUnits(const DataArray &array,
                 starts.push_back(0.0);
             }
             if (i >= ends.size()) {
-                ends.push_back(shape[i]-1);
+                ends.push_back(static_cast<double>(shape[i]-1));
             }
             if (i >= units.size()) {
                 units.push_back("none");

--- a/test/BaseTestDataAccess.cpp
+++ b/test/BaseTestDataAccess.cpp
@@ -31,6 +31,7 @@ void BaseTestDataAccess::testPositionToIndexRangeDimension() {
     std::string invalid_unit = "kV";
     std::string scaled_unit = "s";
     CPPUNIT_ASSERT_THROW(util::positionToIndex(5.0, invalid_unit, rangeDim), nix::IncompatibleDimensions);
+
     CPPUNIT_ASSERT(util::positionToIndex(1.0, unit, rangeDim) == 0);
     CPPUNIT_ASSERT(util::positionToIndex(8.0, unit, rangeDim) == 4);
     CPPUNIT_ASSERT(util::positionToIndex(0.001, scaled_unit, rangeDim) == 0);

--- a/test/BaseTestDataAccess.cpp
+++ b/test/BaseTestDataAccess.cpp
@@ -277,7 +277,14 @@ void BaseTestDataAccess::testMultiTagFeatureData() {
     CPPUNIT_ASSERT(multi_tag.featureCount() == 3);
 
     // indexed feature
-    DataView data_view = util::retrieveFeatureData(multi_tag, indices, 0)[0];
+    // read a single feature, old style function
+    DataView data_view = util::retrieveFeatureData(multi_tag, 1, 0);
+    CPPUNIT_ASSERT(data_view.dataExtent().size()  == 2);
+    CPPUNIT_ASSERT(data_view.dataExtent().nelms() == 10);
+    CPPUNIT_ASSERT_THROW(util::retrieveFeatureData(multi_tag, 10, 0), nix::OutOfBounds);
+    CPPUNIT_ASSERT_NO_THROW(util::retrieveFeatureData(multi_tag, 1, index_feature));
+    // read feature data, multiple indices at once
+    data_view = util::retrieveFeatureData(multi_tag, indices, 0)[0];
 
     NDSize data_size = data_view.dataExtent();
     CPPUNIT_ASSERT(data_size.size() == 2);
@@ -516,6 +523,7 @@ void BaseTestDataAccess::testDataSlice() {
 
     slice = util::dataSlice(twod_array, {0., 0.0}, {9.0, 1.0}, {"none", "s"});
     CPPUNIT_ASSERT(slice.dataExtent()[0] == 10 && slice.dataExtent()[1] == 101);
+
 
     b.deleteDataArray(oned_array);
     b.deleteDataArray(twod_array);

--- a/test/BaseTestDataAccess.cpp
+++ b/test/BaseTestDataAccess.cpp
@@ -283,6 +283,7 @@ void BaseTestDataAccess::testMultiTagFeatureData() {
     CPPUNIT_ASSERT(data_view.dataExtent().nelms() == 10);
     CPPUNIT_ASSERT_THROW(util::retrieveFeatureData(multi_tag, 10, 0), nix::OutOfBounds);
     CPPUNIT_ASSERT_NO_THROW(util::retrieveFeatureData(multi_tag, 1, index_feature));
+
     // read feature data, multiple indices at once
     data_view = util::retrieveFeatureData(multi_tag, indices, 0)[0];
 
@@ -349,10 +350,15 @@ void BaseTestDataAccess::testMultiTagFeatureData() {
     CPPUNIT_ASSERT_THROW(util::retrieveFeatureData(multi_tag, indices, 3), nix::OutOfBounds);
 
     // test multiple positions
-    std::vector<DataView> views = util::retrieveFeatureData(multi_tag, {0, 1}, 0);
+    std::vector<nix::DataView> views = util::retrieveFeatureData(multi_tag, {0, 1}, 0);
     CPPUNIT_ASSERT(views.size() == 2);
     CPPUNIT_ASSERT(views[0].dataExtent() == NDSize({1, 10}));
     CPPUNIT_ASSERT(views[0].dataExtent() == NDSize({1, 10}));
+
+    // test positions without specifying
+    indices.clear();
+    views = util::retrieveFeatureData(multi_tag, indices, 0);
+    CPPUNIT_ASSERT(views.size() == multi_tag.positionCount());
 
     // clean up
     multi_tag.deleteFeature(index_feature.id());

--- a/test/BaseTestDataAccess.cpp
+++ b/test/BaseTestDataAccess.cpp
@@ -508,9 +508,22 @@ void BaseTestDataAccess::testDataSlice() {
 
     // do the tests!
     nix::DataArray no_array;
-    CPPUNIT_ASSERT_THROW(util::dataSlice(no_array, {1, 2}, {2,3}), nix::UninitializedEntity);
+    CPPUNIT_ASSERT_THROW(util::dataSlice(no_array, {1, 2}, {2, 3}), nix::UninitializedEntity);
 
-    CPPUNIT_ASSERT_THROW(util::dataSlice(oned_array, {1, 2}, {2,3}), std::invalid_argument);
+    // test incomplete information
+    nix::DataView view = util::dataSlice(oned_array, {}, {}, {});
+    CPPUNIT_ASSERT(view.dataExtent() == oned_array.dataExtent());
+    view = util::dataSlice(twod_array, {}, {}, {});
+    CPPUNIT_ASSERT(view.dataExtent() == twod_array.dataExtent());
+    view = util::dataSlice(twod_array2, {}, {}, {});
+    CPPUNIT_ASSERT(view.dataExtent() == twod_array2.dataExtent());
+    view = util::dataSlice(twod_array2, {0.0}, {9.0}, {"s"});
+    CPPUNIT_ASSERT(view.dataExtent()[1] == twod_array2.dataExtent()[1]);
+    view = util::dataSlice(twod_array2, {0.0, 0.0}, {9.0, 1000.}, {"s", "ms"});
+    CPPUNIT_ASSERT(view.dataExtent()[1] == (1/interval + 1));
+
+    // test scaling, exceptions etc.
+    CPPUNIT_ASSERT_THROW(util::dataSlice(oned_array, {1, 2}, {2, 3}), std::invalid_argument);
     CPPUNIT_ASSERT_THROW(util::dataSlice(oned_array, {1}, {2}, {"ms", "mV"}), std::invalid_argument);
     CPPUNIT_ASSERT_THROW(util::dataSlice(oned_array, {1, 2, 3}, {1, 2}), std::invalid_argument);
     CPPUNIT_ASSERT_NO_THROW(util::dataSlice(oned_array, {0.0}, {1.0}));

--- a/test/BaseTestDataAccess.cpp
+++ b/test/BaseTestDataAccess.cpp
@@ -142,6 +142,10 @@ void BaseTestDataAccess::testRetrieveData() {
     std::vector<DataView> slices = util::retrieveData(mtag2, temp, 0);
     CPPUNIT_ASSERT(slices.size() == mtag2.positions().dataExtent()[0]);
 
+    // old-style calls, deprecated
+    CPPUNIT_ASSERT_NO_THROW(util::retrieveData(mtag2, 0, 0));
+    CPPUNIT_ASSERT_NO_THROW(util::retrieveData(mtag2, 0, mtag2.references()[0]));
+
     slices = util::retrieveData(pointmtag, temp, 0);
     CPPUNIT_ASSERT(slices.size() == pointmtag.positions().dataExtent()[0]);
 
@@ -163,6 +167,7 @@ void BaseTestDataAccess::testRetrieveData() {
     CPPUNIT_ASSERT(data_size.size() == 3);
     CPPUNIT_ASSERT(data_size[0] == 1 && data_size[1] == 7 && data_size[2] == 2);
 
+
     DataView times_view = util::retrieveData(times_tag, 0);
     data_size = times_view.dataExtent();
     std::vector<double> times(data_size.size());
@@ -170,6 +175,7 @@ void BaseTestDataAccess::testRetrieveData() {
     RangeDimension dim = times_tag.references()[0].dimensions()[0].asRangeDimension();
     CPPUNIT_ASSERT(data_size.size() == 1);
     CPPUNIT_ASSERT(data_size[0] == 77);
+
 }
 
 

--- a/test/BaseTestDataAccess.cpp
+++ b/test/BaseTestDataAccess.cpp
@@ -5,6 +5,10 @@
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted under the terms of the BSD License. See
 // LICENSE file in the root of the Project.
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4996)
+#endif
 
 #include <iostream>
 #include <sstream>
@@ -24,7 +28,6 @@
 #include "BaseTestDataAccess.hpp"
 
 using namespace nix;
-
 
 void BaseTestDataAccess::testPositionToIndexRangeDimension() {
     std::string unit = "ms";
@@ -555,3 +558,7 @@ void BaseTestDataAccess::testDataSlice() {
     b.deleteDataArray(twod_array);
     file.deleteBlock(b);
 }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif


### PR DESCRIPTION
with this pr, the ``util::dataSlice`` method automatically fills in missing information (to some extent). That is: start, end, and unit values may be missing or incomplete. If less info is given than there are dimensions defaults are assumed:
* ``units`` are filled with the ones defined in the dimension
* ``start`` is set to ``offset`` (``SampledDimension``), first tick (``RangeDimension``), or 0 (``SetDimension``)
* ``end`` is set to point (``SampledDimension``, ``RangeDimension``) or max index (``SetDimension``)

General rule: if information is provided, the first value given is assumed to belong to the first dimension the 2nd to the second, etc. 