### PR TITLE
adaptations for RangeDimension indexOf methods

### DIFF
--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -265,7 +265,8 @@ public:
      * This method returns the index of the given position. Use this method for
      * example to find out which data point (index) relates to a given
      * time. Note: This method does not check if the position is within the
-     * extent of the data!
+     * extent of the data! Nevertheless, an OutOfBounds exception is thrown if
+     * the position is less than the offset of the dimension.
      *
      * @param position  The position, e.g. a time
      *
@@ -280,27 +281,59 @@ public:
      * This method returns the index of the given position. Use this method for
      * example to find out which data point (index) relates to a given
      * time. Note: This method does not check if the position is within the
-     * extent of the data!
+     * extent of the data! Nevertheless, an OutOfBounds exception is thrown if
+     * the start position is less than the offset of the dimension.
      *
-     * @param position  The position, e.g. a time
-     *
+     * @param start          The start position, e.g. a time
+     * @param end            The end position
+     * @param match          RangeMatch enum to control whether the range should be
+     *                       including the end position or exclusive, i.e. without 
+     *                       the end position, default is RangeMatch::Inclusive
+     * 
      * @returns The respective index.
      */
-    std::pair<ndsize_t, ndsize_t> indexOf(const double start, const double end) const;
+    std::pair<ndsize_t, ndsize_t> indexOf(const double start, const double end, RangeMatch match = RangeMatch::Inclusive) const;
 
-
+   
+    /**
+     * @brief Returns the index of the given position.
+     *
+     * This method returns the index of the given position. Use this method for
+     * example to find out which data point (index) relates to a given
+     * time. Note: This method does not check if the position is within the
+     * extent of the data! Nevertheless, an OutOfBounds exception is thrown if
+     * the start position is less than the offset of the dimension.
+     *
+     * @param start                The start position, e.g. a time
+     * @param end                  The end position
+     * @param sampling_interval    The sampling interval of the dimension.
+     * @param offset               The offset of the dimension.
+     * @param match                RangeMatch enum to control whether the range should be
+     *                             including the end position or exclusive, i.e. without 
+     *                             the end position, default is RangeMatch::Inclusive
+     * 
+     * @returns The pair of start and end indices.
+     */
+    std::pair<ndsize_t, ndsize_t> indexOf(double start, double end, const double sampling_interval, const double offset,
+                                          RangeMatch match = RangeMatch::Inclusive) const;
+    
+    
     /**
      * @brief Returns a vector of start and end indices of given start and end positions.
-     *
-     * Method will return the index equal or larger than the respective positions
+     * This method does not check whether the index is in the extent of the data. Nevertheless,
+     * an OutOfBounds exception is thrown if the start position is less than the offset of the dimension.
      *
      * @param start_positions    Vector of start positions
      * @param end_positions      Vector of end positions
+     * @param match              RangeMatch enum to control whether the range should be
+     *                           including the end position or exclusive, i.e. without 
+     *                           the end position, default is RangeMatch::Inclusive
      *
      * @return  Vector of pairs of start and end indices.
      */
     std::vector<std::pair<ndsize_t, ndsize_t>> indexOf(const std::vector<double> &start_positions,
-                                                       const std::vector<double> &end_positions) const;
+                                                       const std::vector<double> &end_positions,
+                                                       RangeMatch match = RangeMatch::Inclusive) const;
 
     /**
      * @brief Returns the position of this dimension at a given index.
@@ -502,10 +535,10 @@ public:
 /**
  * @brief Dimension descriptor for a dimension that is irregularly sampled.
  *
- * The RangeDimension covers cases when indexes of a dimension are mapped to other values
- * in a not regular fashion. A use-case for this would be for example irregularly sampled
- * time-series or certain kinds of histograms. To achieve the mapping of the indexes an
- * array of mapping values must be provided. Those values are stored in the dimensions {@link ticks}
+ * The RangeDimension covers cases in which indicess of a dimension are mapped to other values
+ * in a non-regular fashion. For example, when event times are recorded that would occur in irregularly 
+ * intervals. To achieve the mapping of the indexes an array of mapping values must be provided. 
+ * Those values are stored in the dimensions {@link ticks}
  * property. In analogy to the sampled dimension a {@link unit} and a {@link label} can be defined.
  */
 class NIXAPI RangeDimension : public base::ImplContainer<base::IRangeDimension> {

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -548,6 +548,31 @@ public:
      */
     boost::optional<ndsize_t> indexOf(const double position, const PositionMatch match) const;
 
+
+    /**
+     * @brief returns the start and end indices corresponding to the provided start and end positions.
+     * 
+     * @param  start    double, the start position
+     * @param  end      double, the end position 
+     * @param  match    RangeMatch, controls whether the range includes the end position or not.
+     * 
+     * @return optional containing a pair of ndsize_t.
+     */
+    boost::optional<std::pair<ndsize_t, ndsize_t>> indexOf(const double start, const double end, const RangeMatch match) const;
+
+    /**
+     * @brief returns the start and end indices corresponding to the provided start and end positions.
+     * 
+     * @param  start    double, the start position
+     * @param  end      double, the end position 
+     * @param  labels   vector<string> of labels
+     * @param  match    RangeMatch, controls whether the range includes the end position or not.
+     * 
+     * @return optional containing a pair of ndsize_t.
+     */
+    boost::optional<std::pair<ndsize_t, ndsize_t>> indexOf(const double start, const double end, std::vector<std::string> &set_labels, const RangeMatch match) const;
+    
+    
     /**
      * @brief Assignment operator.
      *

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -789,12 +789,18 @@ public:
      *
      * @param start_positions    Vector of start positions
      * @param end_positions      Vector of end positions
+     * @param match              Enum entry that defines whether the range is inclusive
+     *                           or exclusive regarding the end position
+     * @param strict             Bool that indicates whether the function will throw an
+     *                           OutOfBounds exception when an invalid range occurred or
+     *                           if such ranges are silently ignored. Default is true.
      *
      * @return  Vector of pairs of start and end indices.
      */
     std::vector<std::pair<ndsize_t, ndsize_t>> indexOf(const std::vector<double> &start_positions,
                                                        const std::vector<double> &end_positions,
-                                                       RangeMatch match = RangeMatch::Inclusive) const;
+                                                       RangeMatch match = RangeMatch::Inclusive,
+                                                       bool strict = true) const;
 
 
     /**

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -654,9 +654,12 @@ public:
     /**
      * @brief Returns the index of the given position
      *
-     * Method will return the index equal or larger than position
+     * Method will return the index of the tick that matches or is close to
+     * position. If "less_or_equal" is true, the index of the first tick that is
+     * less or equal is given. If "less_or_equal" is false the index of the
+     * first index that is greater than than position is returned.
      *
-     * @param position    The position.
+     * @param position       The position.
      * @param less_or_equal  If true, the first index that is less or
      *                       equal will be returned. Else, the first index
      *                       that is not less than position will be returned.

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -538,6 +538,17 @@ public:
     }
 
     /**
+     * @brief converts a position given as a double to an index in this dimension, if 
+     * it contains labels, then the position will be validated within these limits.
+     * 
+     * @param  position       The position.
+     * @param  match          Memeber of the {@link PositionMatch} enumeration to control conversion.
+     * 
+     * @return An optional containing the index, if valid.
+     */
+    boost::optional<ndsize_t> indexOf(const double position, const PositionMatch match) const;
+
+    /**
      * @brief Assignment operator.
      *
      * @param other     The dimension to assign.

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -749,12 +749,17 @@ public:
      *
      * Method will return the index equal or larger than the respective positions
      *
+     * Version 1.4.5: The behavior of this function has been slightly changed,
+     * it now throws an OutOfBounds exception if the position is not in the
+     * range. Use positionInRange(position) to check before calling this function.
+     *
      * @param start      The start position
      * @param end        The end position
      *
      * @return  Start and end index returned in a std::pair.
+     * @deprecated This function has been deprecated! Use indexOf(position, PositionMatch) instead.
      */
-    std::pair<ndsize_t, ndsize_t> indexOf(const double start, const double end) const;
+    DEPRECATED std::pair<ndsize_t, ndsize_t> indexOf(const double start, const double end) const;
 
 
      /**

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -271,8 +271,24 @@ public:
      * @param position  The position, e.g. a time
      *
      * @returns The respective index.
+     * @deprecated This function has been deprecated use {@link SampledDimension::indexOf} instead.
      */
-    ndsize_t indexOf(const double position) const;
+    DEPRECATED ndsize_t indexOf(const double position) const;
+
+    /**
+     * @brief Returns the index of the given position.
+     *
+     * This method returns the index of the given position. Use this method for
+     * example to find out which data point (index) relates to a given
+     * time. If the position is invalid, an invalid optional is returned.
+     *
+     * @param position  The position, e.g. a time
+     * @param strict    Defines whether an exception should be thrown if the
+     *                  position is invalid
+     *
+     * @returns An optional containing the respective index.
+     */
+    boost::optional<ndsize_t> indexOf(const double position, PositionMatch match) const;
 
 
     /**
@@ -292,8 +308,13 @@ public:
      * 
      * @returns The respective index.
      */
-    std::pair<ndsize_t, ndsize_t> indexOf(const double start, const double end, RangeMatch match = RangeMatch::Inclusive) const;
-
+    boost::optional<std::pair<ndsize_t, ndsize_t>> indexOf(const double start, const double end, RangeMatch match) const;
+    
+    /**
+     * @deprecated This function has been deprecated please use
+     *             {@link SampledDimension::indexOf(const double, const double&, const RangeMatch)} instead
+     */
+    DEPRECATED std::pair<ndsize_t, ndsize_t> indexOf(const double start, const double end) const;
    
     /**
      * @brief Returns the index of the given position.
@@ -312,10 +333,10 @@ public:
      *                             including the end position or exclusive, i.e. without 
      *                             the end position, default is RangeMatch::Inclusive
      * 
-     * @returns The pair of start and end indices.
+     * @returns The a boost::optional containing the pair of start and end indices.
      */
-    std::pair<ndsize_t, ndsize_t> indexOf(double start, double end, const double sampling_interval, const double offset,
-                                          RangeMatch match = RangeMatch::Inclusive) const;
+    boost::optional<std::pair<ndsize_t, ndsize_t>> indexOf(double start, double end, const double sampling_interval, const double offset,
+                                                           const RangeMatch match) const;
     
     
     /**
@@ -329,11 +350,20 @@ public:
      *                           including the end position or exclusive, i.e. without 
      *                           the end position, default is RangeMatch::Inclusive
      *
-     * @return  Vector of pairs of start and end indices.
+     * @return  Vector of optionals containing pairs of start and end indices.
      */
-    std::vector<std::pair<ndsize_t, ndsize_t>> indexOf(const std::vector<double> &start_positions,
-                                                       const std::vector<double> &end_positions,
-                                                       RangeMatch match = RangeMatch::Inclusive) const;
+    std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> indexOf(const std::vector<double> &start_positions,
+                                                                        const std::vector<double> &end_positions,
+                                                                        const RangeMatch match) const;
+
+    /**
+     * @deprecated This function has been deprecated please use
+     *             {@link SampledDimension::indexOf(const std::vector<double>&, const std::vector<double>&, const RangeMatch)} instead
+     */
+    DEPRECATED std::vector<std::pair<ndsize_t, ndsize_t>> indexOf(const std::vector<double> &start_positions,
+                                                                  const std::vector<double> &end_positions) const;
+
+
 
     /**
      * @brief Returns the position of this dimension at a given index.

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -695,9 +695,17 @@ public:
      * @brief Returns the index of the given position
      *
      * Method will return the index of the tick that matches or is close to
+    /**
+     * @brief Returns the index of the given position
+     *
+     * Method will return the index of the tick that matches or is close to
      * position. If "less_or_equal" is true, the index of the first tick that is
      * less or equal is given. If "less_or_equal" is false the index of the
      * first index that is greater than than position is returned.
+     * 
+     * Version 1.4.5: The behavior of this function has been slightly changed,
+     * it now throws an OutOfBounds exception if the position is not in the
+     * range. Use positionInRange(position) to check before calling this function.
      *
      * @param position       The position.
      * @param less_or_equal  If true, the first index that is less or
@@ -705,8 +713,10 @@ public:
      *                       that is not less than position will be returned.
      *
      * @return The index.
+     *
+     * @deprecated This function has been deprecated! Use indexOf(position, PositionMatch) instead.
      */
-    ndsize_t indexOf(const double position, bool less_or_equal = true) const;
+    DEPRECATED ndsize_t indexOf(const double position, bool less_or_equal = true) const;
 
 
     /**

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -847,8 +847,7 @@ public:
      * @return           Start and end indices returned in a boost::optional<std::pair>
      *                   which is invalid if out of range.
      */
-    boost::optional<std::pair<ndsize_t, ndsize_t>> indexOf(double start, double end,
-                                                           std::vector<double> &&ticks,
+    boost::optional<std::pair<ndsize_t, ndsize_t>> indexOf(double start, double end, std::vector<double> ticks,
                                                            RangeMatch match = RangeMatch::Inclusive) const;
 
 

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -30,6 +30,18 @@ enum class PositionMatch {
 };
 
 /**
+ * @brief Enumeration providing constants for range matching.
+ *
+ * These constants are used to control the behaviour of the range finding.
+ * Inclusive means [start, end], i.e. start and end are included 
+ * Exclusive means [start, end), i.e. start is included, end is not
+ */
+enum class RangeMatch {
+                       Inclusive,
+                       Exclusive
+};
+
+/**
  * @brief Enumeration providing constants for position matching.
  *
  * These constants are used as return values when checking if a position is in

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -17,6 +17,31 @@ class DataArray;
 class Dimension;
 
 /**
+ * @brief Enumeration providing constants for position matching.
+ *
+ * These constants are used to control the behaviour of the index finding.
+ */
+enum class PositionMatch {
+                          Equal,
+                          Less,
+                          Greater,
+                          GreaterOrEqual,
+                          LessOrEqual
+};
+
+/**
+ * @brief Enumeration providing constants for position matching.
+ *
+ * These constants are used as Return values when checking if a position is in
+ * the data range.
+ */
+enum class PositionInRange{
+                          InRange,
+                          Greater,
+                          Less
+};
+
+/**
  * @brief Dimension descriptor for regularly sampled dimensions.
  *
  * Instances of the SampledDimension Class are used to describe a dimension of data in

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -803,6 +803,22 @@ public:
                                                        bool strict = true) const;
 
 
+     /**
+     * @brief Returns a vector of start and end indices of given start and end positions.
+     *
+     * Method will return the index equal or larger than the respective positions
+     *
+     * @param start_positions    Vector of start positions
+     * @param end_positions      Vector of end positions
+     * @param match              Enum entry that defines whether the range is inclusive
+     *                           or exclusive regarding the end position
+     *
+     * @return  Vector of optional pairs of start and end indices.
+     */
+    std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> indexOf(const std::vector<double> &start_positions,
+                                                                        const std::vector<double> &end_positions,
+                                                                        RangeMatch match = RangeMatch::Inclusive) const;
+
     /**
      * @brief Returns a vector containing a number of ticks
      *

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -572,7 +572,20 @@ public:
      */
     boost::optional<std::pair<ndsize_t, ndsize_t>> indexOf(const double start, const double end, std::vector<std::string> &set_labels, const RangeMatch match) const;
     
-    
+    /**
+     * @brief converts vectors of start and end positions to a vector of optionals containg start and end indices.
+     * 
+     * @param start_positions    vector of start positions
+     * @param end_positions      vector of end positions
+     * @param match              Member of the RangeMatch enum to control whether ranges are inclusive or exclusiv the end positions
+     * 
+     * @return vector of optionals containing a pair of start and end indices
+     */
+    std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> indexOf(const std::vector<double> &start_positions,
+                                                                        const std::vector<double> &end_positions,
+                                                                        const RangeMatch match) const;
+
+
     /**
      * @brief Assignment operator.
      *

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -695,6 +695,19 @@ public:
      * @brief Returns the index of the given position
      *
      * Method will return the index of the tick that matches or is close to
+     * position. The way of matching can be controlled using the PositionMatch
+     * enum.
+     * 
+     * @param position The position.  
+     * @param matching PositionMatch enum entry that defines the matching
+     *                 behavior. 
+     *
+     * @return boost optional containing the index if valid
+     *
+     */
+    boost::optional<ndsize_t> indexOf(const double position, PositionMatch matching) const;
+
+
     /**
      * @brief Returns the index of the given position
      *

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -33,7 +33,7 @@ enum class PositionMatch {
  * @brief Enumeration providing constants for range matching.
  *
  * These constants are used to control the behaviour of the range finding.
- * Inclusive means [start, end], i.e. start and end are included 
+ * Inclusive means [start, end], i.e. start and end are included
  * Exclusive means [start, end), i.e. start is included, end is not
  */
 enum class RangeMatch {
@@ -51,7 +51,7 @@ enum class PositionInRange{
                           InRange,
                           Greater,
                           Less,
-                          
+
                           NoRange = -1
 };
 
@@ -709,10 +709,10 @@ public:
      * Method will return the index of the tick that matches or is close to
      * position. The way of matching can be controlled using the PositionMatch
      * enum.
-     * 
-     * @param position The position.  
+     *
+     * @param position The position.
      * @param matching PositionMatch enum entry that defines the matching
-     *                 behavior. 
+     *                 behavior.
      *
      * @return boost optional containing the index if valid
      *
@@ -729,17 +729,17 @@ public:
      * @param start      The start position
      * @param end        The end position
      * @param ticks      std::vector<double> of ticks, if empty ({}) they are automatically retrieved
-     * @param range      RangeMatch enum, controls whether end is included or not, 
+     * @param range      RangeMatch enum, controls whether end is included or not,
      *                   defaults to RangeMatch::Inclusive
      *
      * @return           Start and end indices returned in a boost::optional<std::pair>
      *                   which is invalid if out of range.
      */
     boost::optional<std::pair<ndsize_t, ndsize_t>> indexOf(double start, double end,
-                                                           std::vector<double> ticks,
+                                                           std::vector<double> &&ticks,
                                                            RangeMatch match = RangeMatch::Inclusive) const;
 
-   
+
     /**
      * @brief Returns the index of the given position
      *
@@ -747,7 +747,7 @@ public:
      * position. If "less_or_equal" is true, the index of the first tick that is
      * less or equal is given. If "less_or_equal" is false the index of the
      * first index that is greater than than position is returned.
-     * 
+     *
      * Version 1.4.5: The behavior of this function has been slightly changed,
      * it now throws an OutOfBounds exception if the position is not in the
      * range. Use positionInRange(position) to check before calling this function.

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -793,7 +793,8 @@ public:
      * @return  Vector of pairs of start and end indices.
      */
     std::vector<std::pair<ndsize_t, ndsize_t>> indexOf(const std::vector<double> &start_positions,
-                                                       const std::vector<double> &end_positions) const;
+                                                       const std::vector<double> &end_positions,
+                                                       RangeMatch match = RangeMatch::Inclusive) const;
 
 
     /**

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -32,13 +32,15 @@ enum class PositionMatch {
 /**
  * @brief Enumeration providing constants for position matching.
  *
- * These constants are used as Return values when checking if a position is in
+ * These constants are used as return values when checking if a position is in
  * the data range.
  */
 enum class PositionInRange{
                           InRange,
                           Greater,
-                          Less
+                          Less,
+                          
+                          NoRange = -1
 };
 
 /**
@@ -665,6 +667,7 @@ public:
      */
     void ticks(const std::vector<double> &ticks);
 
+
     /**
      * @brief Returns the entry of the range dimension at a given index.
      *
@@ -675,6 +678,18 @@ public:
      * Method will throw an nix::OutOfBounds Exception if the index is invalid
      */
     double tickAt(const ndsize_t index) const;
+
+
+    /**
+     * @brief Checks whether a given position is in the Range of ticks in this
+     * dimension.
+     *
+     * @param position     The position.
+     *
+     * @return PositionInRange which can be either Less, Greater, or InRange
+     */
+    PositionInRange positionInRange(const double position) const;
+
 
     /**
      * @brief Returns the index of the given position

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -721,6 +721,26 @@ public:
 
 
     /**
+     * @brief Returns the start and end index of the given start and end
+     * positions.  By default, the range includes the end position. This can be
+     * controlled via the RangeMatch enum.
+     *
+     *
+     * @param start      The start position
+     * @param end        The end position
+     * @param ticks      std::vector<double> of ticks, if empty ({}) they are automatically retrieved
+     * @param range      RangeMatch enum, controls whether end is included or not, 
+     *                   defaults to RangeMatch::Inclusive
+     *
+     * @return           Start and end indices returned in a boost::optional<std::pair>
+     *                   which is invalid if out of range.
+     */
+    boost::optional<std::pair<ndsize_t, ndsize_t>> indexOf(double start, double end,
+                                                           std::vector<double> ticks,
+                                                           RangeMatch match = RangeMatch::Inclusive) const;
+
+   
+    /**
      * @brief Returns the index of the given position
      *
      * Method will return the index of the tick that matches or is close to

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -789,18 +789,18 @@ public:
      *
      * @param start_positions    Vector of start positions
      * @param end_positions      Vector of end positions
-     * @param match              Enum entry that defines whether the range is inclusive
-     *                           or exclusive regarding the end position
      * @param strict             Bool that indicates whether the function will throw an
      *                           OutOfBounds exception when an invalid range occurred or
      *                           if such ranges are silently ignored. Default is true.
+     * @param match              Enum entry that defines whether the range is inclusive
+     *                           or exclusive regarding the end position
      *
      * @return  Vector of pairs of start and end indices.
+     * @deprecated This function has been deprecated and will be removed in future versions!
      */
-    std::vector<std::pair<ndsize_t, ndsize_t>> indexOf(const std::vector<double> &start_positions,
-                                                       const std::vector<double> &end_positions,
-                                                       RangeMatch match = RangeMatch::Inclusive,
-                                                       bool strict = true) const;
+    DEPRECATED std::vector<std::pair<ndsize_t, ndsize_t>> indexOf(const std::vector<double> &start_positions,
+                                                                  const std::vector<double> &end_positions,
+                                                                  bool strict, RangeMatch match = RangeMatch::Inclusive) const;
 
 
      /**

--- a/include/nix/util/dataAccess.hpp
+++ b/include/nix/util/dataAccess.hpp
@@ -156,14 +156,17 @@ NIXAPI DEPRECATED std::vector<std::pair<ndsize_t, ndsize_t>> positionToIndex(con
  * @param array         A referenced data array.
  * @param[out] offsets  The resulting offset.
  * @param[out] counts   The number of elements to read from data
+ * @param match         Member of the RangeMatch enum, defining wheter the range includes the end position
+ *                      or not. By default this is RangeMatch::Inclusive (Note: this behavior will change 
+ *                      with version 1.5)
  */
-NIXAPI void getOffsetAndCount(const Tag &tag, const DataArray &array, NDSize &offsets, NDSize &counts);
+NIXAPI void getOffsetAndCount(const Tag &tag, const DataArray &array, NDSize &offsets, NDSize &counts, RangeMatch match = RangeMatch::Inclusive);
 
 
-NIXAPI void getOffsetAndCount(const MultiTag &tag, const DataArray &array, ndsize_t index, NDSize &offsets, NDSize &counts);
+NIXAPI void getOffsetAndCount(const MultiTag &tag, const DataArray &array, ndsize_t index, NDSize &offsets, NDSize &counts, RangeMatch match = RangeMatch::Inclusive);
 
 NIXAPI void getOffestAndCount(const MultiTag &tag, const DataArray &array, const std::vector<ndsize_t> indices,
-                              std::vector<NDSize> &offsets, std::vector<NDSize> & counts);
+                              std::vector<NDSize> &offsets, std::vector<NDSize> & counts, RangeMatch match = RangeMatch::Inclusive);
 
 
 /**
@@ -183,7 +186,7 @@ NIXAPI void getOffestAndCount(const MultiTag &tag, const DataArray &array, const
  * @returns {@link nix::DataView} the data slice.
  */
 NIXAPI DataView dataSlice(const DataArray &array, const std::vector<double> &start, const std::vector<double> &end,
-                          const std::vector<std::string> &units={});
+                          const std::vector<std::string> &units={}, RangeMatch match = RangeMatch::Inclusive);
 
 /**
  * @brief Retrieve the data referenced by the given position and extent of the MultiTag.
@@ -195,7 +198,7 @@ NIXAPI DataView dataSlice(const DataArray &array, const std::vector<double> &sta
  * @return The data referenced by position and extent.
  * @deprecated This function has been deprecated! Use retrieveData(MultiTag, vector<ndsize_t>, DataArray) instead.
  */
