### PR TITLE
[CI] Use github actions/workflows as CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+on: [push]
+jobs:
+  build-macos:
+    name: Build on macOS
+    runs-on: macOS-10.14
+    steps:
+    - name: Install dependecies
+      run: |
+        brew update
+        brew install cmake boost cppunit hdf5 yaml-cpp
+    - name: Install coveralls
+      run: |
+        pip install --upgrade pip
+        pip install --user cpp-coveralls
+    - uses: actions/checkout@v1
+    - name: Build
+      run: |
+        mkdir build
+        cd build
+        cmake -DBUILD_FS_BACKEND=OFF ..
+        make
+        make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
   build-macos:
     name: Build on macOS
     runs-on: macOS-10.14
+    strategy:
+      matrix:
+        fs-backend: [ 'FS_BACKEND=ON', 'FS_BACKEND=OFF' ]
     steps:
     - name: Install dependecies
       run: |
@@ -55,6 +58,6 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -DBUILD_FS_BACKEND=OFF ..
+        cmake -DBUILD_${{ matrix.fs-backend }} ..
         make
         make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
         make test
         popd
     - name: Coverage
+      if: endsWith(matrix.fs-backend, 'OFF')
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       run: |
         lcov -q --capture --directory . --no-extern --output-file coverage.info
-        bash <(curl -s https://codecov.io/bash) -f coverage.info
+        bash <(curl -s https://codecov.io/bash) -f coverage.info -Z
 
   build-macos:
     name: Build on macOS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       run: |
-        lcov --capture --directory . --no-extern --output-file coverage.info
+        lcov -q --capture --directory . --no-extern --output-file coverage.info
         bash <(curl -s https://codecov.io/bash) -f coverage.info
 
   build-macos:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,10 @@ jobs:
       run: |
         sudo apt-get update -y &&
         sudo apt-get install -yy --no-install-recommends \
+          bash \
           cmake \
           clang-7 \
+          curl \
           doxygen \
           git \
           gcc-8 \
@@ -24,13 +26,8 @@ jobs:
           libhdf5-serial-dev \
           libyaml-cpp-dev \
           libstdc++-8-dev \
-          python3-pip \
-          python3-setuptools \
-          python3-wheel \
+          lcov \
           valgrind
-    - name: Install coveralls
-      run: |
-        sudo pip3 install cpp-coveralls
     - uses: actions/checkout@v1
     - name: Build
       run: |
@@ -43,9 +40,10 @@ jobs:
     - name: Coverage
       if: endsWith(matrix.fs-backend, 'OFF')
       env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       run: |
-        coveralls -b build -E ".*CMakeFiles.*" -e cli -e test -e tmp -e docs --gcov-options '\-lp'
+        lcov --capture --directory . --no-extern --output-file coverage.info
+        bash <(curl -s https://codecov.io/bash) -f coverage.info
 
   build-macos:
     name: Build on macOS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       run: |
         lcov -q --capture --directory . --no-extern --output-file coverage.info
-        bash <(curl -s https://codecov.io/bash) -f coverage.info -Z
+        bash <(curl -s https://codecov.io/bash) -f coverage.info -C $GITHUB_SHA -B ${GITHUB_REF#refs/heads/} -Z
 
   build-macos:
     name: Build on macOS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,10 +55,6 @@ jobs:
       run: |
         brew update
         brew install cmake boost cppunit hdf5 yaml-cpp
-    - name: Install coveralls
-      run: |
-        pip install --upgrade pip
-        pip install --user cpp-coveralls
     - uses: actions/checkout@v1
     - name: Build
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,43 @@
 name: CI
 on: [push]
 jobs:
+  build-ub1804:
+    name: Build on Ubuntu 18.04
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Install dependecies
+      run: |
+        sudo apt-get update -y &&
+        sudo apt-get install -yy --no-install-recommends \
+          cmake \
+          clang-7 \
+          doxygen \
+          git \
+          gcc-8 \
+          g++-8 \
+          libcppunit-dev \
+          libboost-all-dev \
+          libhdf5-dev \
+          libhdf5-serial-dev \
+          libyaml-cpp-dev \
+          libstdc++-8-dev \
+          python3-pip \
+          python3-setuptools \
+          python3-wheel \
+          valgrind
+    - name: Install coveralls
+      run: |
+        sudo pip3 install cpp-coveralls
+    - uses: actions/checkout@v1
+    - name: Build
+      run: |
+        mkdir build
+        pushd build
+        cmake -DBUILD_FS_BACKEND=OFF ..
+        make
+        make test
+        popd
+
   build-macos:
     name: Build on macOS
     runs-on: macOS-10.14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
         make test
         popd
     - name: Coverage
+      env:
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
       run: |
         coveralls -b build -E ".*CMakeFiles.*" -e cli -e test -e tmp -e docs --gcov-options '\-lp'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ jobs:
   build-ub1804:
     name: Build on Ubuntu 18.04
     runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        fs-backend: [ 'FS_BACKEND=ON', 'FS_BACKEND=OFF' ]
     steps:
     - name: Install dependecies
       run: |
@@ -33,7 +36,7 @@ jobs:
       run: |
         mkdir build
         pushd build
-        cmake -DBUILD_FS_BACKEND=OFF -DBUILD_COVERAGE=ON ..
+        cmake -DBUILD_${{ matrix.fs-backend }} -DBUILD_COVERAGE=ON ..
         make
         make test
         popd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,13 @@ jobs:
       run: |
         mkdir build
         pushd build
-        cmake -DBUILD_FS_BACKEND=OFF ..
+        cmake -DBUILD_FS_BACKEND=OFF -DBUILD_COVERAGE=ON ..
         make
         make test
         popd
+    - name: Coverage
+      run: |
+        coveralls -b build -E ".*CMakeFiles.*" -e cli -e test -e tmp -e docs --gcov-options '\-lp'
 
   build-macos:
     name: Build on macOS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,10 +32,17 @@ if(NOT WIN32)
   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -O2 -DNDEBUG")
 
   if(CMAKE_COMPILER_IS_GNUCXX AND BUILD_COVERAGE)
-    set (HAVE_COVERAGE ON)
     MESSAGE(STATUS "Activating coverage support.")
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fprofile-arcs -ftest-coverage")
-    SET(CMAKE_SHARED_LINKER_FLAGS="${CMAKE_SHARED_LINKER_FLAGS} -fprofile-arcs -ftest-coverage")
+    set(HAVE_COVERAGE ON)
+
+    if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+      message(WARNING "Coverage requested but built type not 'Debug'")
+    endif()
+
+    add_compile_options(--coverage)
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} --coverage")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+    SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --coverage")
   endif()
 
 endif()

--- a/test/hdf5/TestEntityHDF5.hpp
+++ b/test/hdf5/TestEntityHDF5.hpp
@@ -24,6 +24,7 @@ class TestEntityHDF5 : public BaseTestEntity {
     CPPUNIT_TEST(testCreatedAt);
 
     CPPUNIT_TEST(testIsValidEntity);
+    CPPUNIT_TEST(testOperators);
 
     CPPUNIT_TEST_SUITE_END ();
 


### PR DESCRIPTION
Use GH actions/workflows as CI. Should be equivalent to travis. Replaces PR #781 (which was done from my fork and didn't trigger the actions). Lets see if this does.