### PR TITLE
deprecation of retrieve data functions ...

### DIFF
--- a/include/nix/MultiTag.hpp
+++ b/include/nix/MultiTag.hpp
@@ -574,7 +574,21 @@ public:
      *
      * @return The data
      */
-    DataView retrieveFeatureData(size_t position_index, size_t feature_index) const;
+    DataView featureData(size_t position_index, size_t feature_index) const;
+
+    /**
+     * @brief Retrieves the data stored in a feature related to a certain
+     *        position of this tag.
+     *
+     * @param position_index The index of the requested position
+     * @param feature_index The index of the selected feature
+     *
+     * @return The data
+     * @deprecated This function has been deprecated. Use featureData(size_t, size_t) instead.
+     */
+    DEPRECATED DataView retrieveFeatureData(size_t position_index, size_t feature_index) const {
+        return featureData(position_index, feature_index);
+    }
 
     /**
      * @brief Retrieves the data stored in a feature related to a certain
@@ -585,7 +599,21 @@ public:
      *
      * @return The data
      */
-    DataView retrieveFeatureData(size_t position_index, const std::string &name_or_id) const;
+    DataView featureData(size_t position_index, const std::string &name_or_id) const;
+
+    /**
+     * @brief Retrieves the data stored in a feature related to a certain
+     *        position of this tag.
+     *
+     * @param position_index The index of the requested position.
+     * @param name_or_id     The name or id of the feature that is requested.
+     *
+     * @return The data
+     * @deprecated This function has been deprecated! Use featureData(size_t, std::string) instead.
+     */
+    DEPRECATED DataView retrieveFeatureData(size_t position_index, const std::string &name_or_id) const {
+        return featureData(position_index, name_or_id);
+    }
 
     //------------------------------------------------------
     // Operators and other functions

--- a/include/nix/MultiTag.hpp
+++ b/include/nix/MultiTag.hpp
@@ -358,7 +358,20 @@ public:
      *
      * @return the requested data.
      */
-    DataView retrieveData(size_t position_index, size_t reference_index) const;
+    DataView taggedData(size_t position_index, size_t reference_index) const;
+
+    /**
+     * @brief Retrieves the data slice tagged by a certain position and extent
+     *        of a certain reference.
+     *
+     * @param position_index the index of the requested position.
+     * @param reference_index the index of the requested reference.
+     *
+     * @return the requested data.
+     */
+    DEPRECATED DataView retrieveData(size_t position_index, size_t reference_index) const {
+        return taggedData(position_index, reference_index);
+    }
 
     /*
      * @brief Retrieves multiple tagged data slices from a certain reference.
@@ -371,7 +384,35 @@ public:
      *
      * @return vector of DataView objects representing the slices.
      */
-    std::vector<DataView> retrieveData(std::vector<ndsize_t> &position_indices, ndsize_t reference_index) const;
+    std::vector<DataView> taggedData(std::vector<ndsize_t> &position_indices, ndsize_t reference_index) const;
+
+    /*
+     * @brief Retrieves multiple tagged data slices from a certain reference.
+     *
+     * Depending on the dimensionality of the data this function is much more efficient
+     * than retrieving slices separately.
+     *
+     * @param position_indices: vector of indices.
+     * @param reference_index the index of the requested reference.
+     *
+     * @return vector of DataView objects representing the slices.
+     */
+    DEPRECATED std::vector<DataView> retrieveData(std::vector<ndsize_t> &position_indices, ndsize_t reference_index) const {
+        return taggedData(position_indices, reference_index);
+    }
+
+    /*
+     * @brief Retrieves multiple tagged data slices from a certain reference.
+     *
+     * Depending on the dimensionality of the data this function is much more efficient
+     * than retrieving slices separately.
+     *
+     * @param position_indices: vector of indices.
+     * @param name_or_id the name or the id of the requested DataArray.
+     *
+     * @return vector of DataView objects representing the slices.
+     */
+    std::vector<DataView> taggedData(std::vector<ndsize_t> &position_indices, const std::string &name_or_id) const;
 
      /*
      * @brief Retrieves multiple tagged data slices from a certain reference.
@@ -384,7 +425,9 @@ public:
      *
      * @return vector of DataView objects representing the slices.
      */
-    std::vector<DataView> retrieveData(std::vector<ndsize_t> &position_indices, const std::string &name_or_id) const;
+    DEPRECATED std::vector<DataView> retrieveData(std::vector<ndsize_t> &position_indices, const std::string &name_or_id) const {
+        return taggedData(position_indices, name_or_id);
+    }
 
      /**
      * @brief Retrieves the data slice tagged by a certain position and extent
@@ -395,7 +438,20 @@ public:
      *
      * @return the requested data.
      */
-    DataView retrieveData(size_t position_index, const std::string &name_or_id) const;
+    DataView taggedData(size_t position_index, const std::string &name_or_id) const;
+
+     /**
+     * @brief Retrieves the data slice tagged by a certain position and extent
+     *        of a certain reference.
+     *
+     * @param position_index      The index of the requested position.
+     * @param name_or_id          The name or id of the requested DataArray.
+     *
+     * @return the requested data.
+     */
+    DataView retrieveData(size_t position_index, const std::string &name_or_id) const {
+        return taggedData(position_index, name_or_id);
+    }
 
     //--------------------------------------------------
     // Methods concerning features.

--- a/include/nix/Tag.hpp
+++ b/include/nix/Tag.hpp
@@ -431,7 +431,6 @@ public:
     //--------------------------------------------------
     // Methods for data retrieval
     //--------------------------------------------------
-
     /**
      * @brief Returns the data associated with a certain reference.
      *
@@ -440,7 +439,20 @@ public:
      *
      * @return the data
      */
-    DataView retrieveData(size_t reference_index) const;
+    DataView taggedData(size_t reference_index) const;
+
+    /**
+     * @brief Returns the data associated with a certain reference.
+     *
+     * @param reference_index The index of the reference of which
+     *                        the data should be returned.
+     *
+     * @return the data
+     * @deprecated This function has been marked deprecated. Please use taggedData(size_t) instead.
+     */
+    DEPRECATED DataView retrieveData(size_t reference_index) const {
+        return taggedData(reference_index);
+    }
 
     /**
      * @brief Returns the data associated with a certain reference.
@@ -449,7 +461,19 @@ public:
      *
      * @return the data
      */
