### PR TITLE
github: schedule building of build-images

### DIFF
--- a/.github/workflows/Dockerfile-ub1804
+++ b/.github/workflows/Dockerfile-ub1804
@@ -1,0 +1,26 @@
+## -*- mode: dockerfile; indent-tabs-mode: nil; tab-width: 4 -*-
+FROM ubuntu:18.04
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -q && apt-get install -yy \
+    cmake \
+    clang-7 \
+    doxygen \
+    git \
+    gcc-8 \
+    g++-8 \
+    libcppunit-dev \
+    libboost-all-dev \
+    libhdf5-dev \
+    libhdf5-serial-dev \
+    libyaml-cpp-dev \
+    libstdc++-8-dev \
+    python-pip \
+    valgrind \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install cpp-coveralls && \
+    rm -rf /tmp/pip && \
+    rm -rf /root/.cache
+
+RUN mkdir /src
+WORKDIR /src

--- a/.github/workflows/buildimags.yml
+++ b/.github/workflows/buildimags.yml
@@ -1,0 +1,14 @@
+name: Build and publish build images
+on:
+  schedules:
+  - cron: 0 6 * * 1
+jobs:
+  build-publish:
+    name: Build and publish the image
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Build image
+      uses: actions/docker/cli@master
+      with:
+        args: build -f .github/workflows/Dockerfile-ub1804 -t "gnode/nixbuild:ub1804" .


### PR DESCRIPTION
Every week build an image (based on ubuntu 18.04) which contains all the necessary dependencies to build nix.