### PR TITLE
Change creation of Properties

### DIFF
--- a/backend/hdf5/SectionHDF5.cpp
+++ b/backend/hdf5/SectionHDF5.cpp
@@ -254,7 +254,8 @@ shared_ptr<IProperty> SectionHDF5::getProperty(ndsize_t index) const {
 shared_ptr<IProperty> SectionHDF5::createProperty(const string &name, const DataType &dtype, const NDSize &shape) {
     string new_id = util::createId();
     boost::optional<H5Group> g = property_group(true);
-    DataSet ds = g->createData(name, data_type_to_h5_filetype(dtype), shape);
+    DataSet ds = g->createData(name, data_type_to_h5_filetype(dtype), shape, Compression::DeflateNormal,
+                               {}, shape, true, false);
     return make_shared<PropertyHDF5>(file(), ds, new_id, name);
 }
 

--- a/backend/hdf5/SectionHDF5.cpp
+++ b/backend/hdf5/SectionHDF5.cpp
@@ -261,13 +261,13 @@ shared_ptr<IProperty> SectionHDF5::createProperty(const string &name, const Data
 
 
 shared_ptr<IProperty> SectionHDF5::createProperty(const string &name, const DataType &dtype) {
-    shared_ptr<IProperty> p = createProperty(name, dtype, {8});
+    shared_ptr<IProperty> p = createProperty(name, dtype, {DEFAULT_PROPERTY_SIZE});
     return p;
 }
 
 
 shared_ptr<IProperty> SectionHDF5::createProperty(const string &name, const Variant &value) {
-    shared_ptr<IProperty> p = createProperty(name, value.type(), {8});
+    shared_ptr<IProperty> p = createProperty(name, value.type(), {DEFAULT_PROPERTY_SIZE});
     vector<Variant> val{value};
     p->values(val);
     return p;

--- a/backend/hdf5/SectionHDF5.cpp
+++ b/backend/hdf5/SectionHDF5.cpp
@@ -251,16 +251,22 @@ shared_ptr<IProperty> SectionHDF5::getProperty(ndsize_t index) const {
 }
 
 
-shared_ptr<IProperty> SectionHDF5::createProperty(const string &name, const DataType &dtype) {
+shared_ptr<IProperty> SectionHDF5::createProperty(const string &name, const DataType &dtype, const NDSize &shape) {
     string new_id = util::createId();
     boost::optional<H5Group> g = property_group(true);
-    DataSet ds = g->createData(name, data_type_to_h5_filetype(dtype), {0});
+    DataSet ds = g->createData(name, data_type_to_h5_filetype(dtype), shape);
     return make_shared<PropertyHDF5>(file(), ds, new_id, name);
 }
 
 
+shared_ptr<IProperty> SectionHDF5::createProperty(const string &name, const DataType &dtype) {
+    shared_ptr<IProperty> p = createProperty(name, dtype, {8});
+    return p;
+}
+
+
 shared_ptr<IProperty> SectionHDF5::createProperty(const string &name, const Variant &value) {
-    shared_ptr<IProperty> p = createProperty(name, value.type());
+    shared_ptr<IProperty> p = createProperty(name, value.type(), {8});
     vector<Variant> val{value};
     p->values(val);
     return p;
@@ -268,7 +274,8 @@ shared_ptr<IProperty> SectionHDF5::createProperty(const string &name, const Vari
 
 
 shared_ptr<IProperty> SectionHDF5::createProperty(const string &name, const vector<Variant> &values) {
-    shared_ptr<IProperty> p = createProperty(name, values[0].type());
+    NDSize shape(1, values.size());
+    shared_ptr<IProperty> p = createProperty(name, values[0].type(), shape);
     p->values(values);
     return p;
 }

--- a/backend/hdf5/SectionHDF5.hpp
+++ b/backend/hdf5/SectionHDF5.hpp
@@ -19,6 +19,11 @@
 namespace nix {
 namespace hdf5 {
 
+// Most properties will only contain a small number of values. The default chunk
+// guessing uses way too much memory in most cases. 8 is an arbitrary compromise
+// and should avoid the need to resize the dataset for most cases.
+#define DEFAULT_PROPERTY_SIZE 8 
+
 class SectionHDF5 : public NamedEntityHDF5, virtual public base::ISection,
                     public std::enable_shared_from_this<SectionHDF5> {
 

--- a/backend/hdf5/SectionHDF5.hpp
+++ b/backend/hdf5/SectionHDF5.hpp
@@ -136,6 +136,9 @@ public:
 
     std::shared_ptr<base::IProperty> createProperty(const std::string &name, const DataType &dtype);
 
+    
+    std::shared_ptr<base::IProperty> createProperty(const std::string &name, const DataType &dtype, const NDSize &shape);
+
 
     std::shared_ptr<base::IProperty> createProperty(const std::string &name, const Variant &value);
 


### PR DESCRIPTION
So far we set chunking to auto and hence properties reserved quite a bit of unnecessary overhead. With this PR, the default size is reduced to 8 entries for Properties that are created without or only a single value. If they are created with a vector of values, the vector size is used to define the size and the chunking of the H5 dataset. 
Compression has been switched on.

These changes are analogous to recent nixpy changes