-    DataView retrieveData(const std::string &name_or_id) const;
+    DataView taggedData(const std::string &name_or_id) const;
+
+    /**
+     * @brief Returns the data associated with a certain reference.
+     *
+     * @param name_or_id      Name or id of the referenced dataArray.
+     *
+     * @return the data
+     * @deprecated This function has been deprecated. Please use taggedData(std::string) instead.
+     */
+    DEPRECATED DataView retrieveData(const std::string &name_or_id) const {
+        return taggedData(name_or_id);
+    }
 
     /**
      * @brief Returns the data stored in the selected Feature.

--- a/include/nix/Tag.hpp
+++ b/include/nix/Tag.hpp
@@ -475,7 +475,7 @@ public:
         return taggedData(name_or_id);
     }
 
-    /**
+     /**
      * @brief Returns the data stored in the selected Feature.
      *
      * @param feature_index   The index of the requested feature.
@@ -483,7 +483,19 @@ public:
      * @return The data stored in the Feature.
      *
      */
-    DataView retrieveFeatureData(size_t feature_index) const;
+    DataView featureData(size_t feature_index) const;
+
+    /**
+     * @brief Returns the data stored in the selected Feature.
+     *
+     * @param feature_index   The index of the requested feature.
+     *
+     * @return The data stored in the Feature.
+     * @deprecated This function has been deprecated! Please use featureData(size_t) instead.
+     */
+    DEPRECATED DataView retrieveFeatureData(size_t feature_index) const {
+        return featureData(feature_index);
+    }
 
     /**
      * @brief Returns the data stored in the selected Feature.
@@ -494,7 +506,20 @@ public:
      * @return The data stored in the Feature.
      *
      */
-    DataView retrieveFeatureData(const std::string &name_or_id) const;
+    DataView featureData(const std::string &name_or_id) const;
+
+    /**
+     * @brief Returns the data stored in the selected Feature.
+     *
+     * @param name_or_id     The name or id of the feature or the DataArray stored
+     *                       in the feature.
+     *
+     * @return The data stored in the Feature.
+     * @deprecated This function has been deprecated. Pleas use featureData(std::string) instead.
+     */
+    DataView retrieveFeatureData(const std::string &name_or_id) const {
+        return featureData(name_or_id);
+    }
 
     //--------------------------------------------------
     // Other methods and functions

--- a/include/nix/util/dataAccess.hpp
+++ b/include/nix/util/dataAccess.hpp
@@ -338,8 +338,32 @@ NIXAPI DataView featureData(const Tag &tag, const Feature &feature);
  * @param feature_index  The index of the desired feature. Default is 0.
  *
  * @return The associated data.
+ * @deprecated This function has been deprecated! Use featureData(MultiTag, ndsize_t, feature_index) instead.
  */
-NIXAPI DataView retrieveFeatureData(const MultiTag &tag, ndsize_t position_index, ndsize_t feature_index=0);
+NIXAPI DEPRECATED DataView retrieveFeatureData(const MultiTag &tag, ndsize_t position_index, ndsize_t feature_index=0);
+
+/**
+ * @brief Returns the feature data associated with the given MuliTag's position.
+ *
+ * @param tag            The MultiTag whos feature data is requested.
+ * @param position_index The index of the selected position, respectively the selected tag of the MultiTag.
+ * @param feature_index  The index of the desired feature. Default is 0.
+ *
+ * @return The associated data.
+ */
+NIXAPI DataView featureData(const MultiTag &tag, ndsize_t position_index, ndsize_t feature_index=0);
+
+/**
+ * @brief Returns the feature data associated with the given MuliTag's position.
+ *
+ * @param tag            The MultiTag whos feature data is requested.
+ * @param position_index The index of the selected position, respectively the selected tag of the MultiTag.
+ * @param feature        The feature of which the tagged data is requested.
+ *
+ * @return The associated data.
+ * @deprecated This function has been deprecated! Use featureData(MultiTag, ndsize_t, Feature) instead.
+ */
+NIXAPI DEPRECATED DataView retrieveFeatureData(const MultiTag &tag, ndsize_t position_index, const Feature &feature);
 
 /**
  * @brief Returns the feature data associated with the given MuliTag's position.
@@ -350,8 +374,7 @@ NIXAPI DataView retrieveFeatureData(const MultiTag &tag, ndsize_t position_index
  *
  * @return The associated data.
  */
-NIXAPI DataView retrieveFeatureData(const MultiTag &tag, ndsize_t position_index, const Feature &feature);
-
+NIXAPI DataView featureData(const MultiTag &tag, ndsize_t position_index, const Feature &feature);
 
 /**
  * @brief Retruns the feature data associated with a MultiTag.
@@ -361,10 +384,37 @@ NIXAPI DataView retrieveFeatureData(const MultiTag &tag, ndsize_t position_index
  * @param feature_index    The index of the desired feature. Default is 0.
  *
  * @return A vector of the associated data, may be empty.
+ * @deprecated This function has been deprecated! Use featureData(MultiTag, std::vector<ndsize_t>, ndsize_t) instead.
  */
