### PR TITLE
DataView: Check dims on create

### DIFF
--- a/include/nix/DataView.hpp
+++ b/include/nix/DataView.hpp
@@ -20,6 +20,12 @@ public:
     DataView(DataArray da, NDSize count, NDSize offset)
             : array(std::move(da)), offset(std::move(offset)), count(std::move(count)) {
 
+        if (this->offset.size() != array.dataExtent().size()) {
+            throw IncompatibleDimensions("DataView offset dimensionality does not match dimensionality of data", "nix::DataView");
+        }
+        if (this->count.size() != array.dataExtent().size()) {
+            throw IncompatibleDimensions("DataView count dimensionality does not match dimensionality of data", "nix::DataView");
+        }
         if (this->offset + this->count > array.dataExtent()) {
             throw OutOfBounds("Trying to create DataView which is out of bounds");
         }

--- a/test/BaseTestDataAccess.cpp
+++ b/test/BaseTestDataAccess.cpp
@@ -450,6 +450,9 @@ void BaseTestDataAccess::testDataView() {
     CPPUNIT_ASSERT_THROW(io.getData(r2d2, {3, 3, 3}, {}), OutOfBounds);
 
     CPPUNIT_ASSERT_THROW(io.dataExtent(zcount), std::runtime_error);
+
+    CPPUNIT_ASSERT_THROW(DataView(data_array, {0, 0, 0, 0}, {1, 1, 1}), IncompatibleDimensions);
+    CPPUNIT_ASSERT_THROW(DataView(data_array, {0, 0, 0}, {1, 1}), IncompatibleDimensions);
 }
 
 


### PR DESCRIPTION
Check the dimensions of offset and count on DataView creation and throw
appropriate exception.

Fixes #786.