-NIXAPI DEPRECATED DataView retrieveData(const MultiTag &tag, ndsize_t position_index, const DataArray &array);
+NIXAPI DEPRECATED DataView retrieveData(const MultiTag &tag, ndsize_t position_index, const DataArray &array, RangeMatch match = RangeMatch::Inclusive);
 
 /**
  * @brief Retrieve the data referenced by the given position and extent of the MultiTag.
@@ -207,7 +210,7 @@ NIXAPI DEPRECATED DataView retrieveData(const MultiTag &tag, ndsize_t position_i
  * @return The data referenced by position and extent.
  * @deprecated This function has been deprecated! Use retrieveData(MultiTag, vector<ndsize_t>, DataArray) instead.
  */
-NIXAPI DEPRECATED DataView retrieveData(const MultiTag &tag, ndsize_t position_index, ndsize_t reference_index);
+NIXAPI DEPRECATED DataView retrieveData(const MultiTag &tag, ndsize_t position_index, ndsize_t reference_index, RangeMatch match = RangeMatch::Inclusive);
 
 
 /**
@@ -219,7 +222,7 @@ NIXAPI DEPRECATED DataView retrieveData(const MultiTag &tag, ndsize_t position_i
  *
  * @return The data referenced by the specified indices, respectively their positions and extents.
  */
-NIXAPI std::vector<DataView> retrieveData(const MultiTag &tag, std::vector<ndsize_t> &position_indices, const DataArray &array);
+NIXAPI std::vector<DataView> retrieveData(const MultiTag &tag, std::vector<ndsize_t> &position_indices, const DataArray &array, RangeMatch match = RangeMatch::Inclusive);
 
 /**
  * @brief Retrieve several segments of  data referenced by the given position and extent of the MultiTag.
@@ -230,7 +233,7 @@ NIXAPI std::vector<DataView> retrieveData(const MultiTag &tag, std::vector<ndsiz
  *
  * @return The data referenced by the specified indices, respectively their positions and extents.
  */
-NIXAPI std::vector<DataView> retrieveData(const MultiTag &tag, std::vector<ndsize_t> &position_indices, ndsize_t reference_index);
+NIXAPI std::vector<DataView> retrieveData(const MultiTag &tag, std::vector<ndsize_t> &position_indices, ndsize_t reference_index, RangeMatch match = RangeMatch::Inclusive);
 
 
 /**
@@ -241,7 +244,7 @@ NIXAPI std::vector<DataView> retrieveData(const MultiTag &tag, std::vector<ndsiz
  *
  * @return The data referenced by the position.
  */
-NIXAPI DataView retrieveData(const Tag &tag, ndsize_t reference_index);
+NIXAPI DataView retrieveData(const Tag &tag, ndsize_t reference_index, RangeMatch match = RangeMatch::Inclusive);
 
 /**
  * @brief Retrieve the data referenced by the given position and extent of the Tag.
@@ -251,7 +254,7 @@ NIXAPI DataView retrieveData(const Tag &tag, ndsize_t reference_index);
  *
  * @return The data referenced by the position.
  */
-NIXAPI DataView retrieveData(const Tag &tag, const DataArray &array);
+NIXAPI DataView retrieveData(const Tag &tag, const DataArray &array, RangeMatch match = RangeMatch::Inclusive);
 
 
 /**

--- a/include/nix/util/dataAccess.hpp
+++ b/include/nix/util/dataAccess.hpp
@@ -283,20 +283,25 @@ NIXAPI bool positionAndExtentInData(const DataArray &data, const NDSize &positio
  *
  * @param tag           The Tag whos feature data is requested
  * @param feature_index The index of the desired feature. Default is 0.
+ * @param range_match   Member of RangeMatch enum to control whether a 
+ *                      data range should include the last position or not
+ *                      (only required for tagged features, otherwise ignored) 
  *
  * @return The associated data.
  */
-NIXAPI DataView retrieveFeatureData(const Tag &tag, ndsize_t feature_index=0);
+NIXAPI DataView retrieveFeatureData(const Tag &tag, ndsize_t feature_index=0, RangeMatch range_match = RangeMatch::Inclusive);
 
 /**
  * @brief Retruns the feature data associated with a Tag.
  *
  * @param tag           The Tag whos feature data is requested.
  * @param feature       The Feature of which the tagged data is requested.
- *
+ * @param range_match   Member of RangeMatch enum to control whether a 
+ *                      data range should include the last position or not
+ *                      (only required for tagged features, otherwise ignored)
  * @return The associated data.
  */
-NIXAPI DataView retrieveFeatureData(const Tag &tag, const Feature &feature);
+NIXAPI DataView retrieveFeatureData(const Tag &tag, const Feature &feature, RangeMatch range_match = RangeMatch::Inclusive);
 
 /**
  * @brief Returns the feature data associated with the given MuliTag's position.
@@ -304,10 +309,13 @@ NIXAPI DataView retrieveFeatureData(const Tag &tag, const Feature &feature);
  * @param tag            The MultiTag whos feature data is requested.
  * @param position_index The index of the selected position, respectively the selected tag of the MultiTag.
  * @param feature_index  The index of the desired feature. Default is 0.
- *
+ * @param range_match   Member of RangeMatch enum to control whether a 
+ *                      data range should include the last position or not
+ *                      (only required for tagged features, otherwise ignored)
+ * 
  * @return The associated data.
  */
-NIXAPI DataView retrieveFeatureData(const MultiTag &tag, ndsize_t position_index, ndsize_t feature_index=0);
+NIXAPI DataView retrieveFeatureData(const MultiTag &tag, ndsize_t position_index, ndsize_t feature_index=0, RangeMatch range_match = RangeMatch::Inclusive);
 
 /**
  * @brief Returns the feature data associated with the given MuliTag's position.
@@ -315,10 +323,13 @@ NIXAPI DataView retrieveFeatureData(const MultiTag &tag, ndsize_t position_index
  * @param tag            The MultiTag whos feature data is requested.
  * @param position_index The index of the selected position, respectively the selected tag of the MultiTag.
  * @param feature        The feature of which the tagged data is requested.
+ * @param range_match   Member of RangeMatch enum to control whether a 
+ *                      data range should include the last position or not
+ *                      (only required for tagged features, otherwise ignored)
  *
  * @return The associated data.
  */
-NIXAPI DataView retrieveFeatureData(const MultiTag &tag, ndsize_t position_index, const Feature &feature);
+NIXAPI DataView retrieveFeatureData(const MultiTag &tag, ndsize_t position_index, const Feature &feature, RangeMatch range_match = RangeMatch::Inclusive);
 
 
 /**
@@ -327,12 +338,14 @@ NIXAPI DataView retrieveFeatureData(const MultiTag &tag, ndsize_t position_index
  * @param tag              The MultiTag whos feature data is requested
  * @param position_indices A vector of position indices.
  * @param feature_index    The index of the desired feature. Default is 0.
- *
+ * @param range_match   Member of RangeMatch enum to control whether a 
+ *                      data range should include the last position or not
+ *                      (only required for tagged features, otherwise ignored)
+ * 
  * @return A vector of the associated data, may be empty.
  */
-NIXAPI std::vector<DataView> retrieveFeatureData(const MultiTag &tag,
-                                                 std::vector<ndsize_t> position_indices,
-                                                 ndsize_t feature_index = 0);
+NIXAPI std::vector<DataView> retrieveFeatureData(const MultiTag &tag, std::vector<ndsize_t> position_indices,
+                                                 ndsize_t feature_index = 0, RangeMatch range_match = RangeMatch::Inclusive);
 
 /**
  * @brief Returns the feature data associated with the given MuliTag's positions.
@@ -340,12 +353,14 @@ NIXAPI std::vector<DataView> retrieveFeatureData(const MultiTag &tag,
  * @param tag              The MultiTag whos feature data is requested.
  * @param position_indices A vector of position indices.
  * @param feature          The feature of which the tagged data is requested.
- *
+ * @param range_match   Member of RangeMatch enum to control whether a 
+ *                      data range should include the last position or not
+ *                      (only required for tagged features, otherwise ignored)
+ * 
  * @return A vector of the associated data, may be empty.
  */
-NIXAPI std::vector<DataView> retrieveFeatureData(const MultiTag &tag,
-                                                 std::vector<ndsize_t> position_indices,
-                                                 const Feature &feature);
+NIXAPI std::vector<DataView> retrieveFeatureData(const MultiTag &tag, std::vector<ndsize_t> position_indices,
+                                                 const Feature &feature, RangeMatch range_match = RangeMatch::Inclusive);
 
 } //namespace util
 } //namespace nix