-NIXAPI std::vector<DataView> retrieveFeatureData(const MultiTag &tag,
-                                                 std::vector<ndsize_t> position_indices,
-                                                 ndsize_t feature_index = 0);
+NIXAPI DEPRECATED std::vector<DataView> retrieveFeatureData(const MultiTag &tag,
+                                                            std::vector<ndsize_t> position_indices,
+                                                            ndsize_t feature_index = 0);
+/**
+ * @brief Retruns the feature data associated with a MultiTag.
+ *
+ * @param tag              The MultiTag whos feature data is requested
+ * @param position_indices A vector of position indices.
+ * @param feature_index    The index of the desired feature. Default is 0.
+ *
+ * @return A vector of the associated data, may be empty.
+ */
+NIXAPI std::vector<DataView> featureData(const MultiTag &tag,
+                                         std::vector<ndsize_t> position_indices,
+                                         ndsize_t feature_index = 0);
+
+/**
+ * @brief Returns the feature data associated with the given MuliTag's positions.
+ *
+ * @param tag              The MultiTag whos feature data is requested.
+ * @param position_indices A vector of position indices.
+ * @param feature          The feature of which the tagged data is requested.
+ *
+ * @return A vector of the associated data, may be empty.
+ * @deprecated This function has been deprecated! Use featureData(MultiTag, std::vector<ndsize_t>, Feature) instead.
+ */
+NIXAPI DEPRECATED std::vector<DataView> retrieveFeatureData(const MultiTag &tag,
+                                                            std::vector<ndsize_t> position_indices,
+                                                            const Feature &feature);
 
 /**
  * @brief Returns the feature data associated with the given MuliTag's positions.
@@ -375,9 +425,9 @@ NIXAPI std::vector<DataView> retrieveFeatureData(const MultiTag &tag,
  *
  * @return A vector of the associated data, may be empty.
  */
-NIXAPI std::vector<DataView> retrieveFeatureData(const MultiTag &tag,
-                                                 std::vector<ndsize_t> position_indices,
-                                                 const Feature &feature);
+NIXAPI std::vector<DataView> featureData(const MultiTag &tag,
+                                         std::vector<ndsize_t> position_indices,
+                                         const Feature &feature);
 
 } //namespace util
 } //namespace nix

