### PR TITLE
UTF-8 encoding of all strings for names and contents

### DIFF
--- a/backend/hdf5/h5x/Attribute.cpp
+++ b/backend/hdf5/h5x/Attribute.cpp
@@ -51,6 +51,12 @@ void Attribute::write(h5x::DataType mem_type, const NDSize &size, const std::str
     write(mem_type, size, *reader);
 }
 
+PList Attribute::createPList() const {
+    PList pl = H5Aget_create_plist(hid);
+    pl.check("Attribute::createPList(): Could not get creation property list");
+    return pl;
+}
+
 h5x::DataType Attribute::dataType() const {
     h5x::DataType dtype = H5Aget_type(hid);
     dtype.check("Attribute::dataType(): Could not get type");

--- a/backend/hdf5/h5x/Attribute.cpp
+++ b/backend/hdf5/h5x/Attribute.cpp
@@ -51,6 +51,11 @@ void Attribute::write(h5x::DataType mem_type, const NDSize &size, const std::str
     write(mem_type, size, *reader);
 }
 
+h5x::DataType Attribute::dataType() const {
+    h5x::DataType dtype = H5Aget_type(hid);
+    dtype.check("Attribute::dataType(): Could not get type");
+    return dtype;
+}
 
 DataSpace Attribute::getSpace() const {
 

--- a/backend/hdf5/h5x/Attribute.cpp
+++ b/backend/hdf5/h5x/Attribute.cpp
@@ -55,7 +55,7 @@ void Attribute::write(h5x::DataType mem_type, const NDSize &size, const std::str
 DataSpace Attribute::getSpace() const {
 
     DataSpace space = H5Aget_space(hid);
-    space.check("Attribute::getSpace(): Dould not get data space");
+    space.check("Attribute::getSpace(): Could not get data space");
     return space;
 }
 

--- a/backend/hdf5/h5x/Attribute.hpp
+++ b/backend/hdf5/h5x/Attribute.hpp
@@ -13,6 +13,7 @@
 
 #include "DataSpace.hpp"
 #include "H5DataType.hpp"
+#include "H5PList.hpp"
 
 namespace nix {
 
@@ -31,6 +32,7 @@ public:
     void write(h5x::DataType mem_type, const NDSize &size, const void *data);
     void write(h5x::DataType mem_type, const NDSize &size, const std::string *data);
 
+    PList createPList() const;
     h5x::DataType dataType() const;
     DataSpace getSpace() const;
     NDSize extent() const;

--- a/backend/hdf5/h5x/Attribute.hpp
+++ b/backend/hdf5/h5x/Attribute.hpp
@@ -31,6 +31,7 @@ public:
     void write(h5x::DataType mem_type, const NDSize &size, const void *data);
     void write(h5x::DataType mem_type, const NDSize &size, const std::string *data);
 
+    h5x::DataType dataType() const;
     DataSpace getSpace() const;
     NDSize extent() const;
 

--- a/backend/hdf5/h5x/H5DataType.cpp
+++ b/backend/hdf5/h5x/H5DataType.cpp
@@ -34,10 +34,11 @@ DataType DataType::make(H5T_class_t klass, size_t size) {
     return dt;
 }
 
-DataType DataType::makeStrType(size_t size) {
+DataType DataType::makeStrType(size_t size, H5T_cset_t cset) {
     DataType str_type = H5Tcopy(H5T_C_S1);
     str_type.check("Could not create string type");
     str_type.size(size);
+    str_type.cset(cset);
     return str_type;
 }
 

--- a/backend/hdf5/h5x/H5DataType.cpp
+++ b/backend/hdf5/h5x/H5DataType.cpp
@@ -76,6 +76,15 @@ H5T_sign_t DataType::sign() const {
     return res;
 }
 
+void DataType::cset(H5T_cset_t cset) {
+    HErr res = H5Tset_cset(hid, cset);
+    res.check("DataType::cset(): H5Tset_cset failed");
+}
+H5T_cset_t DataType::cset() const {
+    H5T_cset_t res = H5Tget_cset(hid);
+    return res;
+}
+
 bool DataType::isVariableString() const {
     HTri res = H5Tis_variable_str(hid);
     res.check("DataType::isVariableString(): H5Tis_variable_str failed");

--- a/backend/hdf5/h5x/H5DataType.hpp
+++ b/backend/hdf5/h5x/H5DataType.hpp
@@ -53,6 +53,9 @@ public:
     void sign(H5T_sign_t sign);
     H5T_sign_t sign() const;
 
+    void cset(H5T_cset_t cset);
+    H5T_cset_t cset() const;
+
     bool isVariableString() const;
 
     // Compound type related

--- a/backend/hdf5/h5x/H5DataType.hpp
+++ b/backend/hdf5/h5x/H5DataType.hpp
@@ -41,7 +41,7 @@ public:
     static DataType copy(hid_t);
 
     static DataType make(H5T_class_t klass, size_t size);
-    static DataType makeStrType(size_t size = H5T_VARIABLE);
+    static DataType makeStrType(size_t size = H5T_VARIABLE, H5T_cset_t cset = H5T_CSET_UTF8);
     static DataType makeCompound(size_t size);
     static DataType makeEnum(const DataType &base);
 

--- a/backend/hdf5/h5x/H5Group.cpp
+++ b/backend/hdf5/h5x/H5Group.cpp
@@ -9,7 +9,7 @@
 #include "H5Group.hpp"
 #include <nix/util/util.hpp>
 #include "H5Exception.hpp"
-
+#include "H5PList.hpp"
 
 namespace nix {
 namespace hdf5 {
@@ -233,7 +233,13 @@ DataSet H5Group::createData(const std::string &name,
             throw std::invalid_argument("Invalid compression flag!");
         }
     }
-    ds = H5Dcreate(hid, name.c_str(), fileType.h5id(), space.h5id(), H5P_DEFAULT, dcpl.h5id(), H5P_DEFAULT);
+    ds = H5Dcreate(hid,
+                   name.c_str(),
+                   fileType.h5id(),
+                   space.h5id(),
+                   PList::linkUTF8().h5id(),
+                   dcpl.h5id(),
+                   H5P_DEFAULT);
     ds.check("H5Group::createData: Could not create DataSet with name " + name);
 
     return ds;
@@ -269,7 +275,7 @@ H5Group H5Group::openGroup(const std::string &name, bool create) const {
         HErr res = H5Pset_link_creation_order(gcpl.h5id(), H5P_CRT_ORDER_TRACKED|H5P_CRT_ORDER_INDEXED);
         res.check("Unable to create group with name '" + name + "'! (H5Pset_link_cr...)");
 
-        g = H5Group(H5Gcreate2(hid, name.c_str(), H5P_DEFAULT, gcpl.h5id(), H5P_DEFAULT));
+        g = H5Group(H5Gcreate2(hid, name.c_str(), PList::linkUTF8().h5id(), gcpl.h5id(), H5P_DEFAULT));
         g.check("Unable to create group with name '" + name + "'! (H5Gcreate2)");
 
     } else {
@@ -305,7 +311,8 @@ H5Group H5Group::createLink(const H5Group &target, const std::string &link_name)
     check_h5_arg_name(link_name);
 
     HErr res = H5Lcreate_hard(target.hid, ".", hid, link_name.c_str(),
-                              H5L_SAME_LOC, H5L_SAME_LOC);
+                              PList::linkUTF8().h5id(),
+                              H5P_DEFAULT);
     res.check("Unable to create link " + link_name);
     return openGroup(link_name, false);
 }
@@ -337,7 +344,8 @@ bool H5Group::renameAllLinks(const std::string &old_name, const std::string &new
             }
 
             HErr res = H5Lcreate_hard(group.hid, ".", hid, curr_name.c_str(),
-                                      H5L_SAME_LOC, H5L_SAME_LOC);
+                                      PList::linkUTF8().h5id(),
+                                      H5P_DEFAULT);
             renamed = renamed && res;
         }
     }

--- a/backend/hdf5/h5x/H5Group.cpp
+++ b/backend/hdf5/h5x/H5Group.cpp
@@ -317,41 +317,6 @@ H5Group H5Group::createLink(const H5Group &target, const std::string &link_name)
     return openGroup(link_name, false);
 }
 
-// TODO implement some kind of roll-back in order to avoid half renamed links.
-bool H5Group::renameAllLinks(const std::string &old_name, const std::string &new_name) {
-    check_h5_arg_name(new_name);
-
-    bool renamed = false;
-
-    if (hasGroup(old_name)) {
-        std::vector<std::string> links;
-
-        H5Group group     = openGroup(old_name, false);
-        std::string gname = group.name();
-
-        while (! gname.empty()) {
-            deleteLink(gname);
-            links.push_back(gname);
-            gname = group.name();
-        }
-
-        renamed = links.size() > 0;
-        for (std::string curr_name: links) {
-            size_t pos = curr_name.find_last_of('/') + 1;
-
-            if (curr_name.substr(pos) == old_name) {
-                curr_name.replace(curr_name.begin() + pos, curr_name.end(), new_name.begin(), new_name.end());
-            }
-
-            HErr res = H5Lcreate_hard(group.hid, ".", hid, curr_name.c_str(),
-                                      PList::linkUTF8().h5id(),
-                                      H5P_DEFAULT);
-            renamed = renamed && res;
-        }
-    }
-
-    return renamed;
-}
 
 // TODO implement some kind of roll-back in order to avoid half removed links.
 bool H5Group::removeAllLinks(const std::string &name) {

--- a/backend/hdf5/h5x/H5Group.hpp
+++ b/backend/hdf5/h5x/H5Group.hpp
@@ -151,19 +151,6 @@ public:
     H5Group createLink(const H5Group &target, const std::string &link_name);
 
     /**
-     * @brief Renames all links of the object defined by the old name.
-     *
-     * This method will only change the links where the last part of the path
-     * is the old name.
-     *
-     * @param old_name  The old name of the object
-     * @param new_name  The new name of the object
-     *
-     * @return True if all links where changed successfully.
-     */
-    bool renameAllLinks(const std::string &old_name, const std::string &new_name);
-
-    /**
      * @brief Removes all links to the object defined by the given name.
      *
      * @param name      The name of the object to remove.

--- a/backend/hdf5/h5x/H5PList.hpp
+++ b/backend/hdf5/h5x/H5PList.hpp
@@ -1,0 +1,42 @@
+// Copyright © 2020 German Neuroinformatics Node (G-Node)
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted under the terms of the BSD License. See
+// LICENSE file in the root of the Project.
+//
+// Author: Christian Kellner <christian@kellner.me>
+
+#pragma once
+
+#include "H5Object.hpp"
+
+namespace nix {
+namespace hdf5 {
+
+class NIXAPI PList : public H5Object {
+public:
+
+    PList();
+    PList(hid_t hid);
+    PList(hid_t hid, bool is_copy) : H5Object(hid, is_copy) { }
+    PList(const PList &other);
+
+    PList &operator=(const PList &other) {
+        H5Object::operator= (other);
+        return *this;
+    }
+
+    // creators
+    static PList create(hid_t cls_id);
+
+    void charEncoding(H5T_cset_t encoding);
+    H5T_cset_t charEncoding() const;
+
+    // helper
+    static PList linkUTF8();
+};
+
+}
+}

--- a/backend/hdf5/h5x/H5Plist.cpp
+++ b/backend/hdf5/h5x/H5Plist.cpp
@@ -1,0 +1,48 @@
+// Copyright © 2020 German Neuroinformatics Node (G-Node)
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted under the terms of the BSD License. See
+// LICENSE file in the root of the Project.
+//
+// Author: Christian Kellner <christian@kellner.me>
+
+#include "H5PList.hpp"
+
+namespace nix {
+namespace hdf5 {
+
+PList::PList() : H5Object() { }
+
+PList::PList(hid_t hid) : H5Object(hid) { }
+
+PList::PList(const PList &other) : H5Object(other) { }
+
+PList PList::create(hid_t cls_id) {
+    PList pl = H5Pcreate(cls_id);
+    pl.check("H5Pcreate: could not create property list");
+    return pl;
+}
+
+void PList::charEncoding(H5T_cset_t encoding) {
+    HErr res = H5Pset_char_encoding(hid, encoding);
+    res.check("Could not set character encoding on Property List");
+}
+
+H5T_cset_t PList::charEncoding() const {
+    H5T_cset_t encoding;
+    HErr res = H5Pget_char_encoding(hid, &encoding);
+    res.check("Could not get character encoding on Property List");
+    return encoding;
+}
+
+PList PList::linkUTF8() {
+    PList pl = PList::create(H5P_LINK_CREATE);
+    pl.charEncoding(H5T_CSET_UTF8);
+    return pl;
+}
+
+
+} // nix::hdf5
+} // nix::

--- a/backend/hdf5/h5x/LocID.cpp
+++ b/backend/hdf5/h5x/LocID.cpp
@@ -9,6 +9,7 @@
 // Author: Christian Kellner <kellner@bio.lmu.de>
 
 #include "LocID.hpp"
+#include "H5PList.hpp"
 
 namespace nix {
 
@@ -43,7 +44,15 @@ Attribute LocID::openAttr(const std::string &name) const {
 
 
 Attribute LocID::createAttr(const std::string &name, h5x::DataType fileType, const DataSpace &fileSpace) const {
-    Attribute attr = H5Acreate(hid, name.c_str(), fileType.h5id(), fileSpace.h5id(), H5P_DEFAULT, H5P_DEFAULT);
+    PList acpl = PList::create(H5P_ATTRIBUTE_CREATE);
+    acpl.charEncoding(H5T_CSET_UTF8);
+
+    Attribute attr = H5Acreate(hid,
+                               name.c_str(),
+                               fileType.h5id(),
+                               fileSpace.h5id(),
+                               acpl.h5id(),
+                               H5P_DEFAULT);
     attr.check("LocID::openAttr: Could not create attribute " + name);
     return attr;
 }

--- a/backend/hdf5/h5x/LocID.cpp
+++ b/backend/hdf5/h5x/LocID.cpp
@@ -24,6 +24,11 @@ LocID::LocID(hid_t hid) : H5Object(hid) {}
 LocID::LocID(const LocID &other) : H5Object(other) {}
 
 
+void LocID::linkInfo(const std::string &name, H5L_info_t &info) const {
+    HErr res = H5Lget_info(hid, name.c_str(), &info, H5P_DEFAULT);
+    res.check("LocID::linkInfo(): H5Lget_info() failed");
+}
+
 bool LocID::hasAttr(const std::string &name) const {
     HTri res = H5Aexists(hid, name.c_str());
     return res.check("LocID.hasAttr() failed");

--- a/backend/hdf5/h5x/LocID.hpp
+++ b/backend/hdf5/h5x/LocID.hpp
@@ -49,11 +49,10 @@ public:
         return *this;
     }
 
-private:
-
+    /* Low level functions */
     Attribute openAttr(const std::string &name) const;
-    Attribute createAttr(const std::string &name, h5x::DataType fileType, const DataSpace &fileSpace) const;
 
+    Attribute createAttr(const std::string &name, h5x::DataType fileType, const DataSpace &fileSpace) const;
 };
 
 

--- a/backend/hdf5/h5x/LocID.hpp
+++ b/backend/hdf5/h5x/LocID.hpp
@@ -29,6 +29,8 @@ public:
 
     LocID(const LocID &other);
 
+    void linkInfo(const std::string &name, H5L_info_t &info) const;
+
     bool hasAttr(const std::string &name) const;
     void removeAttr(const std::string &name) const;
 

--- a/test/hdf5/TestH5.cpp
+++ b/test/hdf5/TestH5.cpp
@@ -12,6 +12,7 @@
 
 #include "hdf5/FileHDF5.hpp"
 #include "hdf5/h5x/H5Exception.hpp"
+#include "hdf5/h5x/H5PList.hpp"
 
 #include "RefTester.hpp"
 
@@ -148,6 +149,11 @@ void TestH5::testBase() {
 
     H5Gclose(ga);
     H5Gclose(gb);
+
+    test_refcounting<nix::hdf5::PList>(gcpl, dcpl);
+
+    CPPUNIT_ASSERT_EQUAL(1, H5Iget_ref(gcpl));
+    CPPUNIT_ASSERT_EQUAL(1, H5Iget_ref(dcpl));
 
     //name()
     std::string name = h5group.name();
@@ -325,4 +331,16 @@ void TestH5::testDataSpace() {
 
     CPPUNIT_ASSERT_EQUAL(1, H5Iget_ref(ds));
     space.close();
+}
+
+void TestH5::testPropertyList() {
+    nix::hdf5::PList pl = nix::hdf5::PList::create(H5P_LINK_CREATE);
+    pl.charEncoding(H5T_CSET_ASCII);
+    CPPUNIT_ASSERT_EQUAL(H5T_CSET_ASCII, pl.charEncoding());
+
+    pl.charEncoding(H5T_CSET_UTF8);
+    CPPUNIT_ASSERT_EQUAL(H5T_CSET_UTF8, pl.charEncoding());
+
+    nix::hdf5::PList pl_utf8 = nix::hdf5::PList::linkUTF8();
+    CPPUNIT_ASSERT_EQUAL(H5T_CSET_UTF8, pl_utf8.charEncoding());
 }

--- a/test/hdf5/TestH5.cpp
+++ b/test/hdf5/TestH5.cpp
@@ -344,3 +344,39 @@ void TestH5::testPropertyList() {
     nix::hdf5::PList pl_utf8 = nix::hdf5::PList::linkUTF8();
     CPPUNIT_ASSERT_EQUAL(H5T_CSET_UTF8, pl_utf8.charEncoding());
 }
+
+void TestH5::testUTF8() {
+    nix::hdf5::H5Group g = h5group.openGroup("utf8");
+
+    // Check the name of the group is in UTF-8
+    H5L_info_t li;
+    h5group.linkInfo("utf8", li);
+    CPPUNIT_ASSERT_EQUAL(H5T_CSET_UTF8, li.cset);
+
+    // Check the attribute name and contents are in UTF-8
+    g.setAttr("str", std::string{"hopefully utf8"});
+    nix::hdf5::Attribute attr = g.openAttr("str");
+
+    nix::hdf5::PList apl = attr.createPList();
+    CPPUNIT_ASSERT_EQUAL(H5T_CSET_UTF8, apl.charEncoding());
+
+    nix::hdf5::h5x::DataType attr_dtype = attr.dataType();
+    CPPUNIT_ASSERT_EQUAL(H5T_CSET_UTF8, attr_dtype.cset());
+
+    std::vector<std::string> strs = {"a", "b", "c"};
+    g.setData("dataStr", strs);
+
+    // Check the DataSet name and contents are in UTF-8
+    nix::hdf5::DataSet ds = g.openData("dataStr");
+
+    nix::hdf5::h5x::DataType ds_dtype = ds.dataType();
+    CPPUNIT_ASSERT_EQUAL(H5T_CSET_UTF8, ds_dtype.cset());
+
+    g.linkInfo("dataStr", li);
+    CPPUNIT_ASSERT_EQUAL(H5T_CSET_UTF8, li.cset);
+
+    // Check link names are UTF-8
+    h5group.createLink(g, "zelda");
+    h5group.linkInfo("zelda", li);
+    CPPUNIT_ASSERT_EQUAL(H5T_CSET_UTF8, li.cset);
+}

--- a/test/hdf5/TestH5.cpp
+++ b/test/hdf5/TestH5.cpp
@@ -196,9 +196,14 @@ void TestH5::testDataType() {
 
     h5x::DataType v_str = h5x::DataType::makeStrType();
     CPPUNIT_ASSERT_EQUAL(true, v_str.isVariableString());
+    CPPUNIT_ASSERT_EQUAL(H5T_CSET_UTF8, v_str.cset());
 
     h5x::DataType str_255 = h5x::DataType::makeStrType(255);
     CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(255), str_255.size());
+
+    h5x::DataType str_ascii = h5x::DataType::makeStrType(255, H5T_CSET_ASCII);
+    CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(255), str_ascii.size());
+    CPPUNIT_ASSERT_EQUAL(H5T_CSET_ASCII, str_ascii.cset());
 
     h5x::DataType otype = h5x::DataType::make(H5T_OPAQUE, 42);
     CPPUNIT_ASSERT_EQUAL(H5T_OPAQUE, otype.class_t());

--- a/test/hdf5/TestH5.hpp
+++ b/test/hdf5/TestH5.hpp
@@ -36,6 +36,7 @@ public:
     void testDataType();
     void testDataSpace();
     void testPropertyList();
+    void testUTF8();
 
 private:
     hid_t h5file;
@@ -46,6 +47,7 @@ private:
     CPPUNIT_TEST(testDataType);
     CPPUNIT_TEST(testDataSpace);
     CPPUNIT_TEST(testPropertyList);
+    CPPUNIT_TEST(testUTF8);
     CPPUNIT_TEST_SUITE_END ();
 
 };

--- a/test/hdf5/TestH5.hpp
+++ b/test/hdf5/TestH5.hpp
@@ -35,6 +35,7 @@ public:
     void testBase();
     void testDataType();
     void testDataSpace();
+    void testPropertyList();
 
 private:
     hid_t h5file;
@@ -44,6 +45,7 @@ private:
     CPPUNIT_TEST(testBase);
     CPPUNIT_TEST(testDataType);
     CPPUNIT_TEST(testDataSpace);
+    CPPUNIT_TEST(testPropertyList);
     CPPUNIT_TEST_SUITE_END ();
 
 };


### PR DESCRIPTION
This enables utf8 encoding for the names of groups, datasets and links as well as for all string values in datasets and attributes.
Closes #779 