--- a/include/nix/util/dataAccess.hpp
+++ b/include/nix/util/dataAccess.hpp
@@ -27,22 +27,23 @@ namespace nix {
 namespace util {
 
 /**
- * @brief Converts a position given in a unit into an index according to the dimension descriptor.
+ * @brief Converts a position to an index according to the dimension descriptor.
  *
  * This function can be used to get the index of e.g. a certain point in time in a Dimension that
- * represents time. The units of the position and that provided by the Dimension must match, i.e.
- * must be scalable versions of the same SI unit.
+ * represents time.
  *
  * @param position      The position
- * @param unit          The unit in which the position is given, may be "none"
- * @param dimension     The dimension descriptor for the respective dimension.
+ * @param match         Member of the PositionMatch enum to control the matching.
+ * @param dimension     The dimension descriptor for the respective dimension, i.e. a SetDimension.
  *
  * @return The calculated index.
  *
  * @throws nix::IncompatibleDimension The the dimensions are incompatible.
  * @throws nix::OutOfBounds If the position either too large or too small for the dimension.
  */
-NIXAPI ndsize_t positionToIndex(double position, const std::string &unit, const SetDimension &dimension);
+NIXAPI boost::optional<ndsize_t> positionToIndex(double position, const PositionMatch match, const SetDimension &dimension);
+
+NIXAPI DEPRECATED ndsize_t positionToIndex(double position, const std::string &unit, const SetDimension &dimension);
 
 /**
  * @brief Converts a position given in a unit into an index according to the dimension descriptor.
@@ -60,7 +61,9 @@ NIXAPI ndsize_t positionToIndex(double position, const std::string &unit, const 
  * @throws nix::IncompatibleDimension The the dimensions are incompatible.
  * @throws nix::OutOfBounds If the position either too large or too small for the dimension.
  */
-NIXAPI ndsize_t positionToIndex(double position, const std::string &unit, const SampledDimension &dimension);
+NIXAPI  boost::optional<ndsize_t> positionToIndex(double position, const std::string &unit, const PositionMatch match, const SampledDimension &dimension);
+
+NIXAPI  DEPRECATED ndsize_t positionToIndex(double position, const std::string &unit, const SampledDimension &dimension);
 
 /**
  * @brief Converts a position given in a unit into an index according to the dimension descriptor.
@@ -73,14 +76,16 @@ NIXAPI ndsize_t positionToIndex(double position, const std::string &unit, const 
  * @param unit          The unit in which the position is given, may be "none"
  * @param dimension     The dimension descriptor for the respective dimension.
  *
- * @return The calculated index.
+ * @return An optional containng the index.
  *
  * @throws nix::IncompatibleDimension The the dimensions are incompatible.
  * @throws nix::OutOfBounds If the position either too large or too small for the dimension.
  */
-NIXAPI ndsize_t positionToIndex(double position, const std::string &unit, const RangeDimension &dimension);
+NIXAPI boost::optional<ndsize_t> positionToIndex(double position, const std::string &unit, const PositionMatch position_match, const RangeDimension &dimension);
 
-/**
+NIXAPI DEPRECATED ndsize_t positionToIndex(double position, const std::string &unit, const RangeDimension &dimension);
+
+ /**
  * @brief Converts the passed vector of start and end positions in a unit into a vector of respective indices
  * according to the dimension descriptor.
  *
@@ -91,29 +96,56 @@ NIXAPI ndsize_t positionToIndex(double position, const std::string &unit, const 
  * @param positions     std::vector of positions
  * @param units         std::vector of units in which the respective position is given, must have the same size or may
  *                      be empty
+ * @param rangeMatching The desired range matching behavior see {@link Dimension::RangeMatch}.
  * @param dimension     The dimension descriptor for the respective dimension.
  *
  * @return The calculated indices.
  *
  * @throws nix::IncompatibleDimension The the dimensions are incompatible.
  * @throws nix::OutOfBounds If the position either too large or too small for the dimension.
+ */       
+NIXAPI std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> positionToIndex(const std::vector<double> &start_positions,
+                                                                                   const std::vector<double> &end_positions,
+                                                                                   const std::vector<std::string> &units,
+                                                                                   const RangeMatch rangeMatching,
+                                                                                   const SampledDimension &dimension);
+
+/**
+ * @deprecated this function has been deprecated see {@link nix::util::positionToIndex(const std::vector<double>&, const std::vector<double>&, const std::vector<std::string> &, const RangeMatch, const SampledDimension&)}
  */
-NIXAPI std::vector<std::pair<ndsize_t, ndsize_t>> positionToIndex(const std::vector<double> &start_positions,
-                                                                  const std::vector<double> &end_positions,
-                                                                  const std::vector<std::string> &units,
-                                                                  const SampledDimension &dimension);
+NIXAPI DEPRECATED std::vector<std::pair<ndsize_t, ndsize_t>> positionToIndex(const std::vector<double> &start_positions,
+                                                                             const std::vector<double> &end_positions,
+                                                                             const std::vector<std::string> &units,
+                                                                             const SampledDimension &dimension);
 
 
-NIXAPI std::vector<std::pair<ndsize_t, ndsize_t>> positionToIndex(const std::vector<double> &start_positions,
-                                                                  const std::vector<double> &end_positions,
-                                                                  const std::vector<std::string> &units,
-                                                                  const SetDimension &dimension);
+NIXAPI std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> positionToIndex(const std::vector<double> &start_positions,
+                                                                                   const std::vector<double> &end_positions,
+                                                                                   const RangeMatch rangeMatching,
+                                                                                   const SetDimension &dimension);
+
+/**
+ * @deprecated this function has been deprecated see {@link nix::util::positionToIndex(const std::vector<double>&, const std::vector<double>&, const std::vector<std::string> &, const RangeMatch, const SetDimension&)}
+ */
+NIXAPI DEPRECATED std::vector<std::pair<ndsize_t, ndsize_t>> positionToIndex(const std::vector<double> &start_positions,
+                                                                             const std::vector<double> &end_positions,
+                                                                             const std::vector<std::string> &units,
+                                                                             const SetDimension &dimension);
 
 
-NIXAPI std::vector<std::pair<ndsize_t, ndsize_t>> positionToIndex(const std::vector<double> &start_positions,
-                                                                  const std::vector<double> &end_positions,
-                                                                  const std::vector<std::string> &units,
-                                                                  const RangeDimension &dimension);
+NIXAPI std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> positionToIndex(const std::vector<double> &start_positions,
+                                                                                   const std::vector<double> &end_positions,
+                                                                                   const std::vector<std::string> &units,
+                                                                                   const RangeMatch rangeMatching,
+                                                                                   const RangeDimension &dimension);
+
+/**
+ * @deprecated this function has been deprecated see {@link nix::util::positionToIndex(const std::vector<double>&, const std::vector<double>&, const std::vector<std::string> &, const RangeMatch, const RangeDimension&)}
+ */
+NIXAPI DEPRECATED std::vector<std::pair<ndsize_t, ndsize_t>> positionToIndex(const std::vector<double> &start_positions,
+                                                                             const std::vector<double> &end_positions,
+                                                                             const std::vector<std::string> &units,
+                                                                             const RangeDimension &dimension);
 
 
 /**

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -414,7 +414,7 @@ boost::optional<ndsize_t> getIndex(const double position, std::vector<double> &t
             idx = 0;
         return idx;
     } else if (position > *prev(ticks.end())) {
-        if (matching == PositionMatch::Less || matching == PositionMatch::LessOrEqual) 
+        if (matching == PositionMatch::Less || matching == PositionMatch::LessOrEqual)
             idx =  prev(ticks.end()) - ticks.begin();
         return idx;
     }
@@ -467,10 +467,10 @@ boost::optional<std::pair<ndsize_t, ndsize_t>> RangeDimension::indexOf(double st
     if (start > end){
         std::swap(start, end);
     }
-    
+
     boost::optional<ndsize_t> si = getIndex(start, ticks, PositionMatch::GreaterOrEqual);
     if (!si) {
-        return range;  
+        return range;
     }
     PositionMatch endMatching = (match == RangeMatch::Inclusive) ? PositionMatch::LessOrEqual : PositionMatch::Less;
     boost::optional<ndsize_t> ei = getIndex(end, ticks, endMatching);
@@ -505,7 +505,7 @@ pair<ndsize_t, ndsize_t> RangeDimension::indexOf(const double start, const doubl
 
 std::vector<std::pair<ndsize_t, ndsize_t>> RangeDimension::indexOf(const std::vector<double> &start_positions,
                                                                    const std::vector<double> &end_positions,
-                                                                   RangeMatch match) const {
+                                                                   RangeMatch match, bool strict) const {
     if (start_positions.size() != end_positions.size()) {
         throw runtime_error("Dimension::IndexOf - Number of start and end positions must match!");
     }
@@ -516,6 +516,9 @@ std::vector<std::pair<ndsize_t, ndsize_t>> RangeDimension::indexOf(const std::ve
     for (size_t i = 0; i < start_positions.size(); ++i) {
         boost::optional<std::pair<ndsize_t, ndsize_t>> range;
         range = this->indexOf(start_positions[i], end_positions[i], std::move(ticks), match);
+        if (!range && strict) {
+            throw nix::OutOfBounds("RangeDimension::indexOf an invalid range occurred!");
+        }
         if (range) {
             indices.push_back(*range);
         }

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -424,7 +424,12 @@ ndsize_t getIndex(const double position, std::vector<double> &ticks, bool lower_
 
 ndsize_t RangeDimension::indexOf(const double position, bool less_or_equal) const {
     vector<double> ticks = this->ticks();
-    return getIndex(position, ticks, !less_or_equal);
+    PositionMatch matching = less_or_equal ? PositionMatch::LessOrEqual : PositionMatch::GreaterOrEqual;
+    boost::optional<ndsize_t> index = getIndex(position, ticks, matching);
+    if (index)
+        return *index;
+    else
+        throw nix::OutOfBounds("RangeDimension::indexOf: Position is out of bounds.");
 }
 
 

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -174,11 +174,11 @@ void SampledDimension::samplingInterval(double interval) {
 
 
 ndsize_t getSampledIndex(const double position, const double offset, const double sampling_interval) {
-    ndssize_t index = static_cast<ndssize_t>(round(( position - offset) / sampling_interval));
-    if (index < 0) {
-        throw nix::OutOfBounds("Position is out of bounds of this dimension!", 0);
+    if (position < offset) {
+        throw nix::OutOfBounds("Position is out of bounds of this dimension!", position);
     }
-    return static_cast<ndsize_t>(index);
+    ndssize_t index = static_cast<ndssize_t>(round(( position - offset) / sampling_interval));
+    return index;
 }
 
 
@@ -189,18 +189,28 @@ ndsize_t SampledDimension::indexOf(const double position) const {
 }
 
 
-std::pair<ndsize_t, ndsize_t> SampledDimension::indexOf(const double start, const double end) const {
+std::pair<ndsize_t, ndsize_t> SampledDimension::indexOf(const double start, const double end, RangeMatch match) const {
     double offset = backend()->offset() ? *(backend()->offset()) : 0.0;
     double sampling_interval = backend()->samplingInterval();
 
+    return indexOf(start, end, sampling_interval, offset, match);
+}
+
+
+std::pair<ndsize_t, ndsize_t> SampledDimension::indexOf(double start, double end, const double sampling_interval, 
+                                                        const double offset, RangeMatch match) const {
+    if (start > end) {
+        std::swap(start, end);
+    }
     ndsize_t si = getSampledIndex(start, offset, sampling_interval);
-    ndsize_t ei = getSampledIndex(end, offset, sampling_interval);
+    ndsize_t ei = getSampledIndex(end - (match == RangeMatch::Exclusive ? sampling_interval : 0.0), offset, sampling_interval);
     return std::pair<ndsize_t, ndsize_t>(si, ei);
 }
 
 
 std::vector<std::pair<ndsize_t, ndsize_t>> SampledDimension::indexOf(const std::vector<double> &start_positions,
-                                                                     const std::vector<double> &end_positions) const {
+                                                                     const std::vector<double> &end_positions, 
+                                                                     RangeMatch match) const {
     if (start_positions.size() != end_positions.size()) {
         throw runtime_error("Dimension::IndexOf - Number of start and end positions must match!");
     }
@@ -208,13 +218,12 @@ std::vector<std::pair<ndsize_t, ndsize_t>> SampledDimension::indexOf(const std::
     std::vector<std::pair<ndsize_t, ndsize_t>> indices;
     double offset = backend()->offset() ? *(backend()->offset()) : 0.0;
     double sampling_interval = backend()->samplingInterval();
-
     for (size_t i = 0; i < start_positions.size(); ++i) {
-        indices.emplace_back(getSampledIndex(start_positions[i], offset, sampling_interval),
-                             getSampledIndex(end_positions[i], offset, sampling_interval));
+        indices.push_back(indexOf(start_positions[i], end_positions[i], sampling_interval, offset, match));
     }
     return indices;
 }
+
 
 double SampledDimension::positionAt(const ndsize_t index) const {
 
@@ -509,7 +518,6 @@ std::vector<std::pair<ndsize_t, ndsize_t>> RangeDimension::indexOf(const std::ve
     std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> optionalIndices;
     optionalIndices = indexOf(start_positions, end_positions, match);
     std::vector<std::pair<ndsize_t, ndsize_t>> indices;
-
     for(auto o: optionalIndices) {
         if (o) {
             indices.push_back(*o);
@@ -528,17 +536,15 @@ std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> RangeDimension::inde
         throw runtime_error("Dimension::IndexOf - Number of start and end positions must match!");
     }
 
-    std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> indices(start_positions.size());
+    std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> indices;
     vector<double> ticks = this->ticks();
-    // add another overload that accepts a reference
     for (size_t i = 0; i < start_positions.size(); ++i) {
         boost::optional<std::pair<ndsize_t, ndsize_t>> range;
         range = this->indexOf(start_positions[i], end_positions[i], std::move(ticks), match);
-        indices.push_back(*range);
+        indices.push_back(range);
     }
     return indices;
 }
-
 
 
 vector<double> RangeDimension::axis(const ndsize_t count, const ndsize_t startIndex) const {

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -625,7 +625,7 @@ boost::optional<ndsize_t> RangeDimension::indexOf(const double position, Positio
 
 
 boost::optional<std::pair<ndsize_t, ndsize_t>> RangeDimension::indexOf(double start, double end,
-                                                                       std::vector<double> &&ticks,
+                                                                       std::vector<double> ticks,
                                                                        RangeMatch match) const {
     if (ticks.size() == 0) {
         ticks = this->ticks();
@@ -698,7 +698,7 @@ std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> RangeDimension::inde
     vector<double> ticks = this->ticks();
     for (size_t i = 0; i < start_positions.size(); ++i) {
         boost::optional<std::pair<ndsize_t, ndsize_t>> range;
-        range = this->indexOf(start_positions[i], end_positions[i], std::move(ticks), match);
+        range = this->indexOf(start_positions[i], end_positions[i], ticks, match);
         indices.push_back(range);
     }
     return indices;

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -175,7 +175,7 @@ void SampledDimension::samplingInterval(double interval) {
 
 ndsize_t getSampledIndex(const double position, const double offset, const double sampling_interval) {
     if (position < offset) {
-        throw nix::OutOfBounds("Position is out of bounds of this dimension!", position);
+        throw nix::OutOfBounds("SampledDimension::indexOf: Position is less than offset!", position);
     }
     ndssize_t index = static_cast<ndssize_t>(round(( position - offset) / sampling_interval));
     return index;
@@ -192,7 +192,6 @@ ndsize_t SampledDimension::indexOf(const double position) const {
 std::pair<ndsize_t, ndsize_t> SampledDimension::indexOf(const double start, const double end, RangeMatch match) const {
     double offset = backend()->offset() ? *(backend()->offset()) : 0.0;
     double sampling_interval = backend()->samplingInterval();
-
     return indexOf(start, end, sampling_interval, offset, match);
 }
 
@@ -201,6 +200,9 @@ std::pair<ndsize_t, ndsize_t> SampledDimension::indexOf(double start, double end
                                                         const double offset, RangeMatch match) const {
     if (start > end) {
         std::swap(start, end);
+    }
+    if (match == RangeMatch::Exclusive && end - start < sampling_interval/2) {
+        throw nix::OutOfBounds("SampledDimension::indexOf: An invalid range occured, difference of start and end is less than the sampling interval.");
     }
     ndsize_t si = getSampledIndex(start, offset, sampling_interval);
     ndsize_t ei = getSampledIndex(end - (match == RangeMatch::Exclusive ? sampling_interval : 0.0), offset, sampling_interval);

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -387,6 +387,23 @@ double RangeDimension::tickAt(const ndsize_t index) const {
     return ticks[idx];
 }
 
+
+PositionInRange RangeDimension::positionInRange(const double position) const {
+    PositionInRange result;
+    vector<double> ticks = this->ticks();
+    if (ticks.size() == 0) {
+        result = PositionInRange::NoRange;
+    } else if (position < *ticks.begin()) {
+        result = PositionInRange::Less;
+    } else if (position > *prev(ticks.end())) {
+        result = PositionInRange::Greater;
+    } else {
+        result = PositionInRange::InRange;
+    }
+    return result;
+}
+
+
 ndsize_t getIndex(const double position, std::vector<double> &ticks, bool lower_bound) {
     if (position < *ticks.begin()) {
         return 0;

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -468,6 +468,13 @@ boost::optional<ndsize_t> getIndex(const double position, std::vector<double> &t
 }
 
 
+boost::optional<ndsize_t> RangeDimension::indexOf(const double position, PositionMatch matching) const {
+    vector<double> ticks = this->ticks();
+    boost::optional<ndsize_t> index = getIndex(position, ticks, matching);
+    return index;
+}
+
+
 ndsize_t RangeDimension::indexOf(const double position, bool less_or_equal) const {
     vector<double> ticks = this->ticks();
     PositionMatch matching = less_or_equal ? PositionMatch::LessOrEqual : PositionMatch::GreaterOrEqual;

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -506,25 +506,26 @@ pair<ndsize_t, ndsize_t> RangeDimension::indexOf(const double start, const doubl
 std::vector<std::pair<ndsize_t, ndsize_t>> RangeDimension::indexOf(const std::vector<double> &start_positions,
                                                                    const std::vector<double> &end_positions,
                                                                    RangeMatch match, bool strict) const {
+
+
+std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> RangeDimension::indexOf(const std::vector<double> &start_positions,
+                                                                                    const std::vector<double> &end_positions,
+                                                                                    RangeMatch match) const {
     if (start_positions.size() != end_positions.size()) {
         throw runtime_error("Dimension::IndexOf - Number of start and end positions must match!");
     }
 
-    std::vector<std::pair<ndsize_t, ndsize_t>> indices;
+    std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> indices(start_positions.size());
     vector<double> ticks = this->ticks();
-
+    // add another overload that accepts a reference
     for (size_t i = 0; i < start_positions.size(); ++i) {
         boost::optional<std::pair<ndsize_t, ndsize_t>> range;
         range = this->indexOf(start_positions[i], end_positions[i], std::move(ticks), match);
-        if (!range && strict) {
-            throw nix::OutOfBounds("RangeDimension::indexOf an invalid range occurred!");
-        }
-        if (range) {
-            indices.push_back(*range);
-        }
+        indices.push_back(*range);
     }
     return indices;
 }
+
 
 
 vector<double> RangeDimension::axis(const ndsize_t count, const ndsize_t startIndex) const {

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -488,9 +488,12 @@ ndsize_t RangeDimension::indexOf(const double position, bool less_or_equal) cons
 
 pair<ndsize_t, ndsize_t> RangeDimension::indexOf(const double start, const double end) const {
     vector<double> ticks = this->ticks();
-    ndsize_t si = getIndex(start, ticks, true);
-    ndsize_t ei = getIndex(end, ticks, false);
-    return std::pair<ndsize_t, ndsize_t>(si, ei);
+    boost::optional<ndsize_t> si = getIndex(start, ticks, PositionMatch::GreaterOrEqual);
+    boost::optional<ndsize_t> ei = getIndex(end, ticks, PositionMatch::LessOrEqual);
+    if (!ei || !si) {
+        throw nix::OutOfBounds("RangeDimension::indexOf: start or end of range are out of Bounds!");
+    }
+    return std::pair<ndsize_t, ndsize_t>(*si, *ei);
 }
 
 

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -427,8 +427,9 @@ boost::optional<std::pair<ndsize_t, ndsize_t>> SetDimension::indexOf(double star
     
     boost::optional<ndsize_t> si = getSetIndex(start, set_labels, PositionMatch::GreaterOrEqual);
     boost::optional<ndsize_t> ei = getSetIndex(end, set_labels, end_match);
-    if (ei && si) {
-        index = std::pair<ndsize_t, ndsize_t>(*si, *ei);
+    
+    if (si && ei && *si <= *ei) {
+        index = std::pair<ndsize_t, ndsize_t>(*si, *ei);    
     }
     return index;
 }
@@ -439,6 +440,21 @@ boost::optional<std::pair<ndsize_t, ndsize_t>> SetDimension::indexOf(const doubl
     return indexOf(start, end, set_labels, match);
 }
 
+
+std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> SetDimension::indexOf(const std::vector<double> &start_positions,
+                                                                                  const std::vector<double> &end_positions,
+                                                                                  const RangeMatch match) const {
+    if (start_positions.size() != end_positions.size()) {
+        throw runtime_error("Dimension::IndexOf - Number of start and end positions must match!");
+    }
+
+    std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> indices;
+    std::vector<std::string> set_labels = labels();
+    for (size_t i = 0; i < start_positions.size(); ++i) {
+        indices.push_back(indexOf(start_positions[i], end_positions[i], set_labels, match));
+    }
+    return indices;
+}
 
 
 SetDimension& SetDimension::operator=(const SetDimension &other) {

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -239,15 +239,16 @@ boost::optional<std::pair<ndsize_t, ndsize_t>> SampledDimension::indexOf(const d
 
 boost::optional<std::pair<ndsize_t, ndsize_t>> SampledDimension::indexOf(double start, double end, const double sampling_interval, 
                                                                          const double offset, const RangeMatch match) const {
-    if (start > end) {
-        std::swap(start, end);
-    }
+    boost::optional<std::pair<ndsize_t, ndsize_t>> indices;
     PositionMatch pos_match = match == RangeMatch::Inclusive ? PositionMatch::LessOrEqual : PositionMatch::Less;
+    
+    if (start > end) {
+        return indices;
+    }
 
     boost::optional<ndsize_t> si = getSampledIndex(start, offset, sampling_interval, PositionMatch::GreaterOrEqual);
     boost::optional<ndsize_t> ei = getSampledIndex(end, offset, sampling_interval, pos_match);
     
-    boost::optional<std::pair<ndsize_t, ndsize_t>> indices;
     if (si && ei && *si <= *ei) {
         indices = std::pair<ndsize_t, ndsize_t>(*si, *ei);
     }
@@ -405,7 +406,6 @@ boost::optional<ndsize_t> getSetIndex(const double position, std::vector<std::st
         }
     }
     return index;
-
 }
 
 
@@ -419,11 +419,12 @@ boost::optional<std::pair<ndsize_t, ndsize_t>> SetDimension::indexOf(double star
     if (set_labels.size() == 0) {
         set_labels = labels();
     } 
-    if (start > end) {
-        std::swap(start, end);
-    }
-    PositionMatch end_match = match == RangeMatch::Inclusive ? PositionMatch::LessOrEqual : PositionMatch::Less;
+    
     boost::optional<std::pair<ndsize_t, ndsize_t>> index;
+    PositionMatch end_match = match == RangeMatch::Inclusive ? PositionMatch::LessOrEqual : PositionMatch::Less;
+    if (start > end) {
+        return index;
+    }
     
     boost::optional<ndsize_t> si = getSetIndex(start, set_labels, PositionMatch::GreaterOrEqual);
     boost::optional<ndsize_t> ei = getSetIndex(end, set_labels, end_match);

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -371,6 +371,47 @@ SetDimension::SetDimension(const SetDimension &other)
 {
 }
 
+boost::optional<ndsize_t> SetDimension::indexOf(const double position, const PositionMatch match) const {
+    boost::optional<ndsize_t> index;
+    if (position < 0 && (match != PositionMatch::Greater && match != PositionMatch::GreaterOrEqual)) {
+        return index;
+    }
+    double tmp;
+    if (match == PositionMatch::Greater || match == PositionMatch::GreaterOrEqual) {
+        tmp = ceil(position);
+        if (tmp < 0.0) {
+            tmp = 0.0;
+        }
+        bool equals = fabs(tmp - position) <= numeric_limits<double>::epsilon();
+        index = (match == PositionMatch::Greater && equals) ? static_cast<ndsize_t>(tmp + 1) : static_cast<ndsize_t>(tmp);
+    } else if (match == PositionMatch::Less || match == PositionMatch::LessOrEqual) {
+        tmp = floor(position);
+        bool equals = fabs(tmp - position) <= numeric_limits<double>::epsilon();
+        if (match == PositionMatch::Less && equals) { 
+            if (tmp >= 1) {
+                index = static_cast<ndsize_t>(tmp - 1);
+            } 
+        } else {
+            index = static_cast<ndsize_t>(tmp);
+        }
+    } else {
+        tmp = round(position);
+        if (fabs(tmp - position) <= numeric_limits<double>::epsilon()) {
+            index = static_cast<ndsize_t>(tmp);
+        }
+    }
+
+    ndsize_t label_count = labels().size();
+    if (index && label_count > 0 && *index > label_count - 1) {
+        if (match == PositionMatch::Less || match == PositionMatch::LessOrEqual) {
+            index = label_count - 1;
+        } else {
+            index = boost::none;
+        }
+    }
+    return index;
+}
+
 
 SetDimension& SetDimension::operator=(const SetDimension &other) {
     shared_ptr<ISetDimension> tmp(other.impl());

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -458,7 +458,7 @@ boost::optional<ndsize_t> RangeDimension::indexOf(const double position, Positio
 
 
 boost::optional<std::pair<ndsize_t, ndsize_t>> RangeDimension::indexOf(double start, double end,
-                                                                       std::vector<double> ticks,
+                                                                       std::vector<double> &&ticks,
                                                                        RangeMatch match) const {
     if (ticks.size() == 0) {
         ticks = this->ticks();
@@ -515,7 +515,7 @@ std::vector<std::pair<ndsize_t, ndsize_t>> RangeDimension::indexOf(const std::ve
 
     for (size_t i = 0; i < start_positions.size(); ++i) {
         boost::optional<std::pair<ndsize_t, ndsize_t>> range;
-        range = this->indexOf(start_positions[i], end_positions[i], ticks, match);
+        range = this->indexOf(start_positions[i], end_positions[i], std::move(ticks), match);
         if (range) {
             indices.push_back(*range);
         }

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -404,7 +404,6 @@ PositionInRange RangeDimension::positionInRange(const double position) const {
 }
 
 
-    return index;
 boost::optional<ndsize_t> getIndex(const double position, std::vector<double> &ticks, PositionMatch matching) {
     boost::optional<ndsize_t> idx;
     // check easy cases first ...
@@ -505,7 +504,8 @@ pair<ndsize_t, ndsize_t> RangeDimension::indexOf(const double start, const doubl
 
 
 std::vector<std::pair<ndsize_t, ndsize_t>> RangeDimension::indexOf(const std::vector<double> &start_positions,
-                                                                   const std::vector<double> &end_positions) const {
+                                                                   const std::vector<double> &end_positions,
+                                                                   RangeMatch match) const {
     if (start_positions.size() != end_positions.size()) {
         throw runtime_error("Dimension::IndexOf - Number of start and end positions must match!");
     }
@@ -514,8 +514,11 @@ std::vector<std::pair<ndsize_t, ndsize_t>> RangeDimension::indexOf(const std::ve
     vector<double> ticks = this->ticks();
 
     for (size_t i = 0; i < start_positions.size(); ++i) {
-        indices.emplace_back(getIndex(start_positions[i], ticks, true),
-                             getIndex(end_positions[i], ticks, false));
+        boost::optional<std::pair<ndsize_t, ndsize_t>> range;
+        range = this->indexOf(start_positions[i], end_positions[i], ticks, match);
+        if (range) {
+            indices.push_back(*range);
+        }
     }
     return indices;
 }

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -371,7 +371,8 @@ SetDimension::SetDimension(const SetDimension &other)
 {
 }
 
-boost::optional<ndsize_t> SetDimension::indexOf(const double position, const PositionMatch match) const {
+
+boost::optional<ndsize_t> getSetIndex(const double position, std::vector<std::string> labels, const PositionMatch match) {
     boost::optional<ndsize_t> index;
     if (position < 0 && (match != PositionMatch::Greater && match != PositionMatch::GreaterOrEqual)) {
         return index;
@@ -401,7 +402,7 @@ boost::optional<ndsize_t> SetDimension::indexOf(const double position, const Pos
         }
     }
 
-    ndsize_t label_count = labels().size();
+    ndsize_t label_count = labels.size();
     if (index && label_count > 0 && *index > label_count - 1) {
         if (match == PositionMatch::Less || match == PositionMatch::LessOrEqual) {
             index = label_count - 1;
@@ -410,7 +411,40 @@ boost::optional<ndsize_t> SetDimension::indexOf(const double position, const Pos
         }
     }
     return index;
+
 }
+
+
+boost::optional<ndsize_t> SetDimension::indexOf(const double position, const PositionMatch match) const {
+    std::vector<std::string> lbls = labels();
+    return getSetIndex(position, lbls, match);
+}
+
+
+boost::optional<std::pair<ndsize_t, ndsize_t>> SetDimension::indexOf(double start, double end, std::vector<std::string> &set_labels, const RangeMatch match) const {
+    if (set_labels.size() == 0) {
+        set_labels = labels();
+    } 
+    if (start > end) {
+        std::swap(start, end);
+    }
+    PositionMatch end_match = match == RangeMatch::Inclusive ? PositionMatch::LessOrEqual : PositionMatch::Less;
+    boost::optional<std::pair<ndsize_t, ndsize_t>> index;
+    
+    boost::optional<ndsize_t> si = getSetIndex(start, set_labels, PositionMatch::GreaterOrEqual);
+    boost::optional<ndsize_t> ei = getSetIndex(end, set_labels, end_match);
+    if (ei && si) {
+        index = std::pair<ndsize_t, ndsize_t>(*si, *ei);
+    }
+    return index;
+}
+
+
+boost::optional<std::pair<ndsize_t, ndsize_t>> SetDimension::indexOf(const double start, const double end, const RangeMatch match) const {
+    std::vector<std::string> set_labels = labels();
+    return indexOf(start, end, set_labels, match);
+}
+
 
 
 SetDimension& SetDimension::operator=(const SetDimension &other) {

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -173,46 +173,112 @@ void SampledDimension::samplingInterval(double interval) {
 }
 
 
-ndsize_t getSampledIndex(const double position, const double offset, const double sampling_interval) {
-    if (position < offset) {
-        throw nix::OutOfBounds("SampledDimension::indexOf: Position is less than offset!", position);
+boost::optional<ndsize_t> getSampledIndex(const double position, const double offset, const double sampling_interval, const PositionMatch match) {
+    boost::optional<ndsize_t> index;
+    if (position < offset && (match != PositionMatch::Greater && match != PositionMatch::GreaterOrEqual)) {
+        return index;
     }
-    ndssize_t index = static_cast<ndssize_t>(round(( position - offset) / sampling_interval));
+    double tmp;
+    if (match == PositionMatch::Greater || match == PositionMatch::GreaterOrEqual) {
+        tmp = ceil((position - offset) / sampling_interval);
+        if (tmp < 0.0) {
+            tmp = 0.0;
+        }
+        bool equals = fabs(tmp * sampling_interval + offset - position) <= numeric_limits<double>::epsilon();
+        index = (match == PositionMatch::Greater && equals) ? static_cast<ndsize_t>(tmp + 1) : static_cast<ndsize_t>(tmp);
+    } else if (match == PositionMatch::Less || match == PositionMatch::LessOrEqual) {
+        tmp = floor((position - offset) / sampling_interval);
+        bool equals = fabs(tmp * sampling_interval + offset - position) <= numeric_limits<double>::epsilon();
+        if (match == PositionMatch::Less && equals) { 
+            if (tmp >= 1) {
+                index = static_cast<ndsize_t>(tmp - 1);
+            } 
+        } else {
+            index = static_cast<ndsize_t>(tmp);
+        }
+    } else {
+        tmp = round((position - offset) / sampling_interval);
+        if (fabs(tmp * sampling_interval + offset - position) <= numeric_limits<double>::epsilon()) {
+            index = static_cast<ndsize_t>(tmp);
+        }
+    }
     return index;
 }
 
 
 ndsize_t SampledDimension::indexOf(const double position) const {
+    boost::optional<ndsize_t> index = indexOf(position, PositionMatch::GreaterOrEqual);
+    if (!index) {
+        throw nix::OutOfBounds("SampledDimension::indexOf: An invalid position was encountered! position < offset?");
+    }
+    return *index;   
+}
+
+boost::optional<ndsize_t> SampledDimension::indexOf(const double position, const PositionMatch match) const {
     double offset = backend()->offset() ? *(backend()->offset()) : 0.0;
     double sampling_interval = backend()->samplingInterval();
-    return getSampledIndex(position, offset, sampling_interval);
+    boost::optional<ndsize_t> index = getSampledIndex(position, offset, sampling_interval, match);
+    return index;
 }
 
 
-std::pair<ndsize_t, ndsize_t> SampledDimension::indexOf(const double start, const double end, RangeMatch match) const {
+std::pair<ndsize_t, ndsize_t> SampledDimension::indexOf(const double start, const double end) const {
+    boost::optional<std::pair<ndsize_t, ndsize_t>> pair = indexOf(start, end, RangeMatch::Inclusive);
+    if (!pair) {
+        throw nix::OutOfBounds("SampledDimension::indexOf: An invalid range was encountered!");
+    }
+    return *pair;
+}
+
+boost::optional<std::pair<ndsize_t, ndsize_t>> SampledDimension::indexOf(const double start, const double end, const RangeMatch range_matching) const {
     double offset = backend()->offset() ? *(backend()->offset()) : 0.0;
     double sampling_interval = backend()->samplingInterval();
-    return indexOf(start, end, sampling_interval, offset, match);
+    return indexOf(start, end, sampling_interval, offset, range_matching);
 }
 
 
-std::pair<ndsize_t, ndsize_t> SampledDimension::indexOf(double start, double end, const double sampling_interval, 
-                                                        const double offset, RangeMatch match) const {
+boost::optional<std::pair<ndsize_t, ndsize_t>> SampledDimension::indexOf(double start, double end, const double sampling_interval, 
+                                                                         const double offset, const RangeMatch match) const {
     if (start > end) {
         std::swap(start, end);
     }
-    if (match == RangeMatch::Exclusive && end - start < sampling_interval/2) {
-        throw nix::OutOfBounds("SampledDimension::indexOf: An invalid range occured, difference of start and end is less than the sampling interval.");
+    PositionMatch pos_match = match == RangeMatch::Inclusive ? PositionMatch::LessOrEqual : PositionMatch::Less;
+
+    boost::optional<ndsize_t> si = getSampledIndex(start, offset, sampling_interval, PositionMatch::GreaterOrEqual);
+    boost::optional<ndsize_t> ei = getSampledIndex(end, offset, sampling_interval, pos_match);
+    
+    boost::optional<std::pair<ndsize_t, ndsize_t>> indices;
+    if (si && ei) {
+        if (*si <= *ei) {
+            if (match == RangeMatch::Exclusive && *si < *ei) {
+                indices = std::pair<ndsize_t, ndsize_t>(*si, *ei);
+            } else if (match == RangeMatch::Inclusive) {
+                indices = std::pair<ndsize_t, ndsize_t>(*si, *ei);
+            }
+        }
     }
-    ndsize_t si = getSampledIndex(start, offset, sampling_interval);
-    ndsize_t ei = getSampledIndex(end - (match == RangeMatch::Exclusive ? sampling_interval : 0.0), offset, sampling_interval);
-    return std::pair<ndsize_t, ndsize_t>(si, ei);
+    return indices;
 }
 
 
+std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> SampledDimension::indexOf(const std::vector<double> &start_positions,
+                                                                                      const std::vector<double> &end_positions,
+                                                                                      const RangeMatch range_matching) const {
+    if (start_positions.size() != end_positions.size()) {
+        throw runtime_error("Dimension::IndexOf - Number of start and end positions must match!");
+    }
+
+    std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> indices;
+    double offset = backend()->offset() ? *(backend()->offset()) : 0.0;
+    double sampling_interval = backend()->samplingInterval();
+    for (size_t i = 0; i < start_positions.size(); ++i) {
+        indices.push_back(indexOf(start_positions[i], end_positions[i], sampling_interval, offset, range_matching));
+    }
+    return indices;
+}
+
 std::vector<std::pair<ndsize_t, ndsize_t>> SampledDimension::indexOf(const std::vector<double> &start_positions,
-                                                                     const std::vector<double> &end_positions, 
-                                                                     RangeMatch match) const {
+                                                                     const std::vector<double> &end_positions) const {
     if (start_positions.size() != end_positions.size()) {
         throw runtime_error("Dimension::IndexOf - Number of start and end positions must match!");
     }
@@ -220,8 +286,13 @@ std::vector<std::pair<ndsize_t, ndsize_t>> SampledDimension::indexOf(const std::
     std::vector<std::pair<ndsize_t, ndsize_t>> indices;
     double offset = backend()->offset() ? *(backend()->offset()) : 0.0;
     double sampling_interval = backend()->samplingInterval();
+    boost::optional<std::pair<ndsize_t, ndsize_t>> pair;
     for (size_t i = 0; i < start_positions.size(); ++i) {
-        indices.push_back(indexOf(start_positions[i], end_positions[i], sampling_interval, offset, match));
+        pair = indexOf(start_positions[i], end_positions[i], sampling_interval, offset, RangeMatch::Inclusive);
+        if (!pair) {
+            throw nix::OutOfBounds("SampledDimension::indexOf: an invalid range was encountered");
+        }
+        indices.push_back(*pair);
     }
     return indices;
 }

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -505,7 +505,20 @@ pair<ndsize_t, ndsize_t> RangeDimension::indexOf(const double start, const doubl
 
 std::vector<std::pair<ndsize_t, ndsize_t>> RangeDimension::indexOf(const std::vector<double> &start_positions,
                                                                    const std::vector<double> &end_positions,
-                                                                   RangeMatch match, bool strict) const {
+                                                                   bool strict, RangeMatch match) const {
+    std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> optionalIndices;
+    optionalIndices = indexOf(start_positions, end_positions, match);
+    std::vector<std::pair<ndsize_t, ndsize_t>> indices;
+
+    for(auto o: optionalIndices) {
+        if (o) {
+            indices.push_back(*o);
+        } else if(strict) {
+            throw nix::OutOfBounds("RangeDimension::indexOf: an invalid range was encountered.");
+        }
+    }
+    return indices;
+}
 
 
 std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> RangeDimension::indexOf(const std::vector<double> &start_positions,

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -248,14 +248,8 @@ boost::optional<std::pair<ndsize_t, ndsize_t>> SampledDimension::indexOf(double 
     boost::optional<ndsize_t> ei = getSampledIndex(end, offset, sampling_interval, pos_match);
     
     boost::optional<std::pair<ndsize_t, ndsize_t>> indices;
-    if (si && ei) {
-        if (*si <= *ei) {
-            if (match == RangeMatch::Exclusive && *si < *ei) {
-                indices = std::pair<ndsize_t, ndsize_t>(*si, *ei);
-            } else if (match == RangeMatch::Inclusive) {
-                indices = std::pair<ndsize_t, ndsize_t>(*si, *ei);
-            }
-        }
+    if (si && ei && *si <= *ei) {
+        indices = std::pair<ndsize_t, ndsize_t>(*si, *ei);
     }
     return indices;
 }

--- a/src/util/dataAccess.cpp
+++ b/src/util/dataAccess.cpp
@@ -20,6 +20,7 @@
 #include <boost/optional.hpp>
 
 using namespace std;
+using namespace boost;
 
 namespace nix {
 namespace util {
@@ -49,82 +50,44 @@ void scalePositions(const vector<double> &starts, const vector<double> &ends,
 }
 
 
-ndsize_t positionToIndex(double position, const string &unit, const Dimension &dimension) {
-    ndsize_t pos;
+
+
+vector<optional<pair<ndsize_t, ndsize_t>>> positionToIndex(const vector<double> &start_positions,
+                                                           const vector<double> &end_positions,
+                                                           const vector<string> &units,
+                                                           const RangeMatch range_matching,
+                                                           const Dimension &dimension) {
+    vector<optional<pair<ndsize_t, ndsize_t>>> indices;
     if (dimension.dimensionType() == DimensionType::Sample) {
         SampledDimension dim;
         dim = dimension;
-        pos = positionToIndex(position, unit, dim);
+        indices = positionToIndex(start_positions, end_positions, units, range_matching, dim);
     } else if (dimension.dimensionType() == DimensionType::Set) {
         SetDimension dim;
         dim = dimension;
-        pos = positionToIndex(position, unit, dim);
+        indices = positionToIndex(start_positions, end_positions, range_matching, dim);
     } else {
         RangeDimension dim;
         dim = dimension;
-        pos = positionToIndex(position, unit, dim);
+        indices = positionToIndex(start_positions, end_positions, units, range_matching, dim);
     }
-
-    return pos;
+    return indices;
 }
-
 
 vector<pair<ndsize_t, ndsize_t>> positionToIndex(const vector<double> &start_positions,
                                                  const vector<double> end_positions,
                                                  const vector<string> &units,
                                                  const Dimension &dimension) {
+    vector<optional<pair<ndsize_t, ndsize_t>>> opt_indices = positionToIndex(start_positions, end_positions, units, RangeMatch::Inclusive, dimension);
     vector<pair<ndsize_t, ndsize_t>> indices;
-    if (dimension.dimensionType() == DimensionType::Sample) {
-        SampledDimension dim;
-        dim = dimension;
-        indices = positionToIndex(start_positions, end_positions, units, dim);
-    } else if (dimension.dimensionType() == DimensionType::Set) {
-        SetDimension dim;
-        dim = dimension;
-        indices = positionToIndex(start_positions, end_positions, units, dim);
-    } else {
-        RangeDimension dim;
-        dim = dimension;
-        indices = positionToIndex(start_positions, end_positions, units, dim);
-    }
-    return indices;
-}
-
-
-ndsize_t positionToIndex(double position, const string &unit, const SampledDimension &dimension) {
-    ndsize_t index;
-    boost::optional<string> dim_unit = dimension.unit();
-    double scaling = 1.0;
-    if (!dim_unit && unit != "none") {
-        throw IncompatibleDimensions("Units of position and SampledDimension must both be given!",
-                                     "util::positionToIndex");
-    }
-    if (dim_unit && unit != "none") {
-        try {
-            scaling = util::getSIScaling(unit, *dim_unit);
-        } catch (...) {
-            throw IncompatibleDimensions("Cannot apply a position with unit to a SetDimension",
-                                         "nix::util::positionToIndex");
+    for (auto o : opt_indices) {
+        if (o) {
+            indices.push_back(*o);
+        } else {
+            throw nix::OutOfBounds("util::positionToIndex: An invalid range was encountered!");
         }
     }
-    index = dimension.indexOf(position * scaling);
-    return index;
-}
-
-
-ndsize_t positionToIndex(double position, const string &unit, const SetDimension &dimension) {
-    ndsize_t index;
-    if (unit.length() > 0 && unit != "none") {
-        // TODO check here for the content
-        // convert unit and the go looking for it, see range dimension
-        throw IncompatibleDimensions("Cannot apply a position with unit to a SetDimension",
-                                     "nix::util::positionToIndex");
-    }
-    index = static_cast<ndsize_t>(round(position));
-    if (dimension.labels().size() > 0 && index > dimension.labels().size()) {
-        throw OutOfBounds("Position is out of bounds in setDimension.", static_cast<int>(position));
-    }
-    return index;
+    return indices;
 }
 
 
@@ -132,28 +95,76 @@ vector<pair<ndsize_t, ndsize_t>> positionToIndex(const vector<double> &start_pos
                                                  const vector<double> &end_positions,
                                                  const vector<string> &units,
                                                  const SampledDimension &dimension) {
-    ndsize_t count = min(start_positions.size(), end_positions.size());
+    vector<optional<pair<ndsize_t, ndsize_t>>> opt_ranges = positionToIndex(start_positions, end_positions, units, RangeMatch::Inclusive, dimension);
+    vector<pair<ndsize_t, ndsize_t>> ranges;
+    for (auto o : opt_ranges) {
+        if (o) {
+            ranges.push_back(*o);
+        } else {
+            throw nix::OutOfBounds("utial::positionToIndex: An invalid range was encountered!");
+        }
+    }
+    return ranges;
+}
+
+vector<optional<pair<ndsize_t, ndsize_t>>> positionToIndex(const vector<double> &start_positions,
+                                                           const vector<double> &end_positions,
+                                                           const vector<string> &units,
+                                                           const RangeMatch range_matching,
+                                                           const SampledDimension &dimension) {
+    if (start_positions.size() != end_positions.size() || start_positions.size() != units.size() ) {
+        throw std::runtime_error("util::positionToIndex: Invalid numbers of start and end positions, or units!");
+    }
+    ndsize_t count = end_positions.size();
     vector<double> scaled_start(static_cast<size_t>(count));
     vector<double> scaled_end(static_cast<size_t>(count));
     string dim_unit = dimension.unit() ? *dimension.unit() : "none";
     scalePositions(start_positions, end_positions, units, dim_unit, scaled_start, scaled_end);
-    return dimension.indexOf(scaled_start, scaled_end);
+    return dimension.indexOf(scaled_start, scaled_end, range_matching);
 }
 
+
+vector<optional<pair<ndsize_t, ndsize_t>>> positionToIndex(const vector<double> &start_positions,
+                                                           const vector<double> &end_positions,
+                                                           const RangeMatch range_matching,
+                                                           const SetDimension &dimension) {
+    if (start_positions.size() != end_positions.size()) {
+        throw std::runtime_error("util::positionToIndex: Invalid numbers of start and end positions!");
+    }
+    vector<optional<pair<ndsize_t, ndsize_t>>> indices = dimension.indexOf(start_positions, end_positions, range_matching);
+    return indices;
+}
 
 vector<pair<ndsize_t, ndsize_t>> positionToIndex(const vector<double> &start_positions,
                                                  const vector<double> &end_positions,
                                                  const vector<string> &units,
                                                  const SetDimension &dimension) {
     vector<pair<ndsize_t, ndsize_t>> indices;
-    for (size_t i = 0; i < (min(start_positions.size(), end_positions.size())); ++i) {
-        if (start_positions[i] > end_positions[i] ) {
-            continue;
+    vector<optional<pair<ndsize_t, ndsize_t>>> opt_indices = positionToIndex(start_positions, end_positions, RangeMatch::Inclusive, dimension);
+    for (auto o : opt_indices) {
+        if (!o) {
+            throw nix::OutOfBounds("util::positionToIndex: An invalid range was encountered!");
         }
-        indices.emplace_back(static_cast<ndsize_t>(round(start_positions[i])),
-                             static_cast<ndsize_t>(end_positions[i]));
+        indices.push_back(*o);
     }
-    return indices;
+    return indices; 
+}
+
+
+vector<optional<pair<ndsize_t, ndsize_t>>> positionToIndex(const vector<double> &start_positions,
+                                                           const vector<double> &end_positions,
+                                                           const vector<string> &units,
+                                                           const RangeMatch range_matching,
+                                                           const RangeDimension &dimension) {
+    if (start_positions.size() != end_positions.size() || start_positions.size() != units.size() ) {
+        throw std::runtime_error("util::positionToIndex: Invalid numbers of start and end positions, or units!");
+    }
+    size_t count = end_positions.size();
+    vector<double> scaled_start(count);
+    vector<double> scaled_end(count);
+    string dim_unit = dimension.unit() ? *dimension.unit() : "none";
+    scalePositions(start_positions, end_positions, units, dim_unit, scaled_start, scaled_end);
+    return dimension.indexOf(scaled_start, scaled_end, range_matching);
 }
 
 
@@ -161,16 +172,113 @@ vector<pair<ndsize_t, ndsize_t>> positionToIndex(const vector<double> &start_pos
                                                  const vector<double> &end_positions,
                                                  const vector<string> &units,
                                                  const RangeDimension &dimension) {
-    size_t count = min(start_positions.size(), end_positions.size());
-    vector<double> scaled_start(count);
-    vector<double> scaled_end(count);
-    string dim_unit = dimension.unit() ? *dimension.unit() : "none";
-    scalePositions(start_positions, end_positions, units, dim_unit, scaled_start, scaled_end);
-    return dimension.indexOf(scaled_start, scaled_end);
+    vector<optional<pair<ndsize_t, ndsize_t>>> opt_ranges = positionToIndex(start_positions, end_positions, units, RangeMatch::Inclusive, dimension);
+    vector<pair<ndsize_t, ndsize_t>> ranges;
+    for (auto o : opt_ranges) {
+        if (o) {
+            ranges.push_back(*o);
+        } else {
+            throw nix::OutOfBounds("utial::positionToIndex: An invalid range was encountered!");
+        }
+    }
+    return ranges;
+}
+
+
+optional<ndsize_t> positionToIndex(double position, const string &unit, const PositionMatch match, const Dimension &dimension) {
+    optional<ndsize_t> pos;
+    if (dimension.dimensionType() == DimensionType::Sample) {
+        SampledDimension dim;
+        dim = dimension;
+        pos = positionToIndex(position, unit, match, dim);
+    } else if (dimension.dimensionType() == DimensionType::Set) {
+        SetDimension dim;
+        dim = dimension;
+        pos = positionToIndex(position, unit, match, dim);
+    } else {
+        RangeDimension dim;
+        dim = dimension;
+        pos = positionToIndex(position, unit, match, dim);
+    }
+
+    return pos;
+}
+
+ndsize_t positionToIndex(double position, const string &unit, const Dimension &dimension) {
+    boost::optional<ndsize_t> pos;
+
+    if (dimension.dimensionType() == DimensionType::Sample) {
+        SampledDimension dim;
+        dim = dimension;
+        pos = positionToIndex(position, unit, PositionMatch::GreaterOrEqual, dim);
+    } else if (dimension.dimensionType() == DimensionType::Set) {
+        SetDimension dim;
+        dim = dimension;
+        pos = positionToIndex(position, unit, PositionMatch::GreaterOrEqual, dim);
+    } else {
+        RangeDimension dim;
+        dim = dimension;
+        pos = positionToIndex(position, unit, PositionMatch::GreaterOrEqual, dim);
+    }
+    if (!pos) {
+        throw nix::OutOfBounds("util::positionToIndex: Out of range position was given.");
+    }
+    return *pos;
+}
+
+ndsize_t positionToIndex(double position, const string &unit, const SampledDimension &dimension) {
+    optional<ndsize_t> index = positionToIndex(position, unit, PositionMatch::GreaterOrEqual, dimension);
+    if (!index) {
+        throw nix::OutOfBounds("util::positionToIndex: An invalid position was encoutered!");
+    }
+    return *index;
+}
+
+optional<ndsize_t> positionToIndex(double position, const string &unit, const PositionMatch match, const SampledDimension &dimension) {
+    optional<ndsize_t> index;
+    boost::optional<string> dim_unit = dimension.unit();
+    double scaling = 1.0;
+    if (!dim_unit && unit != "none") {
+        throw IncompatibleDimensions("Position is given with a unit, the dimension has none!",
+                                     "util::positionToIndex");
+    }
+    if (dim_unit && unit != "none") {
+        try {
+            scaling = util::getSIScaling(unit, *dim_unit);
+        } catch (...) {
+            throw IncompatibleDimensions("The unit provided for position is not applicable to the unit of the SampledDimension",
+                                         "nix::util::positionToIndex");
+        }
+    }
+    index = dimension.indexOf(position * scaling, match);
+    return index;
+}
+
+
+ndsize_t positionToIndex(double position, const string &unit, const SetDimension &dimension) {
+    optional<ndsize_t> index = positionToIndex(position, PositionMatch::GreaterOrEqual, dimension);
+    if (!index) {
+        throw nix::OutOfBounds("util::positionToIndex: An invalid position was encoutered!");
+    }
+
+    return *index;
+}
+
+optional<ndsize_t> positionToIndex(double position, const PositionMatch match, const SetDimension &dimension) {
+    optional<ndsize_t> index = dimension.indexOf(position, match);
+    return index;
 }
 
 
 ndsize_t positionToIndex(double position, const string &unit, const RangeDimension &dimension) {
+    boost::optional<ndsize_t> index = positionToIndex(position, unit, PositionMatch::GreaterOrEqual, dimension);
+    if (!index) {
+        throw nix::OutOfBounds("PositionToIndex: An invalid index was encountered");
+    }
+    return *index;
+}
+
+boost::optional<ndsize_t> positionToIndex(double position, const string &unit, const PositionMatch position_match, const RangeDimension &dimension) {
     string dim_unit = dimension.unit() ? *dimension.unit() : "none";
     double scaling = 1.0;
     if (unit != "none") {
@@ -181,7 +289,8 @@ ndsize_t positionToIndex(double position, const string &unit, const RangeDimensi
                                          "nix::util::positionToIndex");
         }
     }
-    return dimension.indexOf(position * scaling);
+    boost::optional<ndsize_t> index = dimension.indexOf(position * scaling, position_match);
+    return index;
 }
 
 

--- a/test/BaseTestDataAccess.cpp
+++ b/test/BaseTestDataAccess.cpp
@@ -115,13 +115,13 @@ void BaseTestDataAccess::testPositionToIndexSampledDimension() {
     CPPUNIT_ASSERT_THROW(util::positionToIndex(1.0, unit, sampledDim), nix::IncompatibleDimensions);
     sampledDim.unit(unit);
 
-    vector<optional<pair<ndsize_t, ndsize_t>>> ranges = util::positionToIndex({0.0, 2.0, 10.0}, {10.0, 2.0, 5.0}, {unit, unit, unit}, RangeMatch::Inclusive, sampledDim);
+    vector<optional<pair<ndsize_t, ndsize_t>>> ranges = util::positionToIndex({0.0, 2.0, 5.0}, {10.0, 2.0, 10.0}, {unit, unit, unit}, RangeMatch::Inclusive, sampledDim);
     CPPUNIT_ASSERT(ranges.size() == 3);
     CPPUNIT_ASSERT(ranges[0] && (*ranges[0]).first == 0 && (*ranges[0]).second == 10);
     CPPUNIT_ASSERT(ranges[1] && (*ranges[1]).first == 2 && (*ranges[1]).second == 2);
     CPPUNIT_ASSERT(ranges[2] && (*ranges[2]).first == 5 && (*ranges[2]).second == 10);
 
-    ranges = util::positionToIndex({0.0, 2.0, 10.0}, {10.0, 2.0, 5.0}, {unit, unit, unit}, RangeMatch::Exclusive, sampledDim);
+    ranges = util::positionToIndex({0.0, 2.0, 5.0}, {10.0, 2.0, 10.0}, {unit, unit, unit}, RangeMatch::Exclusive, sampledDim);
     CPPUNIT_ASSERT(ranges.size() == 3);
     CPPUNIT_ASSERT(ranges[0] && (*ranges[0]).first == 0 && (*ranges[0]).second == 9);
     CPPUNIT_ASSERT(!ranges[1]);
@@ -139,7 +139,7 @@ void BaseTestDataAccess::testPositionToIndexSampledDimensionOld() {
     CPPUNIT_ASSERT(util::positionToIndex(0.005, scaled_unit, sampledDim) == 5);
 
     CPPUNIT_ASSERT_THROW(util::positionToIndex({},{1.0}, {unit}, sampledDim), std::runtime_error);
-    CPPUNIT_ASSERT(util::positionToIndex({0.0, 1.0}, {3.5, 0.5}, {unit, unit}, sampledDim).size() == 2);
+    CPPUNIT_ASSERT(util::positionToIndex({0.0, 0.5}, {3.5, 1.0}, {unit, unit}, sampledDim).size() == 2);
     vector<pair<ndsize_t, ndsize_t>> ranges = util::positionToIndex({0.0}, {0.0}, {unit}, sampledDim);
     CPPUNIT_ASSERT(ranges[0].first == 0 && ranges[0].second == 0);
 }

--- a/test/BaseTestDataAccess.cpp
+++ b/test/BaseTestDataAccess.cpp
@@ -24,44 +24,150 @@
 #include "BaseTestDataAccess.hpp"
 
 using namespace nix;
+using namespace std;
+using namespace boost;
 
 
 void BaseTestDataAccess::testPositionToIndexRangeDimension() {
-    std::string unit = "ms";
-    std::string invalid_unit = "kV";
-    std::string scaled_unit = "s";
+    string unit = "ms";
+    string invalid_unit = "kV";
+    string scaled_unit = "s";
+
     CPPUNIT_ASSERT_THROW(util::positionToIndex(5.0, invalid_unit, rangeDim), nix::IncompatibleDimensions);
-    CPPUNIT_ASSERT(util::positionToIndex(1.0, unit, rangeDim) == 0);
-    CPPUNIT_ASSERT(util::positionToIndex(8.0, unit, rangeDim) == 4);
-    CPPUNIT_ASSERT(util::positionToIndex(0.001, scaled_unit, rangeDim) == 0);
-    CPPUNIT_ASSERT(util::positionToIndex(0.008, scaled_unit, rangeDim) == 4);
-    CPPUNIT_ASSERT(util::positionToIndex(3.4, unit, rangeDim) == 2);
-    CPPUNIT_ASSERT(util::positionToIndex(3.6, unit, rangeDim) == 2);
-    CPPUNIT_ASSERT(util::positionToIndex(4.0, unit, rangeDim) == 2);
-    CPPUNIT_ASSERT(util::positionToIndex(0.0036, scaled_unit, rangeDim) == 2);
+    CPPUNIT_ASSERT(*util::positionToIndex(5.0, unit, PositionMatch::Less, rangeDim) == 3);
+    CPPUNIT_ASSERT(*util::positionToIndex(0.005, scaled_unit, PositionMatch::Less, rangeDim) == 3);
+
+    CPPUNIT_ASSERT(!util::positionToIndex(1.0, unit, PositionMatch::Less, rangeDim));
+    CPPUNIT_ASSERT(!util::positionToIndex(1.0, unit, PositionMatch::LessOrEqual, rangeDim));
+    CPPUNIT_ASSERT(!util::positionToIndex(1.0, unit, PositionMatch::Equal, rangeDim));
+    CPPUNIT_ASSERT(*(util::positionToIndex(1.0, unit, PositionMatch::GreaterOrEqual, rangeDim)) == 0);
+    CPPUNIT_ASSERT(*(util::positionToIndex(1.0, unit, PositionMatch::Greater, rangeDim)) == 0);
+
+    CPPUNIT_ASSERT(!util::positionToIndex(1.2, unit, PositionMatch::Less, rangeDim));
+    CPPUNIT_ASSERT(util::positionToIndex(1.2, unit, PositionMatch::LessOrEqual, rangeDim));
+    CPPUNIT_ASSERT(util::positionToIndex(1.2, unit, PositionMatch::Equal, rangeDim));
+    CPPUNIT_ASSERT(*(util::positionToIndex(1.2, unit, PositionMatch::GreaterOrEqual, rangeDim)) == 0);
+    CPPUNIT_ASSERT(*(util::positionToIndex(1.2, unit, PositionMatch::Greater, rangeDim)) == 1);
+
+    CPPUNIT_ASSERT(*util::positionToIndex(4.5, unit, PositionMatch::Less, rangeDim) == 2);
+    CPPUNIT_ASSERT(*util::positionToIndex(4.5, unit, PositionMatch::LessOrEqual, rangeDim) == 3);
+    CPPUNIT_ASSERT(*util::positionToIndex(4.5, unit, PositionMatch::Equal, rangeDim) == 3);
+    CPPUNIT_ASSERT(*(util::positionToIndex(4.5, unit, PositionMatch::GreaterOrEqual, rangeDim)) == 3);
+    CPPUNIT_ASSERT(*(util::positionToIndex(4.5, unit, PositionMatch::Greater, rangeDim)) == 4);
+
+    CPPUNIT_ASSERT(*util::positionToIndex(7.0, unit, PositionMatch::Less, rangeDim) == 4);
+    CPPUNIT_ASSERT(*util::positionToIndex(7.0, unit, PositionMatch::LessOrEqual, rangeDim) == 4);
+    CPPUNIT_ASSERT(!util::positionToIndex(7.0, unit, PositionMatch::Equal, rangeDim));
+    CPPUNIT_ASSERT(!(util::positionToIndex(7.0, unit, PositionMatch::GreaterOrEqual, rangeDim)));
+    CPPUNIT_ASSERT(!util::positionToIndex(7.0, unit, PositionMatch::Greater, rangeDim));
+
+    CPPUNIT_ASSERT_THROW(util::positionToIndex({5.0, 1.2}, {1.4}, {unit, unit}, RangeMatch::Inclusive, rangeDim), std::runtime_error);
+
+    vector<optional<pair<ndsize_t, ndsize_t>>> range = util::positionToIndex({0.0}, {7.0}, {unit}, RangeMatch::Inclusive, rangeDim);
+    CPPUNIT_ASSERT(range[0] && (*range[0]).first == 0 && (*range[0]).second == 4);
+    range = util::positionToIndex({0.0}, {7.0}, {unit}, RangeMatch::Exclusive, rangeDim);
+    CPPUNIT_ASSERT(range[0] && (*range[0]).first == 0 && (*range[0]).second == 4);
+    
+    range = util::positionToIndex({2.0}, {6.7}, {unit}, RangeMatch::Inclusive, rangeDim);
+    CPPUNIT_ASSERT(range[0] && (*range[0]).first == 1 && (*range[0]).second == 4);
+    range = util::positionToIndex({2.0}, {6.7}, {unit}, RangeMatch::Exclusive, rangeDim);
+    CPPUNIT_ASSERT(range[0] && (*range[0]).first == 1 && (*range[0]).second == 3);
+
+    range = util::positionToIndex({1.2}, {1.2}, {unit}, RangeMatch::Inclusive, rangeDim);
+    CPPUNIT_ASSERT(range[0] && (*range[0]).first == 0 && (*range[0]).second == 0);
+    range = util::positionToIndex({1.2}, {1.2}, {unit}, RangeMatch::Exclusive, rangeDim);
+    CPPUNIT_ASSERT(!range[0]);
 }
+
+void BaseTestDataAccess::testPositionToIndexRangeDimensionOld() {
+    string unit = "ms";
+    string invalid_unit = "kV";
+    string scaled_unit = "s";
+
+    CPPUNIT_ASSERT_THROW(util::positionToIndex(0.001, invalid_unit, rangeDim), nix::IncompatibleDimensions);
+    CPPUNIT_ASSERT_THROW(util::positionToIndex(8.0, unit, rangeDim), nix::OutOfBounds);
+    CPPUNIT_ASSERT(util::positionToIndex(0.001, unit, rangeDim) == 0);
+    CPPUNIT_ASSERT(util::positionToIndex(0.001, scaled_unit, rangeDim) == 0);
+    CPPUNIT_ASSERT_THROW(util::positionToIndex(0.008, scaled_unit, rangeDim), nix::OutOfBounds);
+    CPPUNIT_ASSERT(util::positionToIndex(3.4, unit, rangeDim) == 2);
+    CPPUNIT_ASSERT(util::positionToIndex(3.6, unit, rangeDim) == 3);
+    CPPUNIT_ASSERT(util::positionToIndex(4.0, unit, rangeDim) == 3);
+    CPPUNIT_ASSERT(util::positionToIndex(0.0034, scaled_unit, rangeDim) == 2);
+
+    vector<pair<ndsize_t, ndsize_t>> range = util::positionToIndex({0.001}, {3.4}, {unit}, rangeDim);
+    CPPUNIT_ASSERT(range[0].first == 0 && range[0].second == 2);
+    CPPUNIT_ASSERT_THROW(util::positionToIndex({0.001, 2.0}, {3.4}, {unit}, rangeDim), std::runtime_error);
+    CPPUNIT_ASSERT_THROW(util::positionToIndex({7.5}, {8.0}, {unit}, rangeDim), nix::OutOfBounds);
+}
+
 
 
 void BaseTestDataAccess::testPositionToIndexSampledDimension() {
-    std::string unit = "ms";
-    std::string invalid_unit = "kV";
-    std::string scaled_unit = "s";
+    string unit = "ms";
+    string invalid_unit = "kV";
+    string scaled_unit = "s";
+    // test incompatible dims
+    CPPUNIT_ASSERT_THROW(util::positionToIndex(1.0, invalid_unit, sampledDim), nix::IncompatibleDimensions);
+    CPPUNIT_ASSERT_NO_THROW(util::positionToIndex(1.0, unit, sampledDim));
+    CPPUNIT_ASSERT_NO_THROW(util::positionToIndex(1.0, scaled_unit, sampledDim));
 
-    CPPUNIT_ASSERT_THROW(util::positionToIndex(-1.0, unit, sampledDim), nix::OutOfBounds);
+    sampledDim.unit(nix::none);
+    CPPUNIT_ASSERT_THROW(util::positionToIndex(1.0, unit, sampledDim), nix::IncompatibleDimensions);
+    sampledDim.unit(unit);
+
+    vector<optional<pair<ndsize_t, ndsize_t>>> ranges = util::positionToIndex({0.0, 2.0, 10.0}, {10.0, 2.0, 5.0}, {unit, unit, unit}, RangeMatch::Inclusive, sampledDim);
+    CPPUNIT_ASSERT(ranges.size() == 3);
+    CPPUNIT_ASSERT(ranges[0] && (*ranges[0]).first == 0 && (*ranges[0]).second == 10);
+    CPPUNIT_ASSERT(ranges[1] && (*ranges[1]).first == 2 && (*ranges[1]).second == 2);
+    CPPUNIT_ASSERT(ranges[2] && (*ranges[2]).first == 5 && (*ranges[2]).second == 10);
+
+    ranges = util::positionToIndex({0.0, 2.0, 10.0}, {10.0, 2.0, 5.0}, {unit, unit, unit}, RangeMatch::Exclusive, sampledDim);
+    CPPUNIT_ASSERT(ranges.size() == 3);
+    CPPUNIT_ASSERT(ranges[0] && (*ranges[0]).first == 0 && (*ranges[0]).second == 9);
+    CPPUNIT_ASSERT(!ranges[1]);
+    CPPUNIT_ASSERT(ranges[2] && (*ranges[2]).first == 5 && (*ranges[2]).second == 9);
+}
+
+void BaseTestDataAccess::testPositionToIndexSampledDimensionOld() {
+    string unit = "ms";
+    string invalid_unit = "kV";
+    string scaled_unit = "s";
+
+    CPPUNIT_ASSERT(util::positionToIndex(-8.0, unit, sampledDim) == 0);
     CPPUNIT_ASSERT_THROW(util::positionToIndex(0.005, invalid_unit, sampledDim), nix::IncompatibleDimensions);
     CPPUNIT_ASSERT(util::positionToIndex(5.0, unit, sampledDim) == 5);
     CPPUNIT_ASSERT(util::positionToIndex(0.005, scaled_unit, sampledDim) == 5);
+
+    CPPUNIT_ASSERT_THROW(util::positionToIndex({},{1.0}, {unit}, sampledDim), std::runtime_error);
+    CPPUNIT_ASSERT(util::positionToIndex({0.0, 1.0}, {3.5, 0.5}, {unit, unit}, sampledDim).size() == 2);
+    vector<pair<ndsize_t, ndsize_t>> ranges = util::positionToIndex({0.0}, {0.0}, {unit}, sampledDim);
+    CPPUNIT_ASSERT(ranges[0].first == 0 && ranges[0].second == 0);
 }
 
 
-void BaseTestDataAccess::testPositionToIndexSetDimension() {
+void BaseTestDataAccess::testPositionToIndexSetDimensionOld() {
     std::string unit = "ms";
 
     CPPUNIT_ASSERT_THROW(util::positionToIndex(5.8, "none", setDim), nix::OutOfBounds);
-    CPPUNIT_ASSERT_THROW(util::positionToIndex(0.5, unit, setDim), nix::IncompatibleDimensions);
     CPPUNIT_ASSERT_NO_THROW(util::positionToIndex(0.5, "none", setDim));
     CPPUNIT_ASSERT(util::positionToIndex(0.5, "none", setDim) == 1);
-    CPPUNIT_ASSERT(util::positionToIndex(0.45, "none", setDim) == 0);
+    CPPUNIT_ASSERT(util::positionToIndex(0.45, unit, setDim) == 1);
+    CPPUNIT_ASSERT(util::positionToIndex(1., "none", setDim) == 1);
+
+}
+
+void BaseTestDataAccess::testPositionToIndexSetDimension() {
+    CPPUNIT_ASSERT(!util::positionToIndex(5.8, PositionMatch::Equal, setDim));
+
+    vector<optional<pair<ndsize_t, ndsize_t>>> ranges = util::positionToIndex({5.0, 0.}, {10.5, 1.0}, RangeMatch::Inclusive, setDim);
+    CPPUNIT_ASSERT(ranges.size() == 2);
+    CPPUNIT_ASSERT(!ranges[0]);
+    CPPUNIT_ASSERT(ranges[1] && (*ranges[1]).first == 0 && (*ranges[1]).second == 1);
+
+    ranges = util::positionToIndex({5.0, 0.}, {10.5, 1.0}, RangeMatch::Exclusive, setDim);
+    CPPUNIT_ASSERT(ranges.size() == 2);
+    CPPUNIT_ASSERT(!ranges[0]);
+    CPPUNIT_ASSERT(ranges[1] && (*ranges[1]).first == 0 && (*ranges[1]).second == 0);   
 }
 
 
@@ -365,7 +471,7 @@ void BaseTestDataAccess::testMultiTagUnitSupport() {
     testTag.addReference(data_array);
     position_indices[0] = 0;
     CPPUNIT_ASSERT_NO_THROW(util::retrieveData(testTag, position_indices, 0));
-    testTag.units(none);
+    testTag.units(nix::none);
     CPPUNIT_ASSERT_NO_THROW(util::retrieveData(testTag, position_indices, 0));
     testTag.units(invalid_units);
     CPPUNIT_ASSERT_THROW(util::retrieveData(testTag, position_indices, 0), nix::IncompatibleDimensions);

--- a/test/BaseTestDataAccess.cpp
+++ b/test/BaseTestDataAccess.cpp
@@ -646,27 +646,39 @@ void BaseTestDataAccess::testDataSlice() {
     // do the tests!
     nix::DataArray no_array;
     CPPUNIT_ASSERT_THROW(util::dataSlice(no_array, {1, 2}, {2,3}), nix::UninitializedEntity);
-
-    CPPUNIT_ASSERT_THROW(util::dataSlice(oned_array, {1, 2}, {2,3}), std::invalid_argument);
-    CPPUNIT_ASSERT_THROW(util::dataSlice(oned_array, {1}, {2}, {"ms", "mV"}), std::invalid_argument);
-    CPPUNIT_ASSERT_THROW(util::dataSlice(oned_array, {1, 2, 3}, {1, 2}), std::invalid_argument);
-    CPPUNIT_ASSERT_NO_THROW(util::dataSlice(oned_array, {0.0}, {1.0}));
-    CPPUNIT_ASSERT_THROW(util::dataSlice(oned_array, {0.0}, {1.0}, {"mV"}), nix::IncompatibleDimensions);
-    CPPUNIT_ASSERT_NO_THROW(util::dataSlice(oned_array, {0.0}, {1.0}, {"s"}));
-    CPPUNIT_ASSERT_NO_THROW(util::dataSlice(oned_array, {0.0}, {1.0}, {"ms"}));
-    CPPUNIT_ASSERT_THROW(util::dataSlice(oned_array, {0.0}, {1.0}, {"ks"}), nix::OutOfBounds);
-    CPPUNIT_ASSERT_NO_THROW(util::dataSlice(oned_array, {0.0}, {0.001}, {"ks"}));
+    CPPUNIT_ASSERT_THROW(util::dataSlice(oned_array, {1, 2}, {2, 3}), std::invalid_argument); // 1d data but called with 2d segment 
+    CPPUNIT_ASSERT_THROW(util::dataSlice(oned_array, {1}, {2}, {"ms", "mV"}), std::invalid_argument); // 1d positions, but two units
+    CPPUNIT_ASSERT_THROW(util::dataSlice(oned_array, {1, 2, 3}, {1, 2}), std::invalid_argument); // different size of start and end
+    CPPUNIT_ASSERT_THROW(util::dataSlice(oned_array, {0.0}, {1.0}, {"mV"}), nix::IncompatibleDimensions); // sampledDimension represents time
+    CPPUNIT_ASSERT_THROW(util::dataSlice(oned_array, {0.0}, {1.0}, {"ks"}), nix::OutOfBounds); // well beyond data
     CPPUNIT_ASSERT_THROW(util::dataSlice(oned_array, {1.0}, {0.0}), std::invalid_argument);
 
-    nix::DataView slice = util::dataSlice(oned_array, {0.0}, {1.0});
+    CPPUNIT_ASSERT_NO_THROW(util::dataSlice(oned_array, {0.0}, {1.0}));
+    CPPUNIT_ASSERT_NO_THROW(util::dataSlice(oned_array, {0.0}, {1.0}, {"s"}));
+    CPPUNIT_ASSERT_NO_THROW(util::dataSlice(oned_array, {0.0}, {1.0}, {"ms"}));
+    CPPUNIT_ASSERT_NO_THROW(util::dataSlice(oned_array, {0.0}, {0.001}, {"ks"}));
+ 
+    // test with RangeMatch::Inclusive
+    nix::DataView slice = util::dataSlice(oned_array, {0.0}, {1.0}, {}, RangeMatch::Inclusive);
     CPPUNIT_ASSERT(slice.dataExtent().size() == 1);
     CPPUNIT_ASSERT(slice.dataExtent()[0] == 101);
 
-    slice = util::dataSlice(twod_array2, {3.14, 1.0}, {9.6, 2.0});
+    slice = util::dataSlice(twod_array2, {3.14, 1.0}, {9.6, 2.0}, {}, RangeMatch::Inclusive);
     CPPUNIT_ASSERT(slice.dataExtent()[0] == 3 && slice.dataExtent()[1] == 101);
 
-    slice = util::dataSlice(twod_array, {0., 0.0}, {9.0, 1.0}, {"none", "s"});
+    slice = util::dataSlice(twod_array, {0., 0.0}, {9.0, 1.0}, {"none", "s"}, RangeMatch::Inclusive);
     CPPUNIT_ASSERT(slice.dataExtent()[0] == 10 && slice.dataExtent()[1] == 101);
+
+    // test with RangeMatch::Exclusive
+    slice = util::dataSlice(oned_array, {0.0}, {1.0}, {}, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(slice.dataExtent().size() == 1);
+    CPPUNIT_ASSERT(slice.dataExtent()[0] == 100);
+
+    slice = util::dataSlice(twod_array2, {3.14, 1.0}, {9.6, 2.0}, {}, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(slice.dataExtent()[0] == 3 && slice.dataExtent()[1] == 100);
+
+    slice = util::dataSlice(twod_array, {0., 0.0}, {9.0, 1.0}, {"none", "s"}, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(slice.dataExtent()[0] == 9 && slice.dataExtent()[1] == 100);
 
     b.deleteDataArray(oned_array);
     b.deleteDataArray(twod_array);

--- a/test/BaseTestDataAccess.hpp
+++ b/test/BaseTestDataAccess.hpp
@@ -26,8 +26,11 @@ protected:
 
 public:
     void testPositionToIndexSetDimension();
+    void testPositionToIndexSetDimensionOld();
     void testPositionToIndexSampledDimension();
+    void testPositionToIndexSampledDimensionOld();
     void testPositionToIndexRangeDimension();
+    void testPositionToIndexRangeDimensionOld();
     void testOffsetAndCount();
     void testPositionInData();
     void testRetrieveData();

--- a/test/BaseTestDimension.cpp
+++ b/test/BaseTestDimension.cpp
@@ -484,6 +484,43 @@ void BaseTestDimension::testRangeDimIndexOf() {
     CPPUNIT_ASSERT(*rd.indexOf(110., PositionMatch::Less) == 4);
     CPPUNIT_ASSERT(!rd.indexOf(110., PositionMatch::Equal));
 
+    boost::optional<std::pair<ndsize_t, ndsize_t>> range;
+    range = rd.indexOf(40., 100., {}, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 4 && (*range).second == 4);
+    range = rd.indexOf(40., 100., {}, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(!range);
+    range = rd.indexOf(-100., -45., {}, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 0);
+    range = rd.indexOf(-100., -45., {}, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 0);
+    range = rd.indexOf(10., 120., {}, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 3 && (*range).second == 4);
+    range = rd.indexOf(10., 120., {}, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 3 && (*range).second == 4);
+    range = rd.indexOf(100., 120., {}, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 4 && (*range).second == 4);
+    range = rd.indexOf(100., 120., {}, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 4 && (*range).second == 4);
+    range = rd.indexOf(110., 150., {}, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(!range);
+    range = rd.indexOf(100., -100., {}, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 4);
+    range = rd.indexOf(100., -100., {}, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 3);
+
+    range = rd.indexOf(100., -100., rd.ticks(), RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 3);
+
+    std::vector<std::pair<ndsize_t, ndsize_t>> ranges;
+    ranges = rd.indexOf({40., -100.}, {100., 100.}, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(ranges.size() == 2);
+    CPPUNIT_ASSERT(ranges[0].first == 4 && ranges[0].second == 4);
+    CPPUNIT_ASSERT(ranges[1].first == 0 && ranges[1].second == 4);
+
+    ranges = rd.indexOf({40., -100., -100.}, {100., 100., 101.}, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(ranges.size() == 2);
+    CPPUNIT_ASSERT(ranges[0].first == 0 && ranges[0].second == 3);
+    CPPUNIT_ASSERT(ranges[1].first == 0 && ranges[1].second == 4);
     data_array.deleteDimensions();
 }
 

--- a/test/BaseTestDimension.cpp
+++ b/test/BaseTestDimension.cpp
@@ -475,6 +475,23 @@ void BaseTestDimension::testRangeDimAxis() {
 }
 
 
+void BaseTestDimension::testRangeDimPositionInRange() {
+    std::vector<double> ticks = {-100.0, -10.0, 0.0, 10.0, 100.0};
+    Dimension d = data_array.appendRangeDimension(ticks);
+
+    CPPUNIT_ASSERT(d.dimensionType() == DimensionType::Range);
+    RangeDimension rd = d.asRangeDimension();
+
+    CPPUNIT_ASSERT(rd.positionInRange(-99.0) == nix::PositionInRange::InRange);
+    CPPUNIT_ASSERT(rd.positionInRange(99.0) == nix::PositionInRange::InRange);
+    CPPUNIT_ASSERT(rd.positionInRange(100.1) == nix::PositionInRange::Greater);
+    CPPUNIT_ASSERT(rd.positionInRange(-100.1) == nix::PositionInRange::Less);
+
+    rd.ticks({});
+    CPPUNIT_ASSERT(rd.positionInRange(0.1) == nix::PositionInRange::NoRange);
+}
+
+
 void BaseTestDimension::testAsDimensionMethods() {
     std::vector<double> ticks = {-100.0, -10.0, 0.0, 10.0, 100.0};
     Dimension x;

--- a/test/BaseTestDimension.cpp
+++ b/test/BaseTestDimension.cpp
@@ -179,7 +179,14 @@ void BaseTestDimension::testSampledDimIndexOf() {
     CPPUNIT_ASSERT(sd.indexOf(1.0, 1.01).first == 0);
     CPPUNIT_ASSERT_THROW(sd.indexOf(1.01, 0.0), nix::OutOfBounds);
     CPPUNIT_ASSERT_THROW(sd.indexOf(1.01, 0.99), nix::OutOfBounds);
-
+    CPPUNIT_ASSERT_THROW(sd.indexOf(3.14, 3.14 + samplingInterval/2 - 0.2, RangeMatch::Exclusive), nix::OutOfBounds);
+    CPPUNIT_ASSERT_NO_THROW(sd.indexOf(3.14, 3.14 + samplingInterval/2 - 0.2, RangeMatch::Inclusive));
+    CPPUNIT_ASSERT_NO_THROW(sd.indexOf(3.14, 3.14 + samplingInterval/2 + 0.2, RangeMatch::Exclusive));
+    
+    std::pair<ndsize_t, ndsize_t> range = sd.indexOf(3.14, 3.14 + samplingInterval/2 - 0.2, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range.first == 1 && range.second == 1);
+    range = sd.indexOf(3.14, 3.14 + samplingInterval/2 + 0.2, RangeMatch::Exclusive);    
+    CPPUNIT_ASSERT(range.first == 1 && range.second == 0); // this actually an invalid range!
 
     CPPUNIT_ASSERT_THROW(sd.indexOf({0.0, 20.0, 40.0}, {10.9}), std::runtime_error);
     CPPUNIT_ASSERT_THROW(sd.indexOf({0.0, 20.0, 40.0}, {10.9, 12., 1.}), nix::OutOfBounds);

--- a/test/BaseTestDimension.cpp
+++ b/test/BaseTestDimension.cpp
@@ -419,7 +419,7 @@ void BaseTestDimension::testRangeDimIndexOfOld() {
     CPPUNIT_ASSERT(rd.indexOf(-10.0) == 1);
     CPPUNIT_ASSERT(rd.indexOf(-5.0) == 1);
     CPPUNIT_ASSERT(rd.indexOf(5.0) == 2);
-    
+
     CPPUNIT_ASSERT_NO_THROW(rd.indexOf(257.28));
     CPPUNIT_ASSERT_THROW(rd.indexOf(257.28, false), nix::OutOfBounds);
     CPPUNIT_ASSERT_THROW(rd.indexOf(-257.28), nix::OutOfBounds);
@@ -431,7 +431,7 @@ void BaseTestDimension::testRangeDimIndexOfOld() {
     CPPUNIT_ASSERT(range.first == 0 && range.second == 4);
     range = rd.indexOf(-200., 200.);
     CPPUNIT_ASSERT(range.first == 0 && range.second == 4);
-    
+
     CPPUNIT_ASSERT_THROW(rd.indexOf({-100.0, -90, 0.0}, {10.}), std::runtime_error);
     CPPUNIT_ASSERT_NO_THROW(rd.indexOf({-100.0, 20.0, 40.0}, {-45, 120., 100.}));
     CPPUNIT_ASSERT(rd.indexOf({-100.0, 20.0, 40.0}, {-45, 120., 100.}).size() == 3);
@@ -453,13 +453,13 @@ void BaseTestDimension::testRangeDimIndexOf() {
     CPPUNIT_ASSERT(!rd.indexOf(-110., PositionMatch::LessOrEqual));
     CPPUNIT_ASSERT(!rd.indexOf(-110., PositionMatch::Less));
     CPPUNIT_ASSERT(!rd.indexOf(-110., PositionMatch::Equal));
-    
+
     CPPUNIT_ASSERT(*rd.indexOf(-100., PositionMatch::GreaterOrEqual) == 0);
     CPPUNIT_ASSERT(*rd.indexOf(-100., PositionMatch::Greater) == 1);
     CPPUNIT_ASSERT(*rd.indexOf(-100., PositionMatch::LessOrEqual) == 0);
     CPPUNIT_ASSERT(!rd.indexOf(-100., PositionMatch::Less));
     CPPUNIT_ASSERT(*rd.indexOf(-100., PositionMatch::Equal) == 0);
-    
+
     CPPUNIT_ASSERT(*rd.indexOf(-50., PositionMatch::GreaterOrEqual) == 1);
     CPPUNIT_ASSERT(*rd.indexOf(-50., PositionMatch::Greater) == 1);
     CPPUNIT_ASSERT(*rd.indexOf(-50., PositionMatch::LessOrEqual) == 0);
@@ -517,7 +517,8 @@ void BaseTestDimension::testRangeDimIndexOf() {
     CPPUNIT_ASSERT(ranges[0].first == 4 && ranges[0].second == 4);
     CPPUNIT_ASSERT(ranges[1].first == 0 && ranges[1].second == 4);
 
-    ranges = rd.indexOf({40., -100., -100.}, {100., 100., 101.}, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT_THROW(rd.indexOf({40., -100., -100.}, {100., 100., 101.}, RangeMatch::Exclusive), nix::OutOfBounds);
+    ranges = rd.indexOf({40., -100., -100.}, {100., 100., 101.}, RangeMatch::Exclusive, false);
     CPPUNIT_ASSERT(ranges.size() == 2);
     CPPUNIT_ASSERT(ranges[0].first == 0 && ranges[0].second == 3);
     CPPUNIT_ASSERT(ranges[1].first == 0 && ranges[1].second == 4);

--- a/test/BaseTestDimension.cpp
+++ b/test/BaseTestDimension.cpp
@@ -419,9 +419,12 @@ void BaseTestDimension::testRangeDimIndexOf() {
     CPPUNIT_ASSERT(rd.indexOf(-10.0) == 1);
     CPPUNIT_ASSERT(rd.indexOf(-5.0) == 1);
     CPPUNIT_ASSERT(rd.indexOf(5.0) == 2);
-    CPPUNIT_ASSERT(rd.indexOf(257.28) == 4);
-    CPPUNIT_ASSERT(rd.indexOf(-257.28) == 0);
-
+    
+    CPPUNIT_ASSERT_NO_THROW(rd.indexOf(257.28));
+    CPPUNIT_ASSERT_THROW(rd.indexOf(257.28, false), nix::OutOfBounds);
+    CPPUNIT_ASSERT_THROW(rd.indexOf(-257.28), nix::OutOfBounds);
+    CPPUNIT_ASSERT_NO_THROW(rd.indexOf(-257.28, false));
+    
     CPPUNIT_ASSERT_THROW(rd.indexOf({-100.0, -90, 0.0}, {10.}), std::runtime_error);
     CPPUNIT_ASSERT_NO_THROW(rd.indexOf({-100.0, 20.0, 40.0}, {-45, 120., 100.}));
     CPPUNIT_ASSERT(rd.indexOf({-100.0, 20.0, 40.0}, {-45, 120., 100.}).size() == 3);

--- a/test/BaseTestDimension.cpp
+++ b/test/BaseTestDimension.cpp
@@ -405,7 +405,7 @@ void BaseTestDimension::testRangeTicks() {
 }
 
 
-void BaseTestDimension::testRangeDimIndexOf() {
+void BaseTestDimension::testRangeDimIndexOfOld() {
     std::vector<double> ticks = {-100.0, -10.0, 0.0, 10.0, 100.0};
     Dimension d = data_array.appendRangeDimension(ticks);
 
@@ -428,6 +428,55 @@ void BaseTestDimension::testRangeDimIndexOf() {
     CPPUNIT_ASSERT_THROW(rd.indexOf({-100.0, -90, 0.0}, {10.}), std::runtime_error);
     CPPUNIT_ASSERT_NO_THROW(rd.indexOf({-100.0, 20.0, 40.0}, {-45, 120., 100.}));
     CPPUNIT_ASSERT(rd.indexOf({-100.0, 20.0, 40.0}, {-45, 120., 100.}).size() == 3);
+    data_array.deleteDimensions();
+}
+
+
+void BaseTestDimension::testRangeDimIndexOf() {
+    std::vector<double> ticks = {-100.0, -10.0, 0.0, 10.0, 100.0};
+    Dimension d = data_array.appendRangeDimension(ticks);
+
+    CPPUNIT_ASSERT(d.dimensionType() == DimensionType::Range);
+
+    RangeDimension rd;
+    rd = d;
+
+    CPPUNIT_ASSERT(*rd.indexOf(-110., PositionMatch::GreaterOrEqual) == 0);
+    CPPUNIT_ASSERT(*rd.indexOf(-110., PositionMatch::GreaterOrEqual) == 0);
+    CPPUNIT_ASSERT(!rd.indexOf(-110., PositionMatch::LessOrEqual));
+    CPPUNIT_ASSERT(!rd.indexOf(-110., PositionMatch::Less));
+    CPPUNIT_ASSERT(!rd.indexOf(-110., PositionMatch::Equal));
+    
+    CPPUNIT_ASSERT(*rd.indexOf(-100., PositionMatch::GreaterOrEqual) == 0);
+    CPPUNIT_ASSERT(*rd.indexOf(-100., PositionMatch::Greater) == 1);
+    CPPUNIT_ASSERT(*rd.indexOf(-100., PositionMatch::LessOrEqual) == 0);
+    CPPUNIT_ASSERT(!rd.indexOf(-100., PositionMatch::Less));
+    CPPUNIT_ASSERT(*rd.indexOf(-100., PositionMatch::Equal) == 0);
+    
+    CPPUNIT_ASSERT(*rd.indexOf(-50., PositionMatch::GreaterOrEqual) == 1);
+    CPPUNIT_ASSERT(*rd.indexOf(-50., PositionMatch::Greater) == 1);
+    CPPUNIT_ASSERT(*rd.indexOf(-50., PositionMatch::LessOrEqual) == 0);
+    CPPUNIT_ASSERT(*rd.indexOf(-50., PositionMatch::Less) == 0);
+    CPPUNIT_ASSERT(!rd.indexOf(-50., PositionMatch::Equal));
+
+    CPPUNIT_ASSERT(*rd.indexOf(7., PositionMatch::GreaterOrEqual) == 3);
+    CPPUNIT_ASSERT(*rd.indexOf(7., PositionMatch::Greater) == 3);
+    CPPUNIT_ASSERT(*rd.indexOf(7., PositionMatch::LessOrEqual) == 2);
+    CPPUNIT_ASSERT(*rd.indexOf(7., PositionMatch::Less) == 2);
+    CPPUNIT_ASSERT(!rd.indexOf(7., PositionMatch::Equal));
+
+    CPPUNIT_ASSERT(*rd.indexOf(10., PositionMatch::GreaterOrEqual) == 3);
+    CPPUNIT_ASSERT(*rd.indexOf(10., PositionMatch::Greater) == 4);
+    CPPUNIT_ASSERT(*rd.indexOf(10., PositionMatch::LessOrEqual) == 3);
+    CPPUNIT_ASSERT(*rd.indexOf(10., PositionMatch::Less) == 2);
+    CPPUNIT_ASSERT(*rd.indexOf(10., PositionMatch::Equal) == 3);
+
+    CPPUNIT_ASSERT(!rd.indexOf(110., PositionMatch::GreaterOrEqual));
+    CPPUNIT_ASSERT(!rd.indexOf(110., PositionMatch::Greater));
+    CPPUNIT_ASSERT(*rd.indexOf(110., PositionMatch::LessOrEqual) == 4);
+    CPPUNIT_ASSERT(*rd.indexOf(110., PositionMatch::Less) == 4);
+    CPPUNIT_ASSERT(!rd.indexOf(110., PositionMatch::Equal));
+
     data_array.deleteDimensions();
 }
 

--- a/test/BaseTestDimension.cpp
+++ b/test/BaseTestDimension.cpp
@@ -581,7 +581,7 @@ void BaseTestDimension::testSetDimIndexOf() {
     sd.labels(labels);
     range = sd.indexOf(0.0, 0.0, RangeMatch::Inclusive);
     CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 0);
-    range = sd.indexOf(0.0, 0.0, RangeMatch::Exclusive);
+    range = sd.indexOf(1.0, 1.0, RangeMatch::Exclusive);
     CPPUNIT_ASSERT(!range);
     range = sd.indexOf(0.0, 3.0, RangeMatch::Inclusive);
     CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 3);
@@ -595,6 +595,24 @@ void BaseTestDimension::testSetDimIndexOf() {
     CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 4);
     range = sd.indexOf(3.0, 7.0, RangeMatch::Exclusive);
     CPPUNIT_ASSERT(range && (*range).first == 3 && (*range).second == 4);
+
+    std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> ranges;
+    CPPUNIT_ASSERT_THROW(sd.indexOf({0.0, -1.0, 1.0}, {1.0, 2.0}, RangeMatch::Inclusive), std::runtime_error);
+    ranges = sd.indexOf({0.0, -1.0, 1.0, 1.0}, {1.0, 4.0, 9.0, 1.0}, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(ranges.size() == 4);
+    CPPUNIT_ASSERT(ranges[0] && (*ranges[0]).first == 0 && (*ranges[0]).second == 1);
+    CPPUNIT_ASSERT(ranges[1] && (*ranges[1]).first == 0 && (*ranges[1]).second == 4);
+    CPPUNIT_ASSERT(ranges[2] && (*ranges[2]).first == 1 && (*ranges[2]).second == 4);
+    CPPUNIT_ASSERT(ranges[3] && (*ranges[3]).first == 1 && (*ranges[3]).second == 1);
+
+    ranges = sd.indexOf({0.0, -1.0, 1.0, 1.0}, {1.0, 4.0, 9.0, 1.0}, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(ranges.size() == 4);
+    CPPUNIT_ASSERT(ranges[0] && (*ranges[0]).first == 0 && (*ranges[0]).second == 0);
+    CPPUNIT_ASSERT(ranges[1] && (*ranges[1]).first == 0 && (*ranges[1]).second == 3);
+    CPPUNIT_ASSERT(ranges[2] && (*ranges[2]).first == 1 && (*ranges[2]).second == 4);
+    CPPUNIT_ASSERT(!ranges[3]);
+
+
 }
 
 void BaseTestDimension::testRangeDimLabel() {

--- a/test/BaseTestDimension.cpp
+++ b/test/BaseTestDimension.cpp
@@ -512,16 +512,29 @@ void BaseTestDimension::testRangeDimIndexOf() {
     CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 3);
 
     std::vector<std::pair<ndsize_t, ndsize_t>> ranges;
-    ranges = rd.indexOf({40., -100.}, {100., 100.}, RangeMatch::Inclusive);
+    ranges = rd.indexOf({40., -100.}, {100., 100.}, true, RangeMatch::Inclusive);
     CPPUNIT_ASSERT(ranges.size() == 2);
     CPPUNIT_ASSERT(ranges[0].first == 4 && ranges[0].second == 4);
     CPPUNIT_ASSERT(ranges[1].first == 0 && ranges[1].second == 4);
 
-    CPPUNIT_ASSERT_THROW(rd.indexOf({40., -100., -100.}, {100., 100., 101.}, RangeMatch::Exclusive), nix::OutOfBounds);
-    ranges = rd.indexOf({40., -100., -100.}, {100., 100., 101.}, RangeMatch::Exclusive, false);
+    CPPUNIT_ASSERT_THROW(rd.indexOf({40., -100., -100.}, {100., 100., 101.}, true, RangeMatch::Exclusive), nix::OutOfBounds);
+    ranges = rd.indexOf({40., -100., -100.}, {100., 100., 101.}, false, RangeMatch::Exclusive);
     CPPUNIT_ASSERT(ranges.size() == 2);
     CPPUNIT_ASSERT(ranges[0].first == 0 && ranges[0].second == 3);
     CPPUNIT_ASSERT(ranges[1].first == 0 && ranges[1].second == 4);
+
+    std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> optranges;
+    optranges = rd.indexOf({40., -100.}, {100., 100.}, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(optranges.size() == 2);
+    CPPUNIT_ASSERT(optranges[0] && (*optranges[0]).first == 4 && (*optranges[0]).second == 4);
+    CPPUNIT_ASSERT(optranges[1] && (*optranges[1]).first == 0 && (*optranges[1]).second == 4);
+
+    optranges = rd.indexOf({40., -100., -100.}, {100., 100., 101.}, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(optranges.size() == 3);
+    CPPUNIT_ASSERT(!optranges[0]);
+    CPPUNIT_ASSERT(optranges[1] && (*optranges[1]).first == 0 && (*optranges[1]).second == 3);
+    CPPUNIT_ASSERT(optranges[2] && (*optranges[2]).first == 0 && (*optranges[2]).second == 4);
+    
     data_array.deleteDimensions();
 }
 

--- a/test/BaseTestDimension.cpp
+++ b/test/BaseTestDimension.cpp
@@ -313,6 +313,10 @@ void BaseTestDimension::testSampledDimIndexOf() {
     CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 3);
     range = sd.indexOf(2., -2.0, RangeMatch::Exclusive);
     CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 2);
+    range = sd.indexOf(2.0, 2.0, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 3 && (*range).second == 3);
+    range = sd.indexOf(2., 2.0, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(!range);
 
     // test vector of ranges, offset = -1, sampling interval = 1
     CPPUNIT_ASSERT_THROW(sd.indexOf({1.0, 20.0, 40.0}, {10.9, 12.}, RangeMatch::Exclusive), std::runtime_error);

--- a/test/BaseTestDimension.cpp
+++ b/test/BaseTestDimension.cpp
@@ -191,16 +191,16 @@ void BaseTestDimension::testSampledDimIndexOfOld() {
     CPPUNIT_ASSERT_NO_THROW(sd.indexOf(-0.25, 1.01));
     CPPUNIT_ASSERT_NO_THROW(sd.indexOf(0.0, 1.01));
     CPPUNIT_ASSERT_NO_THROW(sd.indexOf(1.0, 1.01));
-    CPPUNIT_ASSERT_NO_THROW(sd.indexOf(1.01, 0.0));
-    CPPUNIT_ASSERT_NO_THROW(sd.indexOf(3.5, 1.5));
+    CPPUNIT_ASSERT_THROW(sd.indexOf(1.01, 0.0), nix::OutOfBounds);
+    CPPUNIT_ASSERT_THROW(sd.indexOf(3.5, 1.5), nix::OutOfBounds);
 
     CPPUNIT_ASSERT_THROW(sd.indexOf(-1.0, -.05), nix::OutOfBounds);  // because end pos is invalid
     std::pair<ndsize_t, ndsize_t> range = sd.indexOf(-1.0, 5.0);
     CPPUNIT_ASSERT(range.first == 0 && range.second == 4);
     range = sd.indexOf(1.0, 5.0);
     CPPUNIT_ASSERT(range.first == 0 && range.second == 4);
-    range = sd.indexOf(5.0, 1.0);
-    CPPUNIT_ASSERT(range.first == 0 && range.second == 4);
+    //range = sd.indexOf(5.0, 1.0);
+    //CPPUNIT_ASSERT(range.first == 0 && range.second == 4);
     range = sd.indexOf(1.5, 3.2);
     CPPUNIT_ASSERT(range.first == 1 && range.second == 2); // less or equal for end of range
     range = sd.indexOf(1.5, 3.7);
@@ -210,11 +210,11 @@ void BaseTestDimension::testSampledDimIndexOfOld() {
     
     // test vectors of ranges, offset = 1, sampling interval = 1
     CPPUNIT_ASSERT_THROW(sd.indexOf({0.0, 20.0, 40.0}, {10.9}), std::runtime_error);        
-    CPPUNIT_ASSERT_NO_THROW(sd.indexOf({0.0, 20.0, 40.0}, {10.9, 12., 1.}));
-    CPPUNIT_ASSERT_NO_THROW(sd.indexOf({1.0, 20.0, 40.0}, {10.9, 12., 1.}));
-    CPPUNIT_ASSERT(sd.indexOf({1.0, 20.0, 40.0}, {10.9, 12., 1.}).size() == 3);
+    CPPUNIT_ASSERT_NO_THROW(sd.indexOf({0.0, 12.0, 1.0}, {10.9, 20., 40.}));
+    CPPUNIT_ASSERT_NO_THROW(sd.indexOf({1.0, 12.0, 1.0}, {10.9, 20., 40.}));
+    CPPUNIT_ASSERT(sd.indexOf({1.0, 12.0, 1.0}, {10.9, 20., 40.}).size() == 3);
 
-    std::vector<std::pair<ndsize_t, ndsize_t>> ranges = sd.indexOf({1.0, 20.0, 40.0}, {10.9, 12., 1.});
+    std::vector<std::pair<ndsize_t, ndsize_t>> ranges = sd.indexOf({1.0, 12.0, 1.0}, {10.9, 20., 40.});
     CPPUNIT_ASSERT(ranges.size() == 3);
     CPPUNIT_ASSERT(ranges[0].first == 0 && ranges[0].second == 9);
     CPPUNIT_ASSERT(sd.positionAt(ranges[0].first) == 1.0 && sd.positionAt(ranges[0].second) == 10.); 
@@ -310,9 +310,9 @@ void BaseTestDimension::testSampledDimIndexOf() {
     range = sd.indexOf(-1.5, 2.0, RangeMatch::Exclusive);
     CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 2);
     range = sd.indexOf(2., -2.0, RangeMatch::Inclusive);
-    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 3);
+    CPPUNIT_ASSERT(!range);
     range = sd.indexOf(2., -2.0, RangeMatch::Exclusive);
-    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 2);
+    CPPUNIT_ASSERT(!range);
     range = sd.indexOf(2.0, 2.0, RangeMatch::Inclusive);
     CPPUNIT_ASSERT(range && (*range).first == 3 && (*range).second == 3);
     range = sd.indexOf(2., 2.0, RangeMatch::Exclusive);
@@ -321,7 +321,7 @@ void BaseTestDimension::testSampledDimIndexOf() {
     // test vector of ranges, offset = -1, sampling interval = 1
     CPPUNIT_ASSERT_THROW(sd.indexOf({1.0, 20.0, 40.0}, {10.9, 12.}, RangeMatch::Exclusive), std::runtime_error);
     
-    std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> ranges = sd.indexOf({1.0, 20.0, 40.0, 5.0}, {10.9, 12.0, 1.0, 5.0}, RangeMatch::Inclusive);
+    std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> ranges = sd.indexOf({1.0, 12.0, 1.0, 5.0}, {10.9, 20.0, 40.0, 5.0}, RangeMatch::Inclusive);
     CPPUNIT_ASSERT(ranges.size() == 4);
     CPPUNIT_ASSERT(ranges[0] && (*ranges[0]).first == 2 && (*ranges[0]).second == 11 && 
                    sd.positionAt((*ranges[0]).first) >= 1.0 && sd.positionAt((*ranges[0]).second) <= 10.9);
@@ -332,7 +332,7 @@ void BaseTestDimension::testSampledDimIndexOf() {
     CPPUNIT_ASSERT(ranges[3] && (*ranges[3]).first == 6 && (*ranges[3]).second == 6 && 
                    sd.positionAt((*ranges[3]).first) == 5 && sd.positionAt((*ranges[3]).second) == 5);
 
-    ranges = sd.indexOf({1.0, 20.0, 40.0, 5.0}, {10.9, 12.0, 1.0, 5.0}, RangeMatch::Exclusive);
+    ranges = sd.indexOf({1.0, 12.0, 1.0, 5.0}, {10.9, 20.0, 40.0, 5.0}, RangeMatch::Exclusive);
     CPPUNIT_ASSERT(ranges.size() == 4);
     CPPUNIT_ASSERT(ranges[0] && (*ranges[0]).first == 2 && (*ranges[0]).second == 11 && 
                    sd.positionAt((*ranges[0]).first) >= 1.0 && sd.positionAt((*ranges[0]).second) <= 10.9);
@@ -574,9 +574,9 @@ void BaseTestDimension::testSetDimIndexOf() {
     range = sd.indexOf(0.0, 3.0, RangeMatch::Exclusive);
     CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 2);
     range = sd.indexOf(3.0, 0.0, RangeMatch::Inclusive);
-    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 3);
+    CPPUNIT_ASSERT(!range);
     range = sd.indexOf(3.0, 0.0, RangeMatch::Exclusive);
-    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 2);
+    CPPUNIT_ASSERT(!range);
 
     sd.labels(labels);
     range = sd.indexOf(0.0, 0.0, RangeMatch::Inclusive);
@@ -588,9 +588,9 @@ void BaseTestDimension::testSetDimIndexOf() {
     range = sd.indexOf(0.0, 3.0, RangeMatch::Exclusive);
     CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 2);
     range = sd.indexOf(3.0, 0.0, RangeMatch::Inclusive);
-    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 3);
+    CPPUNIT_ASSERT(!range);
     range = sd.indexOf(3.0, 0.0, RangeMatch::Exclusive);
-    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 2);
+    CPPUNIT_ASSERT(!range);
     range = sd.indexOf(0.0, 7.0, RangeMatch::Inclusive);
     CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 4);
     range = sd.indexOf(3.0, 7.0, RangeMatch::Exclusive);

--- a/test/BaseTestDimension.cpp
+++ b/test/BaseTestDimension.cpp
@@ -560,6 +560,37 @@ void BaseTestDimension::testSetDimIndexOf() {
     CPPUNIT_ASSERT(index && *index == 6);
     index = sd.indexOf(5.5, PositionMatch::Greater);
     CPPUNIT_ASSERT(index && *index == 6);
+
+    boost::optional<std::pair<ndsize_t, ndsize_t>> range = sd.indexOf(0.0, 0.0, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 0);
+    range = sd.indexOf(0.0, 0.0, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(!range);
+    range = sd.indexOf(0.0, 3.0, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 3);
+    range = sd.indexOf(0.0, 3.0, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 2);
+    range = sd.indexOf(3.0, 0.0, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 3);
+    range = sd.indexOf(3.0, 0.0, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 2);
+
+    sd.labels(labels);
+    range = sd.indexOf(0.0, 0.0, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 0);
+    range = sd.indexOf(0.0, 0.0, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(!range);
+    range = sd.indexOf(0.0, 3.0, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 3);
+    range = sd.indexOf(0.0, 3.0, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 2);
+    range = sd.indexOf(3.0, 0.0, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 3);
+    range = sd.indexOf(3.0, 0.0, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 2);
+    range = sd.indexOf(0.0, 7.0, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 4);
+    range = sd.indexOf(3.0, 7.0, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 3 && (*range).second == 4);
 }
 
 void BaseTestDimension::testRangeDimLabel() {

--- a/test/BaseTestDimension.cpp
+++ b/test/BaseTestDimension.cpp
@@ -424,6 +424,13 @@ void BaseTestDimension::testRangeDimIndexOfOld() {
     CPPUNIT_ASSERT_THROW(rd.indexOf(257.28, false), nix::OutOfBounds);
     CPPUNIT_ASSERT_THROW(rd.indexOf(-257.28), nix::OutOfBounds);
     CPPUNIT_ASSERT_NO_THROW(rd.indexOf(-257.28, false));
+
+    CPPUNIT_ASSERT_THROW(rd.indexOf(110., 120.), nix::OutOfBounds);
+    CPPUNIT_ASSERT_THROW(rd.indexOf(-120., -110.), nix::OutOfBounds);
+    std::pair<ndsize_t, ndsize_t> range = rd.indexOf(-100., 100.);
+    CPPUNIT_ASSERT(range.first == 0 && range.second == 4);
+    range = rd.indexOf(-200., 200.);
+    CPPUNIT_ASSERT(range.first == 0 && range.second == 4);
     
     CPPUNIT_ASSERT_THROW(rd.indexOf({-100.0, -90, 0.0}, {10.}), std::runtime_error);
     CPPUNIT_ASSERT_NO_THROW(rd.indexOf({-100.0, 20.0, 40.0}, {-45, 120., 100.}));

--- a/test/BaseTestDimension.cpp
+++ b/test/BaseTestDimension.cpp
@@ -482,6 +482,85 @@ void BaseTestDimension::testSetDimLabels() {
     data_array.deleteDimensions();
 }
 
+void BaseTestDimension::testSetDimIndexOf() {
+    std::vector<std::string> labels = {"label_a", "label_b","label_c","label_d","label_e"};
+
+    Dimension d = data_array.appendSetDimension();
+    CPPUNIT_ASSERT(d.dimensionType() == DimensionType::Set);
+    SetDimension sd;
+    sd = d;
+    sd.labels(labels);
+
+    boost::optional<ndsize_t> index;
+    index = sd.indexOf(-1.0, PositionMatch::Less);
+    CPPUNIT_ASSERT(!index);
+    index = sd.indexOf(-1.0, PositionMatch::LessOrEqual);
+    CPPUNIT_ASSERT(!index);
+    index = sd.indexOf(-1.0, PositionMatch::Equal);
+    CPPUNIT_ASSERT(!index);
+    index = sd.indexOf(-1.0, PositionMatch::GreaterOrEqual);
+    CPPUNIT_ASSERT(index && *index == 0);
+    index = sd.indexOf(-1.0, PositionMatch::Greater);
+    CPPUNIT_ASSERT(index && *index == 0);
+
+    index = sd.indexOf(0.0, PositionMatch::Less);
+    CPPUNIT_ASSERT(!index);
+    index = sd.indexOf(0.0, PositionMatch::LessOrEqual);
+    CPPUNIT_ASSERT(index && *index == 0);
+    index = sd.indexOf(0.0, PositionMatch::Equal);
+    CPPUNIT_ASSERT(index && *index == 0);
+    index = sd.indexOf(0.0000001, PositionMatch::Equal);
+    CPPUNIT_ASSERT(!index);
+    index = sd.indexOf(0.0, PositionMatch::GreaterOrEqual);
+    CPPUNIT_ASSERT(index && *index == 0);
+    index = sd.indexOf(0.0, PositionMatch::Greater);
+    CPPUNIT_ASSERT(index && *index == 1);
+
+    index = sd.indexOf(4.0, PositionMatch::Less);
+    CPPUNIT_ASSERT(index && *index == 3);
+    index = sd.indexOf(4.0, PositionMatch::LessOrEqual);
+    CPPUNIT_ASSERT(index && *index == 4);
+    index = sd.indexOf(4.0, PositionMatch::Equal);
+    CPPUNIT_ASSERT(index && *index == 4);
+    index = sd.indexOf(4.0, PositionMatch::GreaterOrEqual);
+    CPPUNIT_ASSERT(index && *index == 4);
+    index = sd.indexOf(4.0, PositionMatch::Greater);
+    CPPUNIT_ASSERT(!index);
+
+    index = sd.indexOf(5.0, PositionMatch::Less);
+    CPPUNIT_ASSERT(index && *index == 4);
+    index = sd.indexOf(5.0, PositionMatch::LessOrEqual);
+    CPPUNIT_ASSERT(index && *index == 4);
+    index = sd.indexOf(5.0, PositionMatch::Equal);
+    CPPUNIT_ASSERT(!index);
+    index = sd.indexOf(5.0, PositionMatch::GreaterOrEqual);
+    CPPUNIT_ASSERT(!index);
+    index = sd.indexOf(5.0, PositionMatch::Greater);
+    CPPUNIT_ASSERT(!index);
+
+    sd.labels(boost::none);
+    index = sd.indexOf(5.0, PositionMatch::Less);
+    CPPUNIT_ASSERT(index && *index == 4);
+    index = sd.indexOf(5.0, PositionMatch::LessOrEqual);
+    CPPUNIT_ASSERT(index && *index == 5);
+    index = sd.indexOf(5.0, PositionMatch::Equal);
+    CPPUNIT_ASSERT(index && *index == 5);
+    index = sd.indexOf(5.0, PositionMatch::GreaterOrEqual);
+    CPPUNIT_ASSERT(index && *index == 5);
+    index = sd.indexOf(5.0, PositionMatch::Greater);
+    CPPUNIT_ASSERT(index && *index == 6);
+
+    index = sd.indexOf(5.5, PositionMatch::Less);
+    CPPUNIT_ASSERT(index && *index == 5);
+    index = sd.indexOf(5.5, PositionMatch::LessOrEqual);
+    CPPUNIT_ASSERT(index && *index == 5);
+    index = sd.indexOf(5.5, PositionMatch::Equal);
+    CPPUNIT_ASSERT(!index);
+    index = sd.indexOf(5.5, PositionMatch::GreaterOrEqual);
+    CPPUNIT_ASSERT(index && *index == 6);
+    index = sd.indexOf(5.5, PositionMatch::Greater);
+    CPPUNIT_ASSERT(index && *index == 6);
+}
 
 void BaseTestDimension::testRangeDimLabel() {
     std::string label = "aLabel";

--- a/test/BaseTestDimension.hpp
+++ b/test/BaseTestDimension.hpp
@@ -39,6 +39,7 @@ public:
     void testSampledDimAxis();
 
     void testSetDimLabels();
+    void testSetDimIndexOf();
 
     void testRangeDimLabel();
     void testRangeTicks();

--- a/test/BaseTestDimension.hpp
+++ b/test/BaseTestDimension.hpp
@@ -33,6 +33,7 @@ public:
     void testSampledDimUnit();
     void testSampledDimSamplingInterval();
     void testSampledDimOperators();
+    void testSampledDimIndexOfOld();
     void testSampledDimIndexOf();
     void testSampledDimPositionAt();
     void testSampledDimAxis();

--- a/test/BaseTestDimension.hpp
+++ b/test/BaseTestDimension.hpp
@@ -42,6 +42,7 @@ public:
     void testRangeDimLabel();
     void testRangeTicks();
     void testRangeDimUnit();
+    void testRangeDimIndexOfOld();
     void testRangeDimIndexOf();
     void testRangeDimTickAt();
     void testRangeDimAxis();

--- a/test/BaseTestDimension.hpp
+++ b/test/BaseTestDimension.hpp
@@ -45,7 +45,8 @@ public:
     void testRangeDimIndexOf();
     void testRangeDimTickAt();
     void testRangeDimAxis();
-
+    void testRangeDimPositionInRange();
+    
     void testAsDimensionMethods();
 };
 

--- a/test/hdf5/TestDataAccessHDF5.hpp
+++ b/test/hdf5/TestDataAccessHDF5.hpp
@@ -17,8 +17,11 @@ class TestDataAccessHDF5 : public BaseTestDataAccess {
 
     CPPUNIT_TEST_SUITE(TestDataAccessHDF5);
     CPPUNIT_TEST(testPositionToIndexSampledDimension);
+    CPPUNIT_TEST(testPositionToIndexSampledDimensionOld);
     CPPUNIT_TEST(testPositionToIndexSetDimension);
+    CPPUNIT_TEST(testPositionToIndexSetDimensionOld);
     CPPUNIT_TEST(testPositionToIndexRangeDimension);
+    CPPUNIT_TEST(testPositionToIndexRangeDimensionOld);
     CPPUNIT_TEST(testOffsetAndCount);
     CPPUNIT_TEST(testPositionInData);
     CPPUNIT_TEST(testRetrieveData);

--- a/test/hdf5/TestDimensionHDF5.hpp
+++ b/test/hdf5/TestDimensionHDF5.hpp
@@ -32,6 +32,7 @@ class TestDimensionHDF5 : public BaseTestDimension {
     CPPUNIT_TEST(testRangeDimLabel);
     CPPUNIT_TEST(testRangeDimUnit);
     CPPUNIT_TEST(testRangeTicks);
+    CPPUNIT_TEST(testRangeDimIndexOfOld);
     CPPUNIT_TEST(testRangeDimIndexOf);
     CPPUNIT_TEST(testRangeDimPositionInRange);
     CPPUNIT_TEST(testRangeDimTickAt);

--- a/test/hdf5/TestDimensionHDF5.hpp
+++ b/test/hdf5/TestDimensionHDF5.hpp
@@ -26,6 +26,7 @@ class TestDimensionHDF5 : public BaseTestDimension {
     CPPUNIT_TEST(testSampledDimSamplingInterval);
     CPPUNIT_TEST(testSampledDimOperators);
     CPPUNIT_TEST(testSampledDimIndexOf);
+    CPPUNIT_TEST(testSampledDimIndexOfOld);
     CPPUNIT_TEST(testSampledDimPositionAt);
     CPPUNIT_TEST(testSampledDimAxis);
     CPPUNIT_TEST(testSetDimLabels);

--- a/test/hdf5/TestDimensionHDF5.hpp
+++ b/test/hdf5/TestDimensionHDF5.hpp
@@ -33,6 +33,7 @@ class TestDimensionHDF5 : public BaseTestDimension {
     CPPUNIT_TEST(testRangeDimUnit);
     CPPUNIT_TEST(testRangeTicks);
     CPPUNIT_TEST(testRangeDimIndexOf);
+    CPPUNIT_TEST(testRangeDimPositionInRange);
     CPPUNIT_TEST(testRangeDimTickAt);
     CPPUNIT_TEST(testRangeDimAxis);
     CPPUNIT_TEST(testAsDimensionMethods);

--- a/test/hdf5/TestDimensionHDF5.hpp
+++ b/test/hdf5/TestDimensionHDF5.hpp
@@ -30,6 +30,7 @@ class TestDimensionHDF5 : public BaseTestDimension {
     CPPUNIT_TEST(testSampledDimPositionAt);
     CPPUNIT_TEST(testSampledDimAxis);
     CPPUNIT_TEST(testSetDimLabels);
+    CPPUNIT_TEST(testSetDimIndexOf);
     CPPUNIT_TEST(testRangeDimLabel);
     CPPUNIT_TEST(testRangeDimUnit);
     CPPUNIT_TEST(testRangeTicks);


### PR DESCRIPTION
This pull request is the first step for fixing the issue raised in #818 
Adds some overloads to the RangeDimension::indexOf method family that allow for some behavior controlling. Unfortunately, the original indexOf behavior needed to be altered a bit. Invalid positions will not raise an exception. There is, however a new method that allows for cheking if a position is in range.

I made some decisions I would like to discuss:

1. is it a good idea to allow end be less than start? At the moment I check and simply swap the variables (line 467 in Dimension.cpp).
2. is it a good idea to silently ignore invalid ranges? Currently they are simply not part of the result vector. Alternatively the vector could contain optionals.
3. The method for getting start and end indices of a single range (start and end positions) now also takes a vector of ticks (lines 460 et seq.). This to avoid mulitple retrievals of the ticks which would happen because this method might be repeatedly called by the vector-of-starts-and-ends version. Issue is, that I want to have the ticks argument optional. , i.e. method calls with ``{}`` instead of a vector. This forbids to pass the ticks vector as reference. So there is some copying going on, is there a good way to avoid this?

edit: test failures are expected :)

edit 2: I think this thing is good for review. Regarding the questions stressed above, the current states are: 
1. yes, I think so and this done exactly this way
2. no, it is not. There are overloaded functions that return optionals which are not initialised for invalid ranges. Original functions (deprecated) will throw errors.
3. kept it like that, tried in an intermediate version an rValue reference but, (according to @gicmo) repeated std::move is not a good idea, so this was removed again