--- a/include/nix/util/dataAccess.hpp
+++ b/include/nix/util/dataAccess.hpp
@@ -228,7 +228,7 @@ NIXAPI DEPRECATED DataView retrieveData(const MultiTag &tag, ndsize_t position_i
 /**
  * @brief Retrieve the data tagged by position and extent of the Tag.
  *
- * @param tag                   The multi tag.
+ * @param tag                   The tag.
  * @param reference_index       The index of the reference of which data should be returned.
  *
  * @return nix::DataView containing the tagged data.
@@ -238,7 +238,7 @@ NIXAPI DataView taggedData(const Tag &tag, ndsize_t reference_index);
 /**
  * @brief Retrieve the data referenced by the given position and extent of the Tag.
  *
- * @param tag                   The multi tag.
+ * @param tag                   The Tag.
  * @param reference_index       The index of the reference from which data should be returned.
  *
  * @return The data referenced by the position.
@@ -249,7 +249,7 @@ NIXAPI DEPRECATED DataView retrieveData(const Tag &tag, ndsize_t reference_index
 /**
  * @brief Retrieve the data tagged by position and extent of the Tag.
  *
- * @param tag                   The multi tag.
+ * @param tag                   The tag.
  * @param array                 The referenced DataArray.
  *
  * @return nix::DataView containing the tagged data.
@@ -259,7 +259,7 @@ NIXAPI DataView taggedData(const Tag &tag, const DataArray &array);
 /**
  * @brief Retrieve the data referenced by the given position and extent of the Tag.
  *
- * @param tag                   The multi tag.
+ * @param tag                   The tag.
  * @param array                 The referenced DataArray.
  *
  * @return The data referenced by the position.
@@ -295,8 +295,30 @@ NIXAPI bool positionAndExtentInData(const DataArray &data, const NDSize &positio
  * @param feature_index The index of the desired feature. Default is 0.
  *
  * @return The associated data.
+ * @deprecated This function has been deprecated! User featureData(Tag, ndsize_t) instead.
  */
-NIXAPI DataView retrieveFeatureData(const Tag &tag, ndsize_t feature_index=0);
+NIXAPI DEPRECATED DataView retrieveFeatureData(const Tag &tag, ndsize_t feature_index=0);
+
+/**
+ * @brief Retruns the feature data associated with a Tag.
+ *
+ * @param tag           The Tag whos feature data is requested
+ * @param feature_index The index of the desired feature. Default is 0.
+ *
+ * @return The associated data.
+ */
+NIXAPI DataView featureData(const Tag &tag, ndsize_t feature_index=0);
+
+/**
+ * @brief Retruns the feature data associated with a Tag.
+ *
+ * @param tag           The Tag whos feature data is requested.
+ * @param feature       The Feature of which the tagged data is requested.
+ *
+ * @return The associated data.
+ * @deprecated This function has been deprecated! User featureData(Tag, Feature) instead.
+ */
+NIXAPI DEPRECATED DataView retrieveFeatureData(const Tag &tag, const Feature &feature);
 
 /**
  * @brief Retruns the feature data associated with a Tag.
@@ -306,7 +328,7 @@ NIXAPI DataView retrieveFeatureData(const Tag &tag, ndsize_t feature_index=0);
  *
  * @return The associated data.
  */
-NIXAPI DataView retrieveFeatureData(const Tag &tag, const Feature &feature);
+NIXAPI DataView featureData(const Tag &tag, const Feature &feature);
 
 /**
  * @brief Returns the feature data associated with the given MuliTag's position.

--- a/include/nix/util/dataAccess.hpp
+++ b/include/nix/util/dataAccess.hpp
@@ -156,6 +156,52 @@ NIXAPI DataView dataSlice(const DataArray &array, const std::vector<double> &sta
                           const std::vector<std::string> &units={});
 
 /**
+ * @brief Retrieve several data segments that are tagged by the given position and extent of the MultiTag.
+ *
+ * @param tag                   The multi tag.
+ * @param position_indices      The indices of the positions.
+ * @param array                 The referenced DataArray.
+ *
+ * @return vector of nix::DataViews that contain the data tagged by the specified position indices.
+ */
+NIXAPI std::vector<DataView> taggedData(const MultiTag &tag, std::vector<ndsize_t> &position_indices, const DataArray &array);
+
+/**
+ * @brief Retrieve several data segments referenced by the given position and extent of the MultiTag.
+ *
+ * @param tag                   The multi tag.
+ * @param position_indices      The indices of the positions.
+ * @param array                 The referenced DataArray.
+ *
+ * @return The data referenced by the specified indices, respectively their positions and extents.
+ * @deprecated This function has been deprecated! Use taggedData(MultiTag, vector<ndsize_t>, DataArray) instead.
+ */
+NIXAPI DEPRECATED std::vector<DataView> retrieveData(const MultiTag &tag, std::vector<ndsize_t> &position_indices, const DataArray &array);
+
+/**
+ * @brief Retrieve several data segments that are tagged by the given positions and extents of the MultiTag.
+ *
+ * @param tag                   The multi tag.
+ * @param position_indices      The indices of the position.
+ * @param reference_index       The index of the referenced DataArray.
+ *
+ * @return vector of nix::DataViews containing the data tagged by the specified position indices.
+ */
+NIXAPI std::vector<DataView> taggedData(const MultiTag &tag, std::vector<ndsize_t> &position_indices, ndsize_t reference_index);
+
+/**
+ * @brief Retrieve several segments of data referenced by the given position and extent of the MultiTag.
+ *
+ * @param tag                   The multi tag.
+ * @param position_indices      The indices of the position.
+ * @param reference_index       The index of the referenced DataArray.
+ *
+ * @return The data referenced by the specified indices, respectively their positions and extents.
+ * @deprecated This function has been deprecated! Use taggedData(MultiTag, vector<ndsize_t>, reference_index) instead.
+ */
+NIXAPI DEPRECATED std::vector<DataView> retrieveData(const MultiTag &tag, std::vector<ndsize_t> &position_indices, ndsize_t reference_index);
+
+/**
  * @brief Retrieve the data referenced by the given position and extent of the MultiTag.
  *
  * @param tag                   The multi tag.
@@ -163,7 +209,7 @@ NIXAPI DataView dataSlice(const DataArray &array, const std::vector<double> &sta
  * @param array                 The referenced DataArray.
  *
  * @return The data referenced by position and extent.
- * @deprecated This function has been deprecated! Use retrieveData(MultiTag, vector<ndsize_t>, DataArray) instead.
+ * @deprecated This function has been deprecated! Use taggedData(MultiTag, vector<ndsize_t>, DataArray) instead.
  */
 NIXAPI DEPRECATED DataView retrieveData(const MultiTag &tag, ndsize_t position_index, const DataArray &array);
 
@@ -175,33 +221,19 @@ NIXAPI DEPRECATED DataView retrieveData(const MultiTag &tag, ndsize_t position_i
  * @param reference_index       The index of the reference from which data should be returned.
  *
  * @return The data referenced by position and extent.
- * @deprecated This function has been deprecated! Use retrieveData(MultiTag, vector<ndsize_t>, DataArray) instead.
+ * @deprecated This function has been deprecated! Use taggedData(MultiTag, vector<ndsize_t>, DataArray) instead.
  */
 NIXAPI DEPRECATED DataView retrieveData(const MultiTag &tag, ndsize_t position_index, ndsize_t reference_index);
 
-
 /**
- * @brief Retrieve several data segments referenced by the given position and extent of the MultiTag.
+ * @brief Retrieve the data tagged by position and extent of the Tag.
  *
  * @param tag                   The multi tag.
- * @param position_indices      The indices of the positions.
- * @param array                 The referenced DataArray.
+ * @param reference_index       The index of the reference of which data should be returned.
  *
- * @return The data referenced by the specified indices, respectively their positions and extents.
+ * @return nix::DataView containing the tagged data.
  */
-NIXAPI std::vector<DataView> retrieveData(const MultiTag &tag, std::vector<ndsize_t> &position_indices, const DataArray &array);
-
-/**
- * @brief Retrieve several segments of data referenced by the given position and extent of the MultiTag.
- *
- * @param tag                   The multi tag.
- * @param position_indices      The indices of the position.
- * @param reference_index       The index of the referenced DataArray.
- *
- * @return The data referenced by the specified indices, respectively their positions and extents.
- */
-NIXAPI std::vector<DataView> retrieveData(const MultiTag &tag, std::vector<ndsize_t> &position_indices, ndsize_t reference_index);
-
+NIXAPI DataView taggedData(const Tag &tag, ndsize_t reference_index);
 
 /**
  * @brief Retrieve the data referenced by the given position and extent of the Tag.
@@ -210,8 +242,19 @@ NIXAPI std::vector<DataView> retrieveData(const MultiTag &tag, std::vector<ndsiz
  * @param reference_index       The index of the reference from which data should be returned.
  *
  * @return The data referenced by the position.
+ * @deprecated This function has been deprecated! Use taggedData(Tag, ndsize_t) instead.
  */
-NIXAPI DataView retrieveData(const Tag &tag, ndsize_t reference_index);
+NIXAPI DEPRECATED DataView retrieveData(const Tag &tag, ndsize_t reference_index);
+
+/**
+ * @brief Retrieve the data tagged by position and extent of the Tag.
+ *
+ * @param tag                   The multi tag.
+ * @param array                 The referenced DataArray.
+ *
+ * @return nix::DataView containing the tagged data.
+ */
+NIXAPI DataView taggedData(const Tag &tag, const DataArray &array);
 
 /**
  * @brief Retrieve the data referenced by the given position and extent of the Tag.
@@ -220,9 +263,9 @@ NIXAPI DataView retrieveData(const Tag &tag, ndsize_t reference_index);
  * @param array                 The referenced DataArray.
  *
  * @return The data referenced by the position.
+ * @deprecated This function has been deprecated! Use taggedData(Tag, DataArray) instead.
  */
-NIXAPI DataView retrieveData(const Tag &tag, const DataArray &array);
-
+NIXAPI DEPRECATED DataView retrieveData(const Tag &tag, const DataArray &array);
 
 /**
  * @brief Checks whether a given position is in the extent of the given DataArray.

--- a/src/MultiTag.cpp
+++ b/src/MultiTag.cpp
@@ -152,15 +152,15 @@ bool MultiTag::deleteFeature(const Feature &feature) {
 }
 
 
-DataView MultiTag::retrieveFeatureData(size_t position_index, size_t feature_index) const {
-    return util::retrieveFeatureData(*this, position_index, feature_index);
+DataView MultiTag::featureData(size_t position_index, size_t feature_index) const {
+    return util::featureData(*this, position_index, feature_index);
 }
 
 
-DataView MultiTag::retrieveFeatureData(size_t position_index, const std::string &name_or_id) const {
+DataView MultiTag::featureData(size_t position_index, const std::string &name_or_id) const {
     nix::Feature feature = backend()->getFeature(name_or_id);
     if (feature) {
-        return util::retrieveFeatureData(*this, position_index, feature);
+        return util::featureData(*this, position_index, feature);
     } else {
         throw std::invalid_argument("There is no Feature with the specified name or id! Evoked at MultiTag::retrieveFeatureData");
     }

--- a/src/MultiTag.cpp
+++ b/src/MultiTag.cpp
@@ -100,30 +100,30 @@ std::vector<DataArray> MultiTag::references(const util::Filter<DataArray>::type 
 }
 
 
-DataView MultiTag::retrieveData(size_t position_index, size_t reference_index) const {
+DataView MultiTag::taggedData(size_t position_index, size_t reference_index) const {
     std::vector<ndsize_t> indices(1, position_index);
-    return util::retrieveData(*this, indices, reference_index)[0];
+    return util::taggedData(*this, indices, reference_index)[0];
 }
 
 
-DataView MultiTag::retrieveData(size_t position_index, const std::string &name_or_id) const {
+DataView MultiTag::taggedData(size_t position_index, const std::string &name_or_id) const {
     std::vector<ndsize_t> indices(1, position_index);
-    std::vector<DataView> slices = retrieveData(indices, name_or_id);
+    std::vector<DataView> slices = taggedData(indices, name_or_id);
     if (slices.size() < 1)
-        throw std::invalid_argument("There is no DataArray with the specified name or id! Evoked at MultiTag::retrieveData");
+        throw std::invalid_argument("There is no DataArray with the specified name or id! Evoked at MultiTag::taggedData");
     return slices[0];
 }
 
 
-std::vector<DataView> MultiTag::retrieveData(std::vector<ndsize_t> &position_indices, ndsize_t reference_index) const {
-    return util::retrieveData(*this, position_indices, reference_index);
+std::vector<DataView> MultiTag::taggedData(std::vector<ndsize_t> &position_indices, ndsize_t reference_index) const {
+    return util::taggedData(*this, position_indices, reference_index);
 }
 
 
-std::vector<DataView> MultiTag::retrieveData(std::vector<ndsize_t> &position_indices, const std::string &name_or_id) const {
+std::vector<DataView> MultiTag::taggedData(std::vector<ndsize_t> &position_indices, const std::string &name_or_id) const {
     nix::DataArray array = backend()->getReference(name_or_id);
     if (array) {
-        return util::retrieveData(*this, position_indices, array);
+        return util::taggedData(*this, position_indices, array);
     } else {
         return std::vector<DataView>();
     }

--- a/src/Tag.cpp
+++ b/src/Tag.cpp
@@ -118,17 +118,17 @@ bool Tag::deleteFeature(const Feature &feature) {
 }
 
 
-DataView Tag::retrieveData(size_t reference_index) const {
-    return util::retrieveData(*this, reference_index);
+DataView Tag::taggedData(size_t reference_index) const {
+    return util::taggedData(*this, reference_index);
 }
 
 
-DataView Tag::retrieveData(const std::string &name_or_id) const {
+DataView Tag::taggedData(const std::string &name_or_id) const {
     nix::DataArray array = backend()->getReference(name_or_id);
     if (array) {
-        return util::retrieveData(*this, array);
+        return util::taggedData(*this, array);
     } else {
-        throw std::invalid_argument("There is no DataArray with the specified name or id! Evoked at Tag::retrieveData");
+        throw std::invalid_argument("There is no DataArray with the specified name or id! Evoked at Tag::taggedData");
     }
 }
 

--- a/src/Tag.cpp
+++ b/src/Tag.cpp
@@ -134,16 +134,16 @@ DataView Tag::taggedData(const std::string &name_or_id) const {
 
 
 DataView Tag::featureData(size_t feature_index) const {
-    return util::retrieveFeatureData(*this, feature_index);
+    return util::featureData(*this, feature_index);
 }
 
 
 DataView Tag::featureData(const std::string &name_or_id) const {
     nix::Feature feature = backend()->getFeature(name_or_id);
     if (feature) {
-        return util::retrieveFeatureData(*this, feature);
+        return util::featureData(*this, feature);
     } else {
-        throw std::invalid_argument("There is no Feature with the specified name or id! Evoked at Tag::retrieveFeatureData");
+        throw std::invalid_argument("There is no Feature with the specified name or id! Evoked at Tag::featureData");
     }
 }
 

--- a/src/Tag.cpp
+++ b/src/Tag.cpp
@@ -133,12 +133,12 @@ DataView Tag::taggedData(const std::string &name_or_id) const {
 }
 
 
-DataView Tag::retrieveFeatureData(size_t feature_index) const {
+DataView Tag::featureData(size_t feature_index) const {
     return util::retrieveFeatureData(*this, feature_index);
 }
 
 
-DataView Tag::retrieveFeatureData(const std::string &name_or_id) const {
+DataView Tag::featureData(const std::string &name_or_id) const {
     nix::Feature feature = backend()->getFeature(name_or_id);
     if (feature) {
         return util::retrieveFeatureData(*this, feature);

--- a/src/util/dataAccess.cpp
+++ b/src/util/dataAccess.cpp
@@ -496,11 +496,10 @@ DataView taggedData(const Tag &tag, const DataArray &array) {
 }
 
 
-DataView retrieveFeatureData(const Tag &tag, const Feature &feature) {
+DataView featureData(const Tag &tag, const Feature &feature) {
     DataArray data = feature.data();
     if (data == none) {
         throw UninitializedEntity();
-        //return NDArray(nix::DataType::Float,{0});
     }
     if (feature.linkType() == LinkType::Tagged) {
         return taggedData(tag, data);
@@ -512,7 +511,12 @@ DataView retrieveFeatureData(const Tag &tag, const Feature &feature) {
 }
 
 
-DataView retrieveFeatureData(const Tag &tag, ndsize_t feature_index) {
+DataView retrieveFeatureData(const Tag &tag, const Feature &feature) {
+    return featureData(tag, feature);
+}
+
+
+DataView featureData(const Tag &tag, ndsize_t feature_index) {
     if (tag.featureCount() == 0) {
         throw OutOfBounds("There are no features associated with this tag!", 0);
     }
@@ -520,7 +524,12 @@ DataView retrieveFeatureData(const Tag &tag, ndsize_t feature_index) {
         throw OutOfBounds("Feature index out of bounds.", 0);
     }
     Feature feat = tag.getFeature(feature_index);
-    return retrieveFeatureData(tag, feat);
+    return featureData(tag, feat);
+}
+
+
+DataView retrieveFeatureData(const Tag &tag, ndsize_t feature_index) {
+    return featureData(tag, feature_index);
 }
 
 

--- a/src/util/dataAccess.cpp
+++ b/src/util/dataAccess.cpp
@@ -533,7 +533,7 @@ DataView retrieveFeatureData(const Tag &tag, ndsize_t feature_index) {
 }
 
 
-DataView retrieveFeatureData(const MultiTag &tag, ndsize_t position_index, ndsize_t feature_index) {
+DataView featureData(const MultiTag &tag, ndsize_t position_index, ndsize_t feature_index) {
     size_t feat_idx = check::fits_in_size_t(feature_index, "retrieveFeatureData() failed; feaure_index > size_t.");
     if (feat_idx >= tag.featureCount()) {
         throw OutOfBounds("Feature index out of bounds.", 0);
@@ -541,33 +541,50 @@ DataView retrieveFeatureData(const MultiTag &tag, ndsize_t position_index, ndsiz
 
     Feature feat = tag.getFeature(feat_idx);
     std::vector<ndsize_t> indices(1, position_index);
-    return retrieveFeatureData(tag, indices, feat)[0];
+    return featureData(tag, indices, feat)[0];
+}
+
+
+DataView retrieveFeatureData(const MultiTag &tag, ndsize_t position_index, ndsize_t feature_index) {
+    return featureData(tag, position_index, feature_index);
+}
+
+
+DataView featureData(const MultiTag &tag, ndsize_t position_index, const Feature &feature) {
+    std::vector<ndsize_t> indices(1, position_index);
+    std::vector<DataView> views = featureData(tag, indices, feature);
+    return views[0];
 }
 
 
 DataView retrieveFeatureData(const MultiTag &tag, ndsize_t position_index, const Feature &feature) {
-    std::vector<ndsize_t> indices(1, position_index);
-    std::vector<DataView> views = retrieveFeatureData(tag, indices, feature);
-    return views[0];
+    return featureData(tag, position_index, feature);
+}
+
+
+std::vector<DataView> featureData(const MultiTag &tag,
+                                  std::vector<ndsize_t> position_indices,
+                                  ndsize_t feature_index) {
+    size_t feat_idx = check::fits_in_size_t(feature_index,
+                                            "featureData() failed; feaure_index > size_t.");
+    if (feat_idx >= tag.featureCount()) {
+        throw OutOfBounds("Feature index out of bounds.", 0);
+    }
+    Feature feat = tag.getFeature(feat_idx);
+    return featureData(tag, position_indices, feat);
 }
 
 
 std::vector<DataView> retrieveFeatureData(const MultiTag &tag,
                                           std::vector<ndsize_t> position_indices,
                                           ndsize_t feature_index) {
-    size_t feat_idx = check::fits_in_size_t(feature_index,
-                                            "retrieveFeatureData() failed; feaure_index > size_t.");
-    if (feat_idx >= tag.featureCount()) {
-        throw OutOfBounds("Feature index out of bounds.", 0);
-    }
-    Feature feat = tag.getFeature(feat_idx);
-    return retrieveFeatureData(tag, position_indices, feat);
+     return featureData(tag, position_indices, feature_index);
 }
 
 
-std::vector<DataView> retrieveFeatureData(const MultiTag &tag,
-                                          std::vector<ndsize_t> position_indices,
-                                          const Feature &feature) {
+std::vector<DataView> featureData(const MultiTag &tag,
+                                  std::vector<ndsize_t> position_indices,
+                                  const Feature &feature) {
     std::vector<DataView> views;
     DataArray data = feature.data();
     if (data == nix::none) {
@@ -612,6 +629,13 @@ std::vector<DataView> retrieveFeatureData(const MultiTag &tag,
         }
     }
     return views;
+}
+
+
+std::vector<DataView> retrieveFeatureData(const MultiTag &tag,
+                                          std::vector<ndsize_t> position_indices,
+                                          const Feature &feature) {
+    return featureData(tag, position_indices, feature);
 }
 
 } // namespace util

--- a/test/BaseTestDataAccess.cpp
+++ b/test/BaseTestDataAccess.cpp
@@ -131,25 +131,25 @@ void BaseTestDataAccess::testPositionInData() {
 
 void BaseTestDataAccess::testRetrieveData() {
     std::vector<ndsize_t> position_indices(1, 0);
-    CPPUNIT_ASSERT_THROW(util::retrieveData(multi_tag, position_indices, 1), nix::OutOfBounds);
+    CPPUNIT_ASSERT_THROW(util::taggedData(multi_tag, position_indices, 1), nix::OutOfBounds);
 
     position_indices[0] = 10;
-    CPPUNIT_ASSERT_THROW(util::retrieveData(multi_tag, position_indices, 0), nix::OutOfBounds);
+    CPPUNIT_ASSERT_THROW(util::taggedData(multi_tag, position_indices, 0), nix::OutOfBounds);
 
     position_indices[0] = 0;
     std::vector<DataView> views;
-    views = util::retrieveData(multi_tag, position_indices, 0);
+    views = util::taggedData(multi_tag, position_indices, 0);
     CPPUNIT_ASSERT(views.size() == 1);
 
     std::vector<ndsize_t> temp;
-    std::vector<DataView> slices = util::retrieveData(mtag2, temp, 0);
+    std::vector<DataView> slices = util::taggedData(mtag2, temp, 0);
     CPPUNIT_ASSERT(slices.size() == mtag2.positions().dataExtent()[0]);
 
     // old-style calls, deprecated
     CPPUNIT_ASSERT_NO_THROW(util::retrieveData(mtag2, 0, 0));
     CPPUNIT_ASSERT_NO_THROW(util::retrieveData(mtag2, 0, mtag2.references()[0]));
 
-    slices = util::retrieveData(pointmtag, temp, 0);
+    slices = util::taggedData(pointmtag, temp, 0);
     CPPUNIT_ASSERT(slices.size() == pointmtag.positions().dataExtent()[0]);
 
     DataView data_view = views[0];
@@ -158,20 +158,20 @@ void BaseTestDataAccess::testRetrieveData() {
     CPPUNIT_ASSERT(data_size.size() == 3);
     CPPUNIT_ASSERT(data_size[0] == 1 && data_size[1] == 7 && data_size[2] == 2);
     position_indices[0] = 1;
-    CPPUNIT_ASSERT_THROW(util::retrieveData(multi_tag, position_indices, 0), nix::OutOfBounds);
+    CPPUNIT_ASSERT_THROW(util::taggedData(multi_tag, position_indices, 0), nix::OutOfBounds);
 
-    data_view = util::retrieveData(position_tag, 0);
+    data_view = util::taggedData(position_tag, 0);
     data_size = data_view.dataExtent();
     CPPUNIT_ASSERT(data_size.size() == 3);
     CPPUNIT_ASSERT(data_size[0] == 1 && data_size[1] == 1 && data_size[2] == 1);
 
-    data_view = util::retrieveData(segment_tag, 0);
+    data_view = util::taggedData(segment_tag, 0);
     data_size = data_view.dataExtent();
     CPPUNIT_ASSERT(data_size.size() == 3);
     CPPUNIT_ASSERT(data_size[0] == 1 && data_size[1] == 7 && data_size[2] == 2);
 
 
-    DataView times_view = util::retrieveData(times_tag, 0);
+    DataView times_view = util::taggedData(times_tag, 0);
     data_size = times_view.dataExtent();
     std::vector<double> times(data_size.size());
     times_view.getData(times);
@@ -387,11 +387,11 @@ void BaseTestDataAccess::testMultiTagUnitSupport() {
     testTag.units(valid_units);
     testTag.addReference(data_array);
     position_indices[0] = 0;
-    CPPUNIT_ASSERT_NO_THROW(util::retrieveData(testTag, position_indices, 0));
+    CPPUNIT_ASSERT_NO_THROW(util::taggedData(testTag, position_indices, 0));
     testTag.units(none);
-    CPPUNIT_ASSERT_NO_THROW(util::retrieveData(testTag, position_indices, 0));
+    CPPUNIT_ASSERT_NO_THROW(util::taggedData(testTag, position_indices, 0));
     testTag.units(invalid_units);
-    CPPUNIT_ASSERT_THROW(util::retrieveData(testTag, position_indices, 0), nix::IncompatibleDimensions);
+    CPPUNIT_ASSERT_THROW(util::taggedData(testTag, position_indices, 0), nix::IncompatibleDimensions);
 }
 
 

--- a/test/BaseTestDataAccess.cpp
+++ b/test/BaseTestDataAccess.cpp
@@ -201,18 +201,18 @@ void BaseTestDataAccess::testTagFeatureData() {
     Feature f2 = pos_tag.createFeature(ramp_feat, nix::LinkType::Tagged);
     Feature f3 = pos_tag.createFeature(ramp_feat, nix::LinkType::Untagged);
 
-    DataView data1 = util::retrieveFeatureData(pos_tag, 0);
-    DataView data2 = util::retrieveFeatureData(pos_tag, 1);
-    DataView data3 = util::retrieveFeatureData(pos_tag, 2);
+    DataView data1 = util::featureData(pos_tag, 0);
+    DataView data2 = util::featureData(pos_tag, 1);
+    DataView data3 = util::featureData(pos_tag, 2);
 
     CPPUNIT_ASSERT(pos_tag.featureCount() == 3);
     CPPUNIT_ASSERT(data1.dataExtent().nelms() == 1);
     CPPUNIT_ASSERT(data2.dataExtent().nelms() == 1);
     CPPUNIT_ASSERT(data3.dataExtent().nelms() == ramp_data.size());
 
-    data1 = util::retrieveFeatureData(pos_tag, f1);
-    data2 = util::retrieveFeatureData(pos_tag, f2);
-    data3 = util::retrieveFeatureData(pos_tag, f3);
+    data1 = util::featureData(pos_tag, f1);
+    data2 = util::featureData(pos_tag, f2);
+    data3 = util::featureData(pos_tag, f3);
 
     CPPUNIT_ASSERT(pos_tag.featureCount() == 3);
     CPPUNIT_ASSERT(data1.dataExtent().nelms() == 1);
@@ -221,9 +221,9 @@ void BaseTestDataAccess::testTagFeatureData() {
 
     // make tag pointing to a slice
     pos_tag.extent({2.0});
-    data1 = util::retrieveFeatureData(pos_tag, 0);
-    data2 = util::retrieveFeatureData(pos_tag, 1);
-    data3 = util::retrieveFeatureData(pos_tag, 2);
+    data1 = util::featureData(pos_tag, 0);
+    data2 = util::featureData(pos_tag, 1);
+    data3 = util::featureData(pos_tag, 2);
 
     CPPUNIT_ASSERT(data1.dataExtent().nelms() == 1);
     CPPUNIT_ASSERT(data2.dataExtent().nelms() == 3);
@@ -295,7 +295,7 @@ void BaseTestDataAccess::testMultiTagFeatureData() {
     CPPUNIT_ASSERT_NO_THROW(util::retrieveFeatureData(multi_tag, 1, index_feature));
 
     // read feature data, multiple indices at once
-    data_view = util::retrieveFeatureData(multi_tag, indices, 0)[0];
+    data_view = util::featureData(multi_tag, indices, 0)[0];
 
     NDSize data_size = data_view.dataExtent();
     CPPUNIT_ASSERT(data_size.size() == 2);
@@ -311,7 +311,7 @@ void BaseTestDataAccess::testMultiTagFeatureData() {
     CPPUNIT_ASSERT(sum == 45);
 
     indices[0] = 1;
-    data_view = util::retrieveFeatureData(multi_tag, indices, 0)[0];
+    data_view = util::featureData(multi_tag, indices, 0)[0];
     sum = 0;
     for (size_t i = 0; i < data_view.dataExtent()[1]; ++i){
         offset[1] = i;
@@ -322,11 +322,11 @@ void BaseTestDataAccess::testMultiTagFeatureData() {
 
     // untagged feature
     indices[0] = 0;
-    data_view = util::retrieveFeatureData(multi_tag, indices, 2)[0];
+    data_view = util::featureData(multi_tag, indices, 2)[0];
     CPPUNIT_ASSERT(data_view.dataExtent().nelms() == 100);
 
     indices[0] = 1;
-    data_view = util::retrieveFeatureData(multi_tag, indices, 2)[0];
+    data_view = util::featureData(multi_tag, indices, 2)[0];
     data_size = data_view.dataExtent();
     CPPUNIT_ASSERT(data_size.nelms() == 100);
     sum = 0;
@@ -342,32 +342,32 @@ void BaseTestDataAccess::testMultiTagFeatureData() {
 
     // tagged feature
     indices[0] = 0;
-    data_view = util::retrieveFeatureData(multi_tag, indices, 1)[0];
+    data_view = util::featureData(multi_tag, indices, 1)[0];
     data_size = data_view.dataExtent();
     CPPUNIT_ASSERT(data_size.size() == 3);
 
-    data_view = util::retrieveFeatureData(multi_tag, indices, tagged_feature)[0];
+    data_view = util::featureData(multi_tag, indices, tagged_feature)[0];
     data_size = data_view.dataExtent();
     CPPUNIT_ASSERT(data_size.size() == 3);
 
     indices[0] = 1;
-    data_view = util::retrieveFeatureData(multi_tag, indices, 1)[0];
+    data_view = util::featureData(multi_tag, indices, 1)[0];
     data_size = data_view.dataExtent();
     CPPUNIT_ASSERT(data_size.size() == 3);
 
     indices[0] = 2;
-    CPPUNIT_ASSERT_THROW(util::retrieveFeatureData(multi_tag, indices, 1), nix::OutOfBounds);
-    CPPUNIT_ASSERT_THROW(util::retrieveFeatureData(multi_tag, indices, 3), nix::OutOfBounds);
+    CPPUNIT_ASSERT_THROW(util::featureData(multi_tag, indices, 1), nix::OutOfBounds);
+    CPPUNIT_ASSERT_THROW(util::featureData(multi_tag, indices, 3), nix::OutOfBounds);
 
     // test multiple positions
-    std::vector<nix::DataView> views = util::retrieveFeatureData(multi_tag, {0, 1}, 0);
+    std::vector<nix::DataView> views = util::featureData(multi_tag, {0, 1}, 0);
     CPPUNIT_ASSERT(views.size() == 2);
     CPPUNIT_ASSERT(views[0].dataExtent() == NDSize({1, 10}));
     CPPUNIT_ASSERT(views[0].dataExtent() == NDSize({1, 10}));
 
     // test positions without specifying
     indices.clear();
-    views = util::retrieveFeatureData(multi_tag, indices, 0);
+    views = util::featureData(multi_tag, indices, 0);
     CPPUNIT_ASSERT(views.size() == multi_tag.positionCount());
 
     // clean up

--- a/test/BaseTestMultiTag.cpp
+++ b/test/BaseTestMultiTag.cpp
@@ -372,22 +372,22 @@ void BaseTestMultiTag::testDataAccess() {
     multi_tag.extents(extent_array);
     multi_tag.addReference(data_array);
 
-    CPPUNIT_ASSERT_THROW(multi_tag.retrieveData(0, -1), nix::OutOfBounds);
-    CPPUNIT_ASSERT_THROW(multi_tag.retrieveData(0, 1), nix::OutOfBounds);
-    CPPUNIT_ASSERT_THROW(multi_tag.retrieveData(-1, 0), nix::OutOfBounds);
-    CPPUNIT_ASSERT_THROW(multi_tag.retrieveData(10, 0), nix::OutOfBounds);
+    CPPUNIT_ASSERT_THROW(multi_tag.taggedData(0, -1), nix::OutOfBounds);
+    CPPUNIT_ASSERT_THROW(multi_tag.taggedData(0, 1), nix::OutOfBounds);
+    CPPUNIT_ASSERT_THROW(multi_tag.taggedData(-1, 0), nix::OutOfBounds);
+    CPPUNIT_ASSERT_THROW(multi_tag.taggedData(10, 0), nix::OutOfBounds);
 
-    DataView ret_data = multi_tag.retrieveData(0, 0);
+    DataView ret_data = multi_tag.taggedData(0, 0);
     NDSize data_size = ret_data.dataExtent();
     CPPUNIT_ASSERT(data_size.size() == 3);
     CPPUNIT_ASSERT(data_size[0] == 1 && data_size[1] == 7 && data_size[2] == 2);
 
-    ret_data = multi_tag.retrieveData(0, data_array.name());
+    ret_data = multi_tag.taggedData(0, data_array.name());
     data_size = ret_data.dataExtent();
     CPPUNIT_ASSERT(data_size.size() == 3);
     CPPUNIT_ASSERT(data_size[0] == 1 && data_size[1] == 7 && data_size[2] == 2);
 
-    CPPUNIT_ASSERT_THROW(multi_tag.retrieveData(1, 0), nix::OutOfBounds);
+    CPPUNIT_ASSERT_THROW(multi_tag.taggedData(1, 0), nix::OutOfBounds);
 
     block.deleteMultiTag(multi_tag);
     block.deleteDataArray(data_array);

--- a/test/BaseTestTag.cpp
+++ b/test/BaseTestTag.cpp
@@ -7,6 +7,10 @@
 // LICENSE file in the root of the Project.
 //
 // Author: Jan Grewe <jan.grewe@g-node.org>
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4996)
+#endif
 
 #include <sstream>
 #include <ctime>
@@ -379,3 +383,7 @@ void BaseTestTag::testCreatedAt() {
 void BaseTestTag::testUpdatedAt() {
     CPPUNIT_ASSERT(tag.updatedAt() >= startup_time);
 }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif


### PR DESCRIPTION
replacement methods are now simply called ```featureData``` and ```taggedData```