### PR TITLE
Downward reading of old style properties resp. values

### DIFF
--- a/backend/hdf5/FileHDF5.hpp
+++ b/backend/hdf5/FileHDF5.hpp
@@ -33,6 +33,7 @@ private:
     Compression compr;
     H5Group root, metadata, data;
     FileMode mode;
+    FormatVersion file_format_version;
 
 public:
 
@@ -153,10 +154,10 @@ private:
     void openRoot();
 
 
-    bool checkHeader(FileMode mode) const;
+    bool checkHeader(FileMode mode);
 
 
-    void createHeader() const;
+    void createHeader();
 };
 
 

--- a/backend/hdf5/PropertyHDF5.cpp
+++ b/backend/hdf5/PropertyHDF5.cpp
@@ -36,8 +36,7 @@ struct to_data_type<const char *> {
 namespace hdf5 {
 
 
-
-    PropertyHDF5::PropertyHDF5(const std::shared_ptr<IFile> &file, const DataSet &dataset)
+PropertyHDF5::PropertyHDF5(const std::shared_ptr<IFile> &file, const DataSet &dataset)
     : entity_file(file)
 {
     this->entity_dataset = dataset;
@@ -201,12 +200,11 @@ boost::optional<double> PropertyHDF5::uncertainty() const {
     boost::optional<double> ret;
     double error;
     nix::FormatVersion ver(this->entity_file->version());
-    if ( ver < nix::FormatVersion({1, 1, 1})) {
+    if (ver < nix::FormatVersion({1, 1, 1})) {
         std::vector<Value> values = readOldstyleValues();
         if (values.size() > 0)
             ret = values[0].uncertainty;
-    }
-    else if (dataset().getAttr("uncertainty", error)) {
+    } else if (dataset().getAttr("uncertainty", error)) {
         ret = error;
     }
     return ret;
@@ -266,16 +264,14 @@ struct NIX_PACKED FileOldValue  {
 
 
 template<typename T>
-h5x::DataType h5_type_for_value(bool for_memory)
-{
+h5x::DataType h5_type_for_value(bool for_memory) {
     h5x::DataType value_type = data_type_to_h5(to_data_type<T>::value, for_memory);
     return value_type;
 }
 
 
 template<typename T>
-h5x::DataType h5_type_for_old_value(bool for_memory)
-{
+h5x::DataType h5_type_for_old_value(bool for_memory) {
     typedef FileOldValue<T> file_value_t;
 
     h5x::DataType ct = h5x::DataType::makeCompound(sizeof(file_value_t));
@@ -300,8 +296,7 @@ h5x::DataType h5_type_for_old_value(bool for_memory)
 #endif
 #define DATATYPE_SUPPORT_NOT_IMPLEMENTED false
 
-h5x::DataType PropertyHDF5::fileTypeForValue(DataType dtype)
-{
+h5x::DataType PropertyHDF5::fileTypeForValue(DataType dtype) {
     const bool for_memory = false;
 
     switch(dtype) {
@@ -322,8 +317,7 @@ h5x::DataType PropertyHDF5::fileTypeForValue(DataType dtype)
 
 
 template<typename T>
-void do_read_value(const DataSet &h5ds, size_t size, std::vector<Variant> &values)
-{
+void do_read_value(const DataSet &h5ds, size_t size, std::vector<Variant> &values) {
     h5x::DataType memType = h5_type_for_value<T>(true);
 
     typedef FileValue<T> file_value_t;
@@ -344,8 +338,7 @@ void do_read_value(const DataSet &h5ds, size_t size, std::vector<Variant> &value
 
 
 template<typename T>
-void do_read_old_value(const DataSet &h5ds, size_t size, std::vector<Value> &values)
-{
+void do_read_old_value(const DataSet &h5ds, size_t size, std::vector<Value> &values) {
     h5x::DataType memType = h5_type_for_old_value<T>(true);
 
     typedef FileOldValue<T> file_value_t;
@@ -373,8 +366,7 @@ void do_read_old_value(const DataSet &h5ds, size_t size, std::vector<Value> &val
 #define NOT_IMPLEMENTED 1
 
 template<typename T>
-void do_write_value(DataSet &h5ds, const std::vector<Variant> &values)
-{
+void do_write_value(DataSet &h5ds, const std::vector<Variant> &values) {
     typedef FileValue<T> file_value_t;
     std::vector<file_value_t> fileValues;
 
@@ -402,8 +394,7 @@ ndsize_t PropertyHDF5::valueCount() const {
 }
 
 
-void PropertyHDF5::values(const std::vector<Variant> &values)
-{
+void PropertyHDF5::values(const std::vector<Variant> &values) {
     if (values.size() < 1) {
         deleteValues();
         return;
@@ -415,7 +406,7 @@ void PropertyHDF5::values(const std::vector<Variant> &values)
     }
     dset.setExtent(NDSize{values.size()});
 
-     switch(values[0].type()) {
+    switch(values[0].type()) {
         case DataType::Bool:   do_write_value<bool>(dset, values);         break;
         case DataType::Int32:  do_write_value<int32_t>(dset, values);      break;
         case DataType::UInt32: do_write_value<uint32_t>(dset, values);     break;
@@ -431,15 +422,15 @@ void PropertyHDF5::values(const std::vector<Variant> &values)
 
 Variant valueToVariant(const Value &val) {
      switch (val.type()) {
-     case DataType::Bool:   return Variant(val.get<bool>());
-     case DataType::Int32:  return Variant(val.get<int32_t>());
-     case DataType::UInt32: return Variant(val.get<uint32_t>());
-     case DataType::Int64:  return Variant(val.get<int64_t>());
-     case DataType::UInt64: return Variant(val.get<uint64_t>());
-     case DataType::String: return Variant(val.get<std::string>());
-     case DataType::Double: return Variant(val.get<double>());
+         case DataType::Bool:   return Variant(val.get<bool>());
+         case DataType::Int32:  return Variant(val.get<int32_t>());
+         case DataType::UInt32: return Variant(val.get<uint32_t>());
+         case DataType::Int64:  return Variant(val.get<int64_t>());
+         case DataType::UInt64: return Variant(val.get<uint64_t>());
+         case DataType::String: return Variant(val.get<std::string>());
+         case DataType::Double: return Variant(val.get<double>());
 #ifndef CHECK_SUPPORTED_VALUES
-     default: assert(DATATYPE_SUPPORT_NOT_IMPLEMENTED);
+         default: assert(DATATYPE_SUPPORT_NOT_IMPLEMENTED);
 #endif
      }
      return Variant();
@@ -475,8 +466,7 @@ std::vector<Value> PropertyHDF5::readOldstyleValues() const {
 }
 
 
-std::vector<Variant> PropertyHDF5::values(void) const
-{
+std::vector<Variant> PropertyHDF5::values(void) const {
     std::vector<Variant> values;
     nix::FormatVersion ver(this->entity_file->version());
     if (ver < nix::FormatVersion({1, 1, 1})) {

--- a/backend/hdf5/PropertyHDF5.cpp
+++ b/backend/hdf5/PropertyHDF5.cpp
@@ -296,7 +296,7 @@ h5x::DataType h5_type_for_old_value(bool for_memory)
 
 
 #if 0 //set to one to check that all supported DataTypes are handled
-#define CHECK_SUPOORTED_VALUES
+#define CHECK_SUPPORTED_VALUES
 #endif
 #define DATATYPE_SUPPORT_NOT_IMPLEMENTED false
 
@@ -312,7 +312,7 @@ h5x::DataType PropertyHDF5::fileTypeForValue(DataType dtype)
         case DataType::UInt64: return h5_type_for_value<uint64_t>(for_memory);
         case DataType::Double: return h5_type_for_value<double>(for_memory);
         case DataType::String: return h5_type_for_value<char *>(for_memory);
-#ifndef CHECK_SUPOORTED_VALUES
+#ifndef CHECK_SUPPORTED_VALUES
         default: assert(DATATYPE_SUPPORT_NOT_IMPLEMENTED); break;
 #endif
     }
@@ -423,7 +423,7 @@ void PropertyHDF5::values(const std::vector<Variant> &values)
         case DataType::UInt64: do_write_value<uint64_t>(dset, values);     break;
         case DataType::String: do_write_value<const char *>(dset, values); break;
         case DataType::Double: do_write_value<double>(dset, values);       break;
-#ifndef CHECK_SUPOORTED_VALUES
+#ifndef CHECK_SUPPORTED_VALUES
         default: assert(DATATYPE_SUPPORT_NOT_IMPLEMENTED);
 #endif
      }
@@ -432,13 +432,13 @@ void PropertyHDF5::values(const std::vector<Variant> &values)
 Variant valueToVariant(const Value &val) {
      switch (val.type()) {
      case DataType::Bool:   return Variant(val.get<bool>());
-     case DataType::Int32:   return Variant(val.get<int32_t>());
+     case DataType::Int32:  return Variant(val.get<int32_t>());
      case DataType::UInt32: return Variant(val.get<uint32_t>());
      case DataType::Int64:  return Variant(val.get<int64_t>());
      case DataType::UInt64: return Variant(val.get<uint64_t>());
      case DataType::String: return Variant(val.get<std::string>());
      case DataType::Double: return Variant(val.get<double>());
-#ifndef CHECK_SUPOORTED_VALUES
+#ifndef CHECK_SUPPORTED_VALUES
      default: assert(DATATYPE_SUPPORT_NOT_IMPLEMENTED);
 #endif
      }
@@ -466,7 +466,7 @@ std::vector<Value> PropertyHDF5::readOldstyleValues() const {
         case DataType::UInt64: do_read_old_value<uint64_t>(dset, nvalues, values); break;
         case DataType::String: do_read_old_value<char *>(dset, nvalues, values);   break;
         case DataType::Double: do_read_old_value<double>(dset, nvalues, values);   break;
-#ifndef CHECK_SUPOORTED_VALUES
+#ifndef CHECK_SUPPORTED_VALUES
         default: assert(DATATYPE_SUPPORT_NOT_IMPLEMENTED);
 #endif
     }
@@ -502,7 +502,7 @@ std::vector<Variant> PropertyHDF5::values(void) const
         case DataType::UInt64: do_read_value<uint64_t>(dset, nvalues, values); break;
         case DataType::String: do_read_value<char *>(dset, nvalues, values);   break;
         case DataType::Double: do_read_value<double>(dset, nvalues, values);   break;
-#ifndef CHECK_SUPOORTED_VALUES
+#ifndef CHECK_SUPPORTED_VALUES
     default: assert(DATATYPE_SUPPORT_NOT_IMPLEMENTED);
 #endif
     }

--- a/backend/hdf5/PropertyHDF5.cpp
+++ b/backend/hdf5/PropertyHDF5.cpp
@@ -442,6 +442,7 @@ Variant valueToVariant(const Value &val) {
      default: assert(DATATYPE_SUPPORT_NOT_IMPLEMENTED);
 #endif
      }
+     return Variant();
 }
 
 std::vector<Value> PropertyHDF5::readOldstyleValues() const {
@@ -478,7 +479,7 @@ std::vector<Variant> PropertyHDF5::values(void) const
 {
     std::vector<Variant> values;
     nix::FormatVersion ver(this->entity_file->version());
-    if ( ver < nix::FormatVersion({1, 1, 1})) {
+    if (ver < nix::FormatVersion({1, 1, 1})) {
         for (Value v : readOldstyleValues()) {
             values.push_back(valueToVariant(v));
         }

--- a/backend/hdf5/PropertyHDF5.cpp
+++ b/backend/hdf5/PropertyHDF5.cpp
@@ -424,8 +424,7 @@ void PropertyHDF5::values(const std::vector<Variant> &values)
 }
 
 
-std::vector<Variant> PropertyHDF5::readOldstyleValues() const {
-    std::vector<Variant> vals;
+std::vector<Value> PropertyHDF5::readOldstyleValues() const {
     std::vector<Value> values;
 
     DataSet dset = dataset();
@@ -433,7 +432,7 @@ std::vector<Variant> PropertyHDF5::readOldstyleValues() const {
     NDSize shape = dset.size();
 
     if (shape.size() < 1 || shape[0] < 1) {
-        return vals;
+        return values;
     }
 
     assert(shape.size() == 1);
@@ -451,21 +450,7 @@ std::vector<Variant> PropertyHDF5::readOldstyleValues() const {
         default: assert(DATATYPE_SUPPORT_NOT_IMPLEMENTED);
 #endif
     }
-    for (Value v : values) {
-        switch (v.type()) {
-        case DataType::Bool:   vals.push_back(Variant(v.get<bool>()));        break;
-        case DataType::Int32:  vals.push_back(Variant(v.get<int32_t>()));     break;
-        case DataType::UInt32: vals.push_back(Variant(v.get<uint32_t>()));    break;
-        case DataType::Int64:  vals.push_back(Variant(v.get<int64_t>()));     break;
-        case DataType::UInt64: vals.push_back(Variant(v.get<uint64_t>()));    break;
-        case DataType::String: vals.push_back(Variant(v.get<std::string>())); break;
-        case DataType::Double: vals.push_back(Variant(v.get<double>()));      break;
-#ifndef CHECK_SUPOORTED_VALUES
-        default: assert(DATATYPE_SUPPORT_NOT_IMPLEMENTED);
-#endif
-        }
-    }
-    return vals;
+    return values;
 }
 
 

--- a/backend/hdf5/PropertyHDF5.hpp
+++ b/backend/hdf5/PropertyHDF5.hpp
@@ -135,7 +135,7 @@ private:
         return entity_dataset;
     }
 
-    std::vector<Variant> readOldstyleValues() const;
+    std::vector<Value> readOldstyleValues() const;
 
 };
 

--- a/backend/hdf5/PropertyHDF5.hpp
+++ b/backend/hdf5/PropertyHDF5.hpp
@@ -135,6 +135,8 @@ private:
         return entity_dataset;
     }
 
+    std::vector<Variant> readOldstyleValues() const;
+
 };
 
 

--- a/include/nix/Version.hpp
+++ b/include/nix/Version.hpp
@@ -16,12 +16,12 @@
 namespace nix {
 /**
  * @brief Returns the version of the library.
- * 
+ *
  * @return the version as a vector<int> in the order major, minor, patch
  */
 NIXAPI std::vector<int> apiVersion();
 
-    
+
 class FormatVersion {
 public:
 
@@ -55,6 +55,11 @@ public:
     // exact match for x and, be the same or newer
     // in y
     return vx == thefile.x() && vy >= thefile.y();
+  }
+
+  std::vector<int> asVector() const {
+      std::vector<int> vec = {x(), y(), z()};
+      return vec;
   }
 
   // operators

--- a/test/TestVersion.cpp
+++ b/test/TestVersion.cpp
@@ -68,3 +68,11 @@ void TestVersion::testAPIVersion() {
     std::vector<int> v = nix::apiVersion();
     CPPUNIT_ASSERT(v.size() == 3);
 }
+
+void TestVersion::testToVector() {
+    nix::FormatVersion fmtv({0, 1, 2});
+    std::vector<int> v = fmtv.asVector();
+    CPPUNIT_ASSERT(v.size() == 3);
+    for (size_t i = 0; i < v.size(); ++i)
+        CPPUNIT_ASSERT(v[i] == i);
+}

--- a/test/TestVersion.cpp
+++ b/test/TestVersion.cpp
@@ -74,5 +74,5 @@ void TestVersion::testToVector() {
     std::vector<int> v = fmtv.asVector();
     CPPUNIT_ASSERT(v.size() == 3);
     for (size_t i = 0; i < v.size(); ++i)
-        CPPUNIT_ASSERT(v[i] == i);
+        CPPUNIT_ASSERT(v[i] == (int)i);
 }

--- a/test/TestVersion.hpp
+++ b/test/TestVersion.hpp
@@ -40,12 +40,14 @@ public:
 
     void testFormatVersion();
     void testAPIVersion();
+    void testToVector();
 
 private:
 
     CPPUNIT_TEST_SUITE(TestVersion);
     CPPUNIT_TEST(testFormatVersion);
     CPPUNIT_TEST(testAPIVersion);
+    CPPUNIT_TEST(testToVector);
     CPPUNIT_TEST_SUITE_END ();
 
 };


### PR DESCRIPTION
With this pr the 1.5 version is able to read old metadata. Values are internally converted to Variant. Caveat: uncertainty returns only the uncertainty of the first value. No further consistency check is done