### PR TITLE
Overhaul of the indexOf methods and data retrieval ...

### DIFF
--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -985,12 +985,17 @@ public:
      *
      * Method will return the index equal or larger than the respective positions
      *
+     * Version 1.4.5: The behavior of this function has been slightly changed,
+     * it now throws an OutOfBounds exception if the position is not in the
+     * range. Use positionInRange(position) to check before calling this function.
+     *
      * @param start      The start position
      * @param end        The end position
      *
      * @return  Start and end index returned in a std::pair.
+     * @deprecated This function has been deprecated! Use indexOf(position, PositionMatch) instead.
      */
-    std::pair<ndsize_t, ndsize_t> indexOf(const double start, const double end) const;
+    DEPRECATED std::pair<ndsize_t, ndsize_t> indexOf(const double start, const double end) const;
 
 
      /**

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -957,6 +957,26 @@ public:
 
 
     /**
+     * @brief Returns the start and end index of the given start and end
+     * positions.  By default, the range includes the end position. This can be
+     * controlled via the RangeMatch enum.
+     *
+     *
+     * @param start      The start position
+     * @param end        The end position
+     * @param ticks      std::vector<double> of ticks, if empty ({}) they are automatically retrieved
+     * @param range      RangeMatch enum, controls whether end is included or not, 
+     *                   defaults to RangeMatch::Inclusive
+     *
+     * @return           Start and end indices returned in a boost::optional<std::pair>
+     *                   which is invalid if out of range.
+     */
+    boost::optional<std::pair<ndsize_t, ndsize_t>> indexOf(double start, double end,
+                                                           std::vector<double> ticks,
+                                                           RangeMatch match = RangeMatch::Inclusive) const;
+
+   
+    /**
      * @brief Returns the index of the given position
      *
      * Method will return the index of the tick that matches or is close to

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -890,9 +890,12 @@ public:
     /**
      * @brief Returns the index of the given position
      *
-     * Method will return the index equal or larger than position
+     * Method will return the index of the tick that matches or is close to
+     * position. If "less_or_equal" is true, the index of the first tick that is
+     * less or equal is given. If "less_or_equal" is false the index of the
+     * first index that is greater than than position is returned.
      *
-     * @param position    The position.
+     * @param position       The position.
      * @param less_or_equal  If true, the first index that is less or
      *                       equal will be returned. Else, the first index
      *                       that is not less than position will be returned.

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -19,6 +19,31 @@ class DataArray;
 class Dimension;
 
 /**
+ * @brief Enumeration providing constants for position matching.
+ *
+ * These constants are used to control the behaviour of the index finding.
+ */
+enum class PositionMatch {
+                          Equal,
+                          Less,
+                          Greater,
+                          GreaterOrEqual,
+                          LessOrEqual
+};
+
+/**
+ * @brief Enumeration providing constants for position matching.
+ *
+ * These constants are used as Return values when checking if a position is in
+ * the data range.
+ */
+enum class PositionInRange{
+                          InRange,
+                          Greater,
+                          Less
+};
+
+/**
  * @brief Dimension descriptor for regularly sampled dimensions.
  *
  * Instances of the SampledDimension Class are used to describe a dimension of data in

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -931,6 +931,19 @@ public:
      * @brief Returns the index of the given position
      *
      * Method will return the index of the tick that matches or is close to
+     * position. The way of matching can be controlled using the PositionMatch
+     * enum.
+     * 
+     * @param position The position.  
+     * @param matching PositionMatch enum entry that defines the matching
+     *                 behavior. 
+     *
+     * @return boost optional containing the index if valid
+     *
+     */
+    boost::optional<ndsize_t> indexOf(const double position, PositionMatch matching) const;
+
+
     /**
      * @brief Returns the index of the given position
      *

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -1025,18 +1025,18 @@ public:
      *
      * @param start_positions    Vector of start positions
      * @param end_positions      Vector of end positions
-     * @param match              Enum entry that defines whether the range is inclusive
-     *                           or exclusive regarding the end position
      * @param strict             Bool that indicates whether the function will throw an
      *                           OutOfBounds exception when an invalid range occurred or
      *                           if such ranges are silently ignored. Default is true.
+     * @param match              Enum entry that defines whether the range is inclusive
+     *                           or exclusive regarding the end position
      *
      * @return  Vector of pairs of start and end indices.
+     * @deprecated This function has been deprecated and will be removed in future versions!
      */
-    std::vector<std::pair<ndsize_t, ndsize_t>> indexOf(const std::vector<double> &start_positions,
-                                                       const std::vector<double> &end_positions,
-                                                       RangeMatch match = RangeMatch::Inclusive,
-                                                       bool strict = true) const;
+    DEPRECATED std::vector<std::pair<ndsize_t, ndsize_t>> indexOf(const std::vector<double> &start_positions,
+                                                                  const std::vector<double> &end_positions,
+                                                                  bool strict, RangeMatch match = RangeMatch::Inclusive) const;
 
 
      /**

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -35,7 +35,7 @@ enum class PositionMatch {
  * @brief Enumeration providing constants for range matching.
  *
  * These constants are used to control the behaviour of the range finding.
- * Inclusive means [start, end], i.e. start and end are included 
+ * Inclusive means [start, end], i.e. start and end are included
  * Exclusive means [start, end), i.e. start is included, end is not
  */
 enum class RangeMatch {
@@ -53,7 +53,7 @@ enum class PositionInRange{
                           InRange,
                           Greater,
                           Less,
-                          
+
                           NoRange = -1
 };
 
@@ -945,10 +945,10 @@ public:
      * Method will return the index of the tick that matches or is close to
      * position. The way of matching can be controlled using the PositionMatch
      * enum.
-     * 
-     * @param position The position.  
+     *
+     * @param position The position.
      * @param matching PositionMatch enum entry that defines the matching
-     *                 behavior. 
+     *                 behavior.
      *
      * @return boost optional containing the index if valid
      *
@@ -965,17 +965,17 @@ public:
      * @param start      The start position
      * @param end        The end position
      * @param ticks      std::vector<double> of ticks, if empty ({}) they are automatically retrieved
-     * @param range      RangeMatch enum, controls whether end is included or not, 
+     * @param range      RangeMatch enum, controls whether end is included or not,
      *                   defaults to RangeMatch::Inclusive
      *
      * @return           Start and end indices returned in a boost::optional<std::pair>
      *                   which is invalid if out of range.
      */
     boost::optional<std::pair<ndsize_t, ndsize_t>> indexOf(double start, double end,
-                                                           std::vector<double> ticks,
+                                                           std::vector<double> &&ticks,
                                                            RangeMatch match = RangeMatch::Inclusive) const;
 
-   
+
     /**
      * @brief Returns the index of the given position
      *
@@ -983,7 +983,7 @@ public:
      * position. If "less_or_equal" is true, the index of the first tick that is
      * less or equal is given. If "less_or_equal" is false the index of the
      * first index that is greater than than position is returned.
-     * 
+     *
      * Version 1.4.5: The behavior of this function has been slightly changed,
      * it now throws an OutOfBounds exception if the position is not in the
      * range. Use positionInRange(position) to check before calling this function.

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -1039,6 +1039,22 @@ public:
                                                        bool strict = true) const;
 
 
+     /**
+     * @brief Returns a vector of start and end indices of given start and end positions.
+     *
+     * Method will return the index equal or larger than the respective positions
+     *
+     * @param start_positions    Vector of start positions
+     * @param end_positions      Vector of end positions
+     * @param match              Enum entry that defines whether the range is inclusive
+     *                           or exclusive regarding the end position
+     *
+     * @return  Vector of optional pairs of start and end indices.
+     */
+    std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> indexOf(const std::vector<double> &start_positions,
+                                                                        const std::vector<double> &end_positions,
+                                                                        RangeMatch match = RangeMatch::Inclusive) const;
+
     /**
      * @brief Returns a vector containing a number of ticks
      *

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -32,6 +32,18 @@ enum class PositionMatch {
 };
 
 /**
+ * @brief Enumeration providing constants for range matching.
+ *
+ * These constants are used to control the behaviour of the range finding.
+ * Inclusive means [start, end], i.e. start and end are included 
+ * Exclusive means [start, end), i.e. start is included, end is not
+ */
+enum class RangeMatch {
+                       Inclusive,
+                       Exclusive
+};
+
+/**
  * @brief Enumeration providing constants for position matching.
  *
  * These constants are used as return values when checking if a position is in

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -1082,8 +1082,7 @@ public:
      * @return           Start and end indices returned in a boost::optional<std::pair>
      *                   which is invalid if out of range.
      */
-    boost::optional<std::pair<ndsize_t, ndsize_t>> indexOf(double start, double end,
-                                                           std::vector<double> &&ticks,
+    boost::optional<std::pair<ndsize_t, ndsize_t>> indexOf(double start, double end, std::vector<double> ticks,
                                                            RangeMatch match = RangeMatch::Inclusive) const;
 
 

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -1025,12 +1025,18 @@ public:
      *
      * @param start_positions    Vector of start positions
      * @param end_positions      Vector of end positions
+     * @param match              Enum entry that defines whether the range is inclusive
+     *                           or exclusive regarding the end position
+     * @param strict             Bool that indicates whether the function will throw an
+     *                           OutOfBounds exception when an invalid range occurred or
+     *                           if such ranges are silently ignored. Default is true.
      *
      * @return  Vector of pairs of start and end indices.
      */
     std::vector<std::pair<ndsize_t, ndsize_t>> indexOf(const std::vector<double> &start_positions,
                                                        const std::vector<double> &end_positions,
-                                                       RangeMatch match = RangeMatch::Inclusive) const;
+                                                       RangeMatch match = RangeMatch::Inclusive,
+                                                       bool strict = true) const;
 
 
     /**

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -273,8 +273,24 @@ public:
      * @param position  The position, e.g. a time
      *
      * @returns The respective index.
+     * @deprecated This function has been deprecated use {@link SampledDimension::indexOf} instead.
      */
-    ndsize_t indexOf(const double position) const;
+    DEPRECATED ndsize_t indexOf(const double position) const;
+
+    /**
+     * @brief Returns the index of the given position.
+     *
+     * This method returns the index of the given position. Use this method for
+     * example to find out which data point (index) relates to a given
+     * time. If the position is invalid, an invalid optional is returned.
+     *
+     * @param position  The position, e.g. a time
+     * @param strict    Defines whether an exception should be thrown if the
+     *                  position is invalid
+     *
+     * @returns An optional containing the respective index.
+     */
+    boost::optional<ndsize_t> indexOf(const double position, PositionMatch match) const;
 
 
     /**
@@ -294,8 +310,13 @@ public:
      * 
      * @returns The respective index.
      */
-    std::pair<ndsize_t, ndsize_t> indexOf(const double start, const double end, RangeMatch match = RangeMatch::Inclusive) const;
-
+    boost::optional<std::pair<ndsize_t, ndsize_t>> indexOf(const double start, const double end, RangeMatch match) const;
+    
+    /**
+     * @deprecated This function has been deprecated please use
+     *             {@link SampledDimension::indexOf(const double, const double&, const RangeMatch)} instead
+     */
+    DEPRECATED std::pair<ndsize_t, ndsize_t> indexOf(const double start, const double end) const;
    
     /**
      * @brief Returns the index of the given position.
@@ -314,10 +335,10 @@ public:
      *                             including the end position or exclusive, i.e. without 
      *                             the end position, default is RangeMatch::Inclusive
      * 
-     * @returns The pair of start and end indices.
+     * @returns The a boost::optional containing the pair of start and end indices.
      */
-    std::pair<ndsize_t, ndsize_t> indexOf(double start, double end, const double sampling_interval, const double offset,
-                                          RangeMatch match = RangeMatch::Inclusive) const;
+    boost::optional<std::pair<ndsize_t, ndsize_t>> indexOf(double start, double end, const double sampling_interval, const double offset,
+                                                           const RangeMatch match) const;
     
     
     /**
@@ -331,11 +352,20 @@ public:
      *                           including the end position or exclusive, i.e. without 
      *                           the end position, default is RangeMatch::Inclusive
      *
-     * @return  Vector of pairs of start and end indices.
+     * @return  Vector of optionals containing pairs of start and end indices.
      */
-    std::vector<std::pair<ndsize_t, ndsize_t>> indexOf(const std::vector<double> &start_positions,
-                                                       const std::vector<double> &end_positions,
-                                                       RangeMatch match = RangeMatch::Inclusive) const;
+    std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> indexOf(const std::vector<double> &start_positions,
+                                                                        const std::vector<double> &end_positions,
+                                                                        const RangeMatch match) const;
+
+    /**
+     * @deprecated This function has been deprecated please use
+     *             {@link SampledDimension::indexOf(const std::vector<double>&, const std::vector<double>&, const RangeMatch)} instead
+     */
+    DEPRECATED std::vector<std::pair<ndsize_t, ndsize_t>> indexOf(const std::vector<double> &start_positions,
+                                                                  const std::vector<double> &end_positions) const;
+
+
 
     /**
      * @brief Returns the position of this dimension at a given index.

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -931,9 +931,17 @@ public:
      * @brief Returns the index of the given position
      *
      * Method will return the index of the tick that matches or is close to
+    /**
+     * @brief Returns the index of the given position
+     *
+     * Method will return the index of the tick that matches or is close to
      * position. If "less_or_equal" is true, the index of the first tick that is
      * less or equal is given. If "less_or_equal" is false the index of the
      * first index that is greater than than position is returned.
+     * 
+     * Version 1.4.5: The behavior of this function has been slightly changed,
+     * it now throws an OutOfBounds exception if the position is not in the
+     * range. Use positionInRange(position) to check before calling this function.
      *
      * @param position       The position.
      * @param less_or_equal  If true, the first index that is less or
@@ -941,8 +949,10 @@ public:
      *                       that is not less than position will be returned.
      *
      * @return The index.
+     *
+     * @deprecated This function has been deprecated! Use indexOf(position, PositionMatch) instead.
      */
-    ndsize_t indexOf(const double position, bool less_or_equal = true) const;
+    DEPRECATED ndsize_t indexOf(const double position, bool less_or_equal = true) const;
 
 
     /**

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -602,7 +602,52 @@ class NIXAPI DataFrameDimension : public base::ImplContainer<base::IDataFrameDim
         df.readColumn(*column_index, ticks, true, offset);
     }
 
+    /**
+    * @brief returns the index in this dimension that matches the given position. 
+    * 
+    * @param position   The position that should be converted to a corresponding index in the dimension.
+    * @param match      The matching rule for the position {@link PositionMatch}.
+    * 
+    * @return an boost::optional containing the index. 
+    */
+    boost::optional<ndsize_t> indexOf(const double position, const PositionMatch match) const;
 
+    /**
+    * @brief Converts a range defined by start and end position to the corresponding indices in the dimension.
+    * 
+    * @param start_position   The start position that should be converted to a corresponding index in the dimension.
+    * @param end_position     The start position that should be converted to a corresponding index in the dimension.
+    * @param range_match      The matching rule for the position {@link RangeMatch}.
+    * 
+    * @return an boost::optional containing a std::pair of start and end index. 
+    */
+    boost::optional<std::pair<ndsize_t, ndsize_t>> indexOf(double start_position, double end_position, RangeMatch range_match) const;
+    
+    /**
+    * @brief Converts a range defined by start and end position to the corresponding indices in the dimension. Mostly needed internally.
+    * 
+    * @param start_position   The start position that should be converted to a corresponding index in the dimension.
+    * @param end_position     The start position that should be converted to a corresponding index in the dimension.
+    * @param tick_count       The number of of ticks stored in this dimension.
+    * @param range_match      The matching rule for the range {@link RangeMatch}.
+    * 
+    * @return an boost::optional containing a std::pair of start and end index. 
+    */
+    boost::optional<std::pair<ndsize_t, ndsize_t>> indexOf(double start_position, double end_position, ndsize_t tick_count, RangeMatch range_match) const;
+
+    /**
+     * @brief Converts a set of start and end positions to a vector of pairs of start and end indices.
+     * 
+     * @param start_positions  std::vector of start positions. 
+     * @param end_positions    std::vector of end positions. 
+     * @param range_match      The matching rule for the range {@link RangeMatch}.
+     * 
+     * @return A std::vector of boost::optionals containing pairs of start and end indices.
+    */
+    std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> indexOf(const std::vector<double> &start_positions,
+                                                                        const std::vector<double> &end_positions,
+                                                                        const RangeMatch range_match) const;
+    
     /**
      * @brief returns the number of entries in the dimension, aka the number of
      * rows in the DataFrame.

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -769,6 +769,31 @@ public:
      */
     boost::optional<ndsize_t> indexOf(const double position, const PositionMatch match) const;
 
+
+    /**
+     * @brief returns the start and end indices corresponding to the provided start and end positions.
+     * 
+     * @param  start    double, the start position
+     * @param  end      double, the end position 
+     * @param  match    RangeMatch, controls whether the range includes the end position or not.
+     * 
+     * @return optional containing a pair of ndsize_t.
+     */
+    boost::optional<std::pair<ndsize_t, ndsize_t>> indexOf(const double start, const double end, const RangeMatch match) const;
+
+    /**
+     * @brief returns the start and end indices corresponding to the provided start and end positions.
+     * 
+     * @param  start    double, the start position
+     * @param  end      double, the end position 
+     * @param  labels   vector<string> of labels
+     * @param  match    RangeMatch, controls whether the range includes the end position or not.
+     * 
+     * @return optional containing a pair of ndsize_t.
+     */
+    boost::optional<std::pair<ndsize_t, ndsize_t>> indexOf(const double start, const double end, std::vector<std::string> &set_labels, const RangeMatch match) const;
+    
+    
     /**
      * @brief Assignment operator.
      *

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -267,7 +267,8 @@ public:
      * This method returns the index of the given position. Use this method for
      * example to find out which data point (index) relates to a given
      * time. Note: This method does not check if the position is within the
-     * extent of the data!
+     * extent of the data! Nevertheless, an OutOfBounds exception is thrown if
+     * the position is less than the offset of the dimension.
      *
      * @param position  The position, e.g. a time
      *
@@ -279,31 +280,62 @@ public:
     /**
      * @brief Returns a pair of indices of the start and end positions within this dimension.
      *
-     * This method returns the indices of the given start and end positions. Use this method for
-     * example to find out which data indices relate to a given start and end positions given in
-     * time. Note: This method does not check if the positions are within the
-     * extent of the data!
+     * This method returns the index of the given position. Use this method for
+     * example to find out which data point (index) relates to a given
+     * time. Note: This method does not check if the position is within the
+     * extent of the data! Nevertheless, an OutOfBounds exception is thrown if
+     * the start position is less than the offset of the dimension.
      *
-     * @param start  The start position of, e.g., a time segment
-     * @param end    The end position
-     *
-     * @returns The pair of respective indices.
+     * @param start          The start position, e.g. a time
+     * @param end            The end position
+     * @param match          RangeMatch enum to control whether the range should be
+     *                       including the end position or exclusive, i.e. without 
+     *                       the end position, default is RangeMatch::Inclusive
+     * 
+     * @returns The respective index.
      */
-    std::pair<ndsize_t, ndsize_t> indexOf(const double start, const double end) const;
+    std::pair<ndsize_t, ndsize_t> indexOf(const double start, const double end, RangeMatch match = RangeMatch::Inclusive) const;
 
-
+   
+    /**
+     * @brief Returns the index of the given position.
+     *
+     * This method returns the index of the given position. Use this method for
+     * example to find out which data point (index) relates to a given
+     * time. Note: This method does not check if the position is within the
+     * extent of the data! Nevertheless, an OutOfBounds exception is thrown if
+     * the start position is less than the offset of the dimension.
+     *
+     * @param start                The start position, e.g. a time
+     * @param end                  The end position
+     * @param sampling_interval    The sampling interval of the dimension.
+     * @param offset               The offset of the dimension.
+     * @param match                RangeMatch enum to control whether the range should be
+     *                             including the end position or exclusive, i.e. without 
+     *                             the end position, default is RangeMatch::Inclusive
+     * 
+     * @returns The pair of start and end indices.
+     */
+    std::pair<ndsize_t, ndsize_t> indexOf(double start, double end, const double sampling_interval, const double offset,
+                                          RangeMatch match = RangeMatch::Inclusive) const;
+    
+    
     /**
      * @brief Returns a vector of start and end indices of given start and end positions.
-     *
-     * Method will return the index equal or larger than the respective positions
+     * This method does not check whether the index is in the extent of the data. Nevertheless,
+     * an OutOfBounds exception is thrown if the start position is less than the offset of the dimension.
      *
      * @param start_positions    Vector of start positions
      * @param end_positions      Vector of end positions
+     * @param match              RangeMatch enum to control whether the range should be
+     *                           including the end position or exclusive, i.e. without 
+     *                           the end position, default is RangeMatch::Inclusive
      *
      * @return  Vector of pairs of start and end indices.
      */
     std::vector<std::pair<ndsize_t, ndsize_t>> indexOf(const std::vector<double> &start_positions,
-                                                       const std::vector<double> &end_positions) const;
+                                                       const std::vector<double> &end_positions,
+                                                       RangeMatch match = RangeMatch::Inclusive) const;
 
     /**
      * @brief Returns the position of this dimension at a given index.
@@ -724,10 +756,10 @@ public:
 /**
  * @brief Dimension descriptor for a dimension that is irregularly sampled.
  *
- * The RangeDimension covers cases when indexes of a dimension are mapped to other values
- * in a not regular fashion. A use-case for this would be for example irregularly sampled
- * time-series or certain kinds of histograms. To achieve the mapping of the indexes an
- * array of mapping values must be provided. Those values are stored in the dimensions {@link ticks}
+ * The RangeDimension covers cases in which indicess of a dimension are mapped to other values
+ * in a non-regular fashion. For example, when event times are recorded that would occur in irregularly 
+ * intervals. To achieve the mapping of the indexes an array of mapping values must be provided. 
+ * Those values are stored in the dimensions {@link ticks}
  * property. In analogy to the sampled dimension a {@link unit} and a {@link label} can be defined.
  */
 class NIXAPI RangeDimension : public base::ImplContainer<base::IRangeDimension> {

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -1029,7 +1029,8 @@ public:
      * @return  Vector of pairs of start and end indices.
      */
     std::vector<std::pair<ndsize_t, ndsize_t>> indexOf(const std::vector<double> &start_positions,
-                                                       const std::vector<double> &end_positions) const;
+                                                       const std::vector<double> &end_positions,
+                                                       RangeMatch match = RangeMatch::Inclusive) const;
 
 
     /**

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -333,7 +333,7 @@ public:
      * @param offset               The offset of the dimension.
      * @param match                RangeMatch enum to control whether the range should be
      *                             including the end position or exclusive, i.e. without 
-     *                             the end position, default is RangeMatch::Inclusive
+     *                             the end position.
      * 
      * @returns The a boost::optional containing the pair of start and end indices.
      */
@@ -350,7 +350,7 @@ public:
      * @param end_positions      Vector of end positions
      * @param match              RangeMatch enum to control whether the range should be
      *                           including the end position or exclusive, i.e. without 
-     *                           the end position, default is RangeMatch::Inclusive
+     *                           the end position.
      *
      * @return  Vector of optionals containing pairs of start and end indices.
      */
@@ -1128,7 +1128,7 @@ public:
      *                   which is invalid if out of range.
      */
     boost::optional<std::pair<ndsize_t, ndsize_t>> indexOf(double start, double end, std::vector<double> ticks,
-                                                           RangeMatch match = RangeMatch::Inclusive) const;
+                                                           RangeMatch match = RangeMatch::Exclusive) const;
 
 
     /**
@@ -1208,7 +1208,7 @@ public:
      */
     std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> indexOf(const std::vector<double> &start_positions,
                                                                         const std::vector<double> &end_positions,
-                                                                        RangeMatch match = RangeMatch::Inclusive) const;
+                                                                        RangeMatch match = RangeMatch::Exclusive) const;
 
     /**
      * @brief Returns a vector containing a number of ticks

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -759,6 +759,17 @@ public:
     }
 
     /**
+     * @brief converts a position given as a double to an index in this dimension, if 
+     * it contains labels, then the position will be validated within these limits.
+     * 
+     * @param  position       The position.
+     * @param  match          Memeber of the {@link PositionMatch} enumeration to control conversion.
+     * 
+     * @return An optional containing the index, if valid.
+     */
+    boost::optional<ndsize_t> indexOf(const double position, const PositionMatch match) const;
+
+    /**
      * @brief Assignment operator.
      *
      * @param other     The dimension to assign.

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -793,7 +793,20 @@ public:
      */
     boost::optional<std::pair<ndsize_t, ndsize_t>> indexOf(const double start, const double end, std::vector<std::string> &set_labels, const RangeMatch match) const;
     
-    
+    /**
+     * @brief converts vectors of start and end positions to a vector of optionals containg start and end indices.
+     * 
+     * @param start_positions    vector of start positions
+     * @param end_positions      vector of end positions
+     * @param match              Member of the RangeMatch enum to control whether ranges are inclusive or exclusiv the end positions
+     * 
+     * @return vector of optionals containing a pair of start and end indices
+     */
+    std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> indexOf(const std::vector<double> &start_positions,
+                                                                        const std::vector<double> &end_positions,
+                                                                        const RangeMatch match) const;
+
+
     /**
      * @brief Assignment operator.
      *

--- a/include/nix/Dimensions.hpp
+++ b/include/nix/Dimensions.hpp
@@ -34,13 +34,15 @@ enum class PositionMatch {
 /**
  * @brief Enumeration providing constants for position matching.
  *
- * These constants are used as Return values when checking if a position is in
+ * These constants are used as return values when checking if a position is in
  * the data range.
  */
 enum class PositionInRange{
                           InRange,
                           Greater,
-                          Less
+                          Less,
+                          
+                          NoRange = -1
 };
 
 /**
@@ -901,6 +903,7 @@ public:
      */
     void ticks(const std::vector<double> &ticks);
 
+
     /**
      * @brief Returns the entry of the range dimension at a given index.
      *
@@ -911,6 +914,18 @@ public:
      * Method will throw an nix::OutOfBounds Exception if the index is invalid
      */
     double tickAt(const ndsize_t index) const;
+
+
+    /**
+     * @brief Checks whether a given position is in the Range of ticks in this
+     * dimension.
+     *
+     * @param position     The position.
+     *
+     * @return PositionInRange which can be either Less, Greater, or InRange
+     */
+    PositionInRange positionInRange(const double position) const;
+
 
     /**
      * @brief Returns the index of the given position

--- a/include/nix/util/dataAccess.hpp
+++ b/include/nix/util/dataAccess.hpp
@@ -249,11 +249,12 @@ NIXAPI void getOffestAndCount(const MultiTag &tag, const DataArray &array, const
  *                       Start and end are assumed to be given in the same unit. If no unit is required for a dimension
  *                       provide an empty string or "none". SI units will be automatically scaled. That is, a time
  *                       start may be given in s even though the dimension is defined in ms.
+ * @param range_match    RangeMatch to control range matching, default is RangeMatch::Exclusive.
  *
  * @returns {@link nix::DataView} the data slice.
  */
 NIXAPI DataView dataSlice(const DataArray &array, const std::vector<double> &start, const std::vector<double> &end,
-                          const std::vector<std::string> &units={}, RangeMatch match = RangeMatch::Inclusive);
+                          const std::vector<std::string> &units={}, RangeMatch match = RangeMatch::Exclusive);
 
 /**
  * @brief Retrieve several data segments that are tagged by the given position and extent of the MultiTag.
@@ -265,7 +266,7 @@ NIXAPI DataView dataSlice(const DataArray &array, const std::vector<double> &sta
  *
  * @return vector of nix::DataViews that contain the data tagged by the specified position indices.
  */
-NIXAPI std::vector<DataView> taggedData(const MultiTag &tag, std::vector<ndsize_t> &position_indices, const DataArray &array, RangeMatch match = RangeMatch::Inclusive); //TODO range support
+NIXAPI std::vector<DataView> taggedData(const MultiTag &tag, std::vector<ndsize_t> &position_indices, const DataArray &array, RangeMatch match = RangeMatch::Exclusive);
 
 /**
  * @brief Retrieve several data segments that are tagged by the given positions and extents of the MultiTag.
@@ -273,11 +274,11 @@ NIXAPI std::vector<DataView> taggedData(const MultiTag &tag, std::vector<ndsize_
  * @param tag                   The multi tag.
  * @param position_indices      The indices of the position.
  * @param reference_index       The index of the referenced DataArray.
- * @param match                 Controls the RangeMatch behavior.
+ * @param match                 Controls the RangeMatch behavior, default is RangeMatch::Exclusive.
  *
  * @return vector of nix::DataViews containing the data tagged by the specified position indices.
  */
-NIXAPI std::vector<DataView> taggedData(const MultiTag &tag, std::vector<ndsize_t> &position_indices, ndsize_t reference_index, RangeMatch match = RangeMatch::Inclusive);
+NIXAPI std::vector<DataView> taggedData(const MultiTag &tag, std::vector<ndsize_t> &position_indices, ndsize_t reference_index, RangeMatch match = RangeMatch::Exclusive);
 
 /**
  * @brief Retrieve several data segments referenced by the given position and extent of the MultiTag.
@@ -285,6 +286,7 @@ NIXAPI std::vector<DataView> taggedData(const MultiTag &tag, std::vector<ndsize_
  * @param tag                   The multi tag.
  * @param position_indices      The indices of the positions.
  * @param array                 The referenced DataArray.
+ * @param range_match           RangeMatch to control range matching, default is RangeMatch::Inclusive.
  *
  * @return The data referenced by the specified indices, respectively their positions and extents.
  * @deprecated This function has been deprecated! Use taggedData(MultiTag, vector<ndsize_t>, DataArray) instead.
@@ -297,6 +299,8 @@ NIXAPI DEPRECATED std::vector<DataView> retrieveData(const MultiTag &tag, std::v
  * @param tag                   The multi tag.
  * @param position_indices      The indices of the position.
  * @param reference_index       The index of the referenced DataArray.
+ * @param range_match           RangeMatch to control range matching, default is RangeMatch::Inclusive.
+
  *
  * @return The data referenced by the specified indices, respectively their positions and extents.
  * @deprecated This function has been deprecated! Use taggedData(MultiTag, vector<ndsize_t>, reference_index) instead.
@@ -309,12 +313,14 @@ NIXAPI DEPRECATED std::vector<DataView> retrieveData(const MultiTag &tag, std::v
  * @param tag                   The multi tag.
  * @param position_indice       The index of the position, extent.
  * @param reference_index       The index of the referenced DataArray.
+ * @param range_match           RangeMatch to control range matching, default is RangeMatch::Exclusive.
+ * 
  *
  * @return nix::DataView containing the data tagged by the specified position index.
  */
-NIXAPI DataView taggedData(const MultiTag &tag, ndsize_t position_index, ndsize_t reference_index, RangeMatch match = RangeMatch::Inclusive);
+NIXAPI DataView taggedData(const MultiTag &tag, ndsize_t position_index, ndsize_t reference_index, RangeMatch match = RangeMatch::Exclusive);
 
-NIXAPI DataView taggedData(const MultiTag &tag, ndsize_t position_index, const DataArray &array, RangeMatch match = RangeMatch::Inclusive);
+NIXAPI DataView taggedData(const MultiTag &tag, ndsize_t position_index, const DataArray &array, RangeMatch match = RangeMatch::Exclusive);
 
 /**
  * @brief Retrieve the data referenced by the given position and extent of the MultiTag.
@@ -322,6 +328,7 @@ NIXAPI DataView taggedData(const MultiTag &tag, ndsize_t position_index, const D
  * @param tag                   The multi tag.
  * @param position_index        The index of the position.
  * @param array                 The referenced DataArray.
+ * @param range_match           RangeMatch to control range matching, default is RangeMatch::Inclusive.
  *
  * @return The data referenced by position and extent.
  * @deprecated This function has been deprecated! Use taggedData(MultiTag, vector<ndsize_t>, DataArray) instead.
@@ -334,6 +341,7 @@ NIXAPI DEPRECATED DataView retrieveData(const MultiTag &tag, ndsize_t position_i
  * @param tag                   The multi tag.
  * @param position_index        The index of the position.
  * @param reference_index       The index of the reference from which data should be returned.
+ * @param range_match           RangeMatch to control range matching, default is RangeMatch::Inclusive.
  *
  * @return The data referenced by position and extent.
  * @deprecated This function has been deprecated! Use taggedData(MultiTag, vector<ndsize_t>, DataArray) instead.
@@ -345,11 +353,11 @@ NIXAPI DEPRECATED DataView retrieveData(const MultiTag &tag, ndsize_t position_i
  *
  * @param tag                   The tag.
  * @param reference_index       The index of the reference of which data should be returned.
- * @param match                 RangeMatch to control range matching behavior.
+ * @param range_match           RangeMatch to control range matching behavior, default is RangeMatch::Exclusive.
  *
  * @return nix::DataView containing the tagged data.
  */
-NIXAPI DataView taggedData(const Tag &tag, ndsize_t reference_index, RangeMatch match = RangeMatch::Inclusive);
+NIXAPI DataView taggedData(const Tag &tag, ndsize_t reference_index, RangeMatch range_match = RangeMatch::Exclusive);
 
 /**
  * @brief Retrieve the data referenced by the given position and extent of the Tag.
@@ -368,18 +376,18 @@ NIXAPI DEPRECATED DataView retrieveData(const Tag &tag, ndsize_t reference_index
  *
  * @param tag                   The tag.
  * @param array                 The referenced DataArray.
- * @param match                 The range matching behavior, default //TODO
+ * @param range_match           RangeMatch to control range matching behavior, default is RangeMatch::Exclusive.
  *
  * @return nix::DataView containing the tagged data.
  */
-NIXAPI DataView taggedData(const Tag &tag, const DataArray &array, RangeMatch match = RangeMatch::Inclusive);
+NIXAPI DataView taggedData(const Tag &tag, const DataArray &array, RangeMatch range_match = RangeMatch::Exclusive);
 
 /**
  * @brief Retrieve the data referenced by the given position and extent of the Tag.
  *
  * @param tag                   The tag.
  * @param array                 The referenced DataArray.
- * @param match                 The range matching behavior, default //TODO
+ * @param match                 The range matching behavior, default is RangeMatch::Inclusive
  *
  * @return The data referenced by the position.
  * @deprecated This function has been deprecated! Use taggedData(Tag, DataArray) instead.
@@ -426,22 +434,22 @@ NIXAPI DEPRECATED DataView retrieveFeatureData(const Tag &tag, ndsize_t feature_
  *
  * @param tag           The Tag whos feature data is requested
  * @param feature_index The index of the desired feature. Default is 0.
- * @param match         RangeMatch argument to control range matching behavior. Default is //TODO
+ * @param match         RangeMatch argument to control range matching behavior. Default is RangeMatch::Exclusive
  *
  * @return The associated data.
  */
-NIXAPI DataView featureData(const Tag &tag, ndsize_t feature_index=0, RangeMatch range_match = RangeMatch::Inclusive);
+NIXAPI DataView featureData(const Tag &tag, ndsize_t feature_index=0, RangeMatch range_match = RangeMatch::Exclusive);
 
 /**
  * @brief Retruns the feature data associated with a Tag.
  *
  * @param tag           The Tag whos feature data is requested.
  * @param feature       The Feature of which the tagged data is requested.
- * @param match         RangeMatch argument to control range matching behavior. Default is //TODO
+ * @param match         RangeMatch argument to control range matching behavior. Default is RangeMatch::Exclusive
  *
  * @return The associated data.
  */
-NIXAPI DataView featureData(const Tag &tag, const Feature &feature, RangeMatch range_match = RangeMatch::Inclusive);
+NIXAPI DataView featureData(const Tag &tag, const Feature &feature, RangeMatch range_match = RangeMatch::Exclusive);
 
 
 /**
@@ -449,7 +457,7 @@ NIXAPI DataView featureData(const Tag &tag, const Feature &feature, RangeMatch r
  *
  * @param tag           The Tag whos feature data is requested.
  * @param feature       The Feature of which the tagged data is requested.
- * @param match         RangeMatch argument to control range matching behavior. Default is //TODO
+ * @param match         RangeMatch argument to control range matching behavior. Default is RangeMatch::Inclusive
  *
  * @return The associated data.
  * @deprecated This function has been deprecated! User featureData(Tag, Feature) instead.
@@ -478,11 +486,11 @@ NIXAPI DEPRECATED DataView retrieveFeatureData(const MultiTag &tag, ndsize_t pos
  * @param tag            The MultiTag whos feature data is requested.
  * @param position_index The index of the selected position, respectively the selected tag of the MultiTag.
  * @param feature_index  The index of the desired feature. Default is 0.
- * @param range_match         RangeMatch argument to control range matching behavior. Default is //TODO
+ * @param range_match         RangeMatch argument to control range matching behavior. Default is RangeMatch::Exclusive
  *
  * @return The associated data.
  */
-NIXAPI DataView featureData(const MultiTag &tag, ndsize_t position_index, ndsize_t feature_index=0, RangeMatch range_match = RangeMatch::Inclusive);
+NIXAPI DataView featureData(const MultiTag &tag, ndsize_t position_index, ndsize_t feature_index=0, RangeMatch range_match = RangeMatch::Exclusive);
 
 /**
  * @brief Returns the feature data associated with the given MuliTag's position.
@@ -505,11 +513,11 @@ NIXAPI DEPRECATED DataView retrieveFeatureData(const MultiTag &tag, ndsize_t pos
  * @param tag            The MultiTag whos feature data is requested.
  * @param position_index The index of the selected position, respectively the selected tag of the MultiTag.
  * @param feature        The feature of which the tagged data is requested.
- * @param match         RangeMatch argument to control range matching behavior. Default is //TODO
+ * @param match         RangeMatch argument to control range matching behavior. Default is RangeMatch::Exclusive
  *
  * @return The associated data.
  */
-NIXAPI DataView featureData(const MultiTag &tag, ndsize_t position_index, const Feature &feature, RangeMatch match = RangeMatch::Inclusive);
+NIXAPI DataView featureData(const MultiTag &tag, ndsize_t position_index, const Feature &feature, RangeMatch match = RangeMatch::Exclusive);
 
 /**
  * @brief Retruns the feature data associated with a MultiTag.
@@ -517,7 +525,7 @@ NIXAPI DataView featureData(const MultiTag &tag, ndsize_t position_index, const 
  * @param tag              The MultiTag whos feature data is requested
  * @param position_indices A vector of position indices.
  * @param feature_index    The index of the desired feature. Default is 0.
- * @param range_match      RangeMatch argument to control range matching behavior. Default is //TODO
+ * @param range_match      RangeMatch argument to control range matching behavior. Default is RangeMatch::Inclusive
  *
  * @return A vector of the associated data, may be empty.
  * @deprecated This function has been deprecated! Use featureData(MultiTag, std::vector<ndsize_t>, ndsize_t) instead.
@@ -530,12 +538,12 @@ NIXAPI DEPRECATED std::vector<DataView> retrieveFeatureData(const MultiTag &tag,
  * @param tag              The MultiTag whos feature data is requested
  * @param position_indices A vector of position indices.
  * @param feature_index    The index of the desired feature. Default is 0.
- * @param range_match         RangeMatch argument to control range matching behavior. Default is //TODO
+ * @param range_match         RangeMatch argument to control range matching behavior. Default is RangeMatch::Exclusive
  *
  * @return A vector of the associated data, may be empty.
  */
 NIXAPI std::vector<DataView> featureData(const MultiTag &tag, std::vector<ndsize_t> position_indices,
-                                         ndsize_t feature_index = 0, RangeMatch range_match = RangeMatch::Inclusive);
+                                         ndsize_t feature_index = 0, RangeMatch range_match = RangeMatch::Exclusive);
 
 /**
  * @brief Returns the feature data associated with the given MuliTag's positions.
@@ -559,12 +567,12 @@ NIXAPI DEPRECATED std::vector<DataView> retrieveFeatureData(const MultiTag &tag,
  * @param tag              The MultiTag whos feature data is requested.
  * @param position_indices A vector of position indices.
  * @param feature          The feature of which the tagged data is requested.
- * @param match         RangeMatch argument to control range matching behavior. Default is //TODO
+ * @param match         RangeMatch argument to control range matching behavior. Default is RangeMatch::Exclusive
  *
  * @return A vector of the associated data, may be empty.
  */
 NIXAPI std::vector<DataView> featureData(const MultiTag &tag, std::vector<ndsize_t> position_indices,
-                                         const Feature &feature, RangeMatch match = RangeMatch::Inclusive);
+                                         const Feature &feature, RangeMatch match = RangeMatch::Exclusive);
 
 } //namespace util
 } //namespace nix

--- a/include/nix/util/dataAccess.hpp
+++ b/include/nix/util/dataAccess.hpp
@@ -27,24 +27,27 @@ namespace nix {
 namespace util {
 
 /**
- * @brief Converts a position given in a unit into an index according to the dimension descriptor.
+ * @brief Converts a position to an index according to the dimension descriptor.
  *
  * This function can be used to get the index of e.g. a certain point in time in
  * a Dimension that represents time. The units of the position and that provided
  * by the Dimension must match, i.e.  must be scalable versions of the same SI
- * unit.  In case of a SetDimension the provided position is interpreted as an
- * index. Units are ignored and the position is rounded to the next integer.
+ * unit. In case of a SetDimension the provided position is interpreted as an
+ * index. Units are ignored.
+ * The match argument controls how the position is converted to an index.
  *
  * @param position      The position
- * @param unit          The unit in which the position is given, may be "none"
- * @param dimension     The dimension descriptor for the respective dimension.
+ * @param match         Member of the PositionMatch enum to control the matching.
+ * @param dimension     The dimension descriptor for the respective dimension, i.e. a SetDimension.
  *
  * @return The calculated index.
  *
  * @throws nix::IncompatibleDimension The the dimensions are incompatible.
  * @throws nix::OutOfBounds If the position either too large or too small for the dimension.
  */
-NIXAPI ndsize_t positionToIndex(double position, const std::string &unit, const SetDimension &dimension);
+NIXAPI boost::optional<ndsize_t> positionToIndex(double position, const PositionMatch match, const SetDimension &dimension);
+
+NIXAPI DEPRECATED ndsize_t positionToIndex(double position, const std::string &unit, const SetDimension &dimension);
 
  /**
  * @brief Converts a position given in a unit into an index according to the dimension descriptor.
@@ -83,7 +86,9 @@ NIXAPI ndsize_t positionToIndex(double position, const std::string &unit, const 
  * @throws nix::IncompatibleDimension The the dimensions are incompatible.
  * @throws nix::OutOfBounds If the position either too large or too small for the dimension.
  */
-NIXAPI ndsize_t positionToIndex(double position, const std::string &unit, const SampledDimension &dimension);
+NIXAPI  boost::optional<ndsize_t> positionToIndex(double position, const std::string &unit, const PositionMatch match, const SampledDimension &dimension);
+
+NIXAPI  DEPRECATED ndsize_t positionToIndex(double position, const std::string &unit, const SampledDimension &dimension);
 
 /**
  * @brief Converts a position given in a unit into an index according to the dimension descriptor.
@@ -96,55 +101,78 @@ NIXAPI ndsize_t positionToIndex(double position, const std::string &unit, const 
  * @param unit          The unit in which the position is given, may be "none"
  * @param dimension     The dimension descriptor for the respective dimension.
  *
- * @return The calculated index.
+ * @return An optional containng the index.
  *
  * @throws nix::IncompatibleDimension The the dimensions are incompatible.
  * @throws nix::OutOfBounds If the position either too large or too small for the dimension.
  */
-NIXAPI ndsize_t positionToIndex(double position, const std::string &unit, const RangeDimension &dimension);
+NIXAPI boost::optional<ndsize_t> positionToIndex(double position, const std::string &unit, const PositionMatch position_match, const RangeDimension &dimension);
 
-/**
- * @brief Converts the passed vector of start and end positions given in the respective units
- * into a vector of pairs of respective indices according to the dimension descriptor.
- * start_positions and end_positions must have the same number of entries.
+
+NIXAPI DEPRECATED ndsize_t positionToIndex(double position, const std::string &unit, const RangeDimension &dimension);
+
+ /**
+ * @brief Converts the passed vector of start and end positions in a unit into a vector of respective indices
+ * according to the dimension descriptor.
  *
  * This function can be used to get the index of e.g. a certain point in time in a Dimension that
  * represents time. The units of the position and that provided by the Dimension must match, i.e.
  * must be scalable versions of the same SI unit.
  *
- * @param start_positions     std::vector of the start positions
- * @param end_positions       std::vector of respective  end positions
- * @param units               std::vector of units in which the respective position is given,
- *                            must have the same size or may be empty
+ * @param positions     std::vector of positions
+ * @param units         std::vector of units in which the respective position is given, must have the same size or may
+ *                      be empty
+ * @param rangeMatching The desired range matching behavior see {@link Dimension::RangeMatch}.
  * @param dimension     The dimension descriptor for the respective dimension.
  *
  * @return A std::vector of pairs of calculated start and end indices.
  *
  * @throws nix::IncompatibleDimension The the dimensions are incompatible.
  * @throws nix::OutOfBounds If the position either too large or too small for the dimension.
+ */       
+NIXAPI std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> positionToIndex(const std::vector<double> &start_positions,
+                                                                                   const std::vector<double> &end_positions,
+                                                                                   const std::vector<std::string> &units,
+                                                                                   const RangeMatch rangeMatching,
+                                                                                   const SampledDimension &dimension);
+
+/**
+ * @deprecated this function has been deprecated see {@link nix::util::positionToIndex(const std::vector<double>&, const std::vector<double>&, const std::vector<std::string> &, const RangeMatch, const SampledDimension&)}
  */
-NIXAPI std::vector<std::pair<ndsize_t, ndsize_t>> positionToIndex(const std::vector<double> &start_positions,
-                                                                  const std::vector<double> &end_positions,
-                                                                  const std::vector<std::string> &units,
-                                                                  const SampledDimension &dimension);
+NIXAPI DEPRECATED std::vector<std::pair<ndsize_t, ndsize_t>> positionToIndex(const std::vector<double> &start_positions,
+                                                                             const std::vector<double> &end_positions,
+                                                                             const std::vector<std::string> &units,
+                                                                             const SampledDimension &dimension);
 
 
-NIXAPI std::vector<std::pair<ndsize_t, ndsize_t>> positionToIndex(const std::vector<double> &start_positions,
-                                                                  const std::vector<double> &end_positions,
-                                                                  const std::vector<std::string> &units,
-                                                                  const SetDimension &dimension);
+NIXAPI std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> positionToIndex(const std::vector<double> &start_positions,
+                                                                                   const std::vector<double> &end_positions,
+                                                                                   const RangeMatch rangeMatching,
+                                                                                   const SetDimension &dimension);
+
+/**
+ * @deprecated this function has been deprecated see {@link nix::util::positionToIndex(const std::vector<double>&, const std::vector<double>&, const std::vector<std::string> &, const RangeMatch, const SetDimension&)}
+ */
+NIXAPI DEPRECATED std::vector<std::pair<ndsize_t, ndsize_t>> positionToIndex(const std::vector<double> &start_positions,
+                                                                             const std::vector<double> &end_positions,
+                                                                             const std::vector<std::string> &units,
+                                                                             const SetDimension &dimension);
 
 
-NIXAPI std::vector<std::pair<ndsize_t, ndsize_t>> positionToIndex(const std::vector<double> &start_positions,
-                                                                  const std::vector<double> &end_positions,
-                                                                  const std::vector<std::string> &units,
-                                                                  const DataFrameDimension &dimension);
+NIXAPI std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> positionToIndex(const std::vector<double> &start_positions,
+                                                                                   const std::vector<double> &end_positions,
+                                                                                   const std::vector<std::string> &units,
+                                                                                   const RangeMatch rangeMatching,
+                                                                                   const RangeDimension &dimension);
 
+/**
+ * @deprecated this function has been deprecated see {@link nix::util::positionToIndex(const std::vector<double>&, const std::vector<double>&, const std::vector<std::string> &, const RangeMatch, const RangeDimension&)}
+ */
+NIXAPI DEPRECATED std::vector<std::pair<ndsize_t, ndsize_t>> positionToIndex(const std::vector<double> &start_positions,
+                                                                             const std::vector<double> &end_positions,
+                                                                             const std::vector<std::string> &units,
+                                                                             const RangeDimension &dimension);
 
-NIXAPI std::vector<std::pair<ndsize_t, ndsize_t>> positionToIndex(const std::vector<double> &start_positions,
-                                                                  const std::vector<double> &end_positions,
-                                                                  const std::vector<std::string> &units,
-                                                                  const RangeDimension &dimension);
 
 /**
  * @brief Returns the unit associated with the respective {@link nix::Dimension}.

--- a/include/nix/util/dataAccess.hpp
+++ b/include/nix/util/dataAccess.hpp
@@ -384,12 +384,14 @@ NIXAPI bool positionAndExtentInData(const DataArray &data, const NDSize &positio
  *
  * @param tag           The Tag whos feature data is requested
  * @param feature_index The index of the desired feature. Default is 0.
- * @param match         RangeMatch argument to control range matching behavior. Default is //TODO
+ * @param range_match   Member of RangeMatch enum to control whether a 
+ *                      data range should include the last position or not
+ *                      (only required for tagged features, otherwise ignored) 
  *
  * @return The associated data.
  * @deprecated This function has been deprecated! User featureData(Tag, ndsize_t) instead.
  */
-NIXAPI DEPRECATED DataView retrieveFeatureData(const Tag &tag, ndsize_t feature_index=0, RangeMatch match = RangeMatch::Inclusive);
+NIXAPI DEPRECATED DataView retrieveFeatureData(const Tag &tag, ndsize_t feature_index=0, RangeMatch range_match = RangeMatch::Inclusive);
 
 /**
  * @brief Retruns the feature data associated with a Tag.
@@ -400,7 +402,19 @@ NIXAPI DEPRECATED DataView retrieveFeatureData(const Tag &tag, ndsize_t feature_
  *
  * @return The associated data.
  */
-NIXAPI DataView featureData(const Tag &tag, ndsize_t feature_index=0, RangeMatch match = RangeMatch::Inclusive);
+NIXAPI DataView featureData(const Tag &tag, ndsize_t feature_index=0, RangeMatch range_match = RangeMatch::Inclusive);
+
+/**
+ * @brief Retruns the feature data associated with a Tag.
+ *
+ * @param tag           The Tag whos feature data is requested.
+ * @param feature       The Feature of which the tagged data is requested.
+ * @param match         RangeMatch argument to control range matching behavior. Default is //TODO
+ *
+ * @return The associated data.
+ */
+NIXAPI DataView featureData(const Tag &tag, const Feature &feature, RangeMatch range_match = RangeMatch::Inclusive);
+
 
 /**
  * @brief Retruns the feature data associated with a Tag.
@@ -412,18 +426,8 @@ NIXAPI DataView featureData(const Tag &tag, ndsize_t feature_index=0, RangeMatch
  * @return The associated data.
  * @deprecated This function has been deprecated! User featureData(Tag, Feature) instead.
  */
-NIXAPI DEPRECATED DataView retrieveFeatureData(const Tag &tag, const Feature &feature, RangeMatch match = RangeMatch::Inclusive);
+NIXAPI DEPRECATED DataView retrieveFeatureData(const Tag &tag, const Feature &feature, RangeMatch range_match = RangeMatch::Inclusive);
 
-/**
- * @brief Retruns the feature data associated with a Tag.
- *
- * @param tag           The Tag whos feature data is requested.
- * @param feature       The Feature of which the tagged data is requested.
- * @param match         RangeMatch argument to control range matching behavior. Default is //TODO
- *
- * @return The associated data.
- */
-NIXAPI DataView featureData(const Tag &tag, const Feature &feature, RangeMatch match = RangeMatch::Inclusive);
 
 /**
  * @brief Returns the feature data associated with the given MuliTag's position.
@@ -431,12 +435,14 @@ NIXAPI DataView featureData(const Tag &tag, const Feature &feature, RangeMatch m
  * @param tag            The MultiTag whos feature data is requested.
  * @param position_index The index of the selected position, respectively the selected tag of the MultiTag.
  * @param feature_index  The index of the desired feature. Default is 0.
- * @param match         RangeMatch argument to control range matching behavior. Default is //TODO
- *
+ * @param range_match   Member of RangeMatch enum to control whether a 
+ *                      data range should include the last position or not
+ *                      (only required for tagged features, otherwise ignored)
+ * 
  * @return The associated data.
  * @deprecated This function has been deprecated! Use featureData(MultiTag, ndsize_t, feature_index) instead.
  */
-NIXAPI DEPRECATED DataView retrieveFeatureData(const MultiTag &tag, ndsize_t position_index, ndsize_t feature_index=0, RangeMatch match = RangeMatch::Inclusive);
+NIXAPI DEPRECATED DataView retrieveFeatureData(const MultiTag &tag, ndsize_t position_index, ndsize_t feature_index=0, RangeMatch range_match = RangeMatch::Inclusive);
 
 /**
  * @brief Returns the feature data associated with the given MuliTag's position.
@@ -444,11 +450,11 @@ NIXAPI DEPRECATED DataView retrieveFeatureData(const MultiTag &tag, ndsize_t pos
  * @param tag            The MultiTag whos feature data is requested.
  * @param position_index The index of the selected position, respectively the selected tag of the MultiTag.
  * @param feature_index  The index of the desired feature. Default is 0.
- * @param match         RangeMatch argument to control range matching behavior. Default is //TODO
+ * @param range_match         RangeMatch argument to control range matching behavior. Default is //TODO
  *
  * @return The associated data.
  */
-NIXAPI DataView featureData(const MultiTag &tag, ndsize_t position_index, ndsize_t feature_index=0, RangeMatch match = RangeMatch::Inclusive);
+NIXAPI DataView featureData(const MultiTag &tag, ndsize_t position_index, ndsize_t feature_index=0, RangeMatch range_match = RangeMatch::Inclusive);
 
 /**
  * @brief Returns the feature data associated with the given MuliTag's position.
@@ -456,12 +462,14 @@ NIXAPI DataView featureData(const MultiTag &tag, ndsize_t position_index, ndsize
  * @param tag            The MultiTag whos feature data is requested.
  * @param position_index The index of the selected position, respectively the selected tag of the MultiTag.
  * @param feature        The feature of which the tagged data is requested.
- * @param match         RangeMatch argument to control range matching behavior. Default is //TODO
+ * @param range_match   Member of RangeMatch enum to control whether a 
+ *                      data range should include the last position or not
+ *                      (only required for tagged features, otherwise ignored)
  *
  * @return The associated data.
  * @deprecated This function has been deprecated! Use featureData(MultiTag, ndsize_t, Feature) instead.
  */
-NIXAPI DEPRECATED DataView retrieveFeatureData(const MultiTag &tag, ndsize_t position_index, const Feature &feature, RangeMatch match = RangeMatch::Inclusive);
+NIXAPI DEPRECATED DataView retrieveFeatureData(const MultiTag &tag, ndsize_t position_index, const Feature &feature, RangeMatch range_match = RangeMatch::Inclusive);
 
 /**
  * @brief Returns the feature data associated with the given MuliTag's position.
@@ -481,25 +489,25 @@ NIXAPI DataView featureData(const MultiTag &tag, ndsize_t position_index, const 
  * @param tag              The MultiTag whos feature data is requested
  * @param position_indices A vector of position indices.
  * @param feature_index    The index of the desired feature. Default is 0.
- * @param match         RangeMatch argument to control range matching behavior. Default is //TODO
+ * @param range_match      RangeMatch argument to control range matching behavior. Default is //TODO
  *
  * @return A vector of the associated data, may be empty.
  * @deprecated This function has been deprecated! Use featureData(MultiTag, std::vector<ndsize_t>, ndsize_t) instead.
  */
 NIXAPI DEPRECATED std::vector<DataView> retrieveFeatureData(const MultiTag &tag, std::vector<ndsize_t> position_indices,
-                                                            ndsize_t feature_index = 0, RangeMatch match = RangeMatch::Inclusive);
+                                                            ndsize_t feature_index = 0, RangeMatch range_match = RangeMatch::Inclusive);
 /**
  * @brief Retruns the feature data associated with a MultiTag.
  *
  * @param tag              The MultiTag whos feature data is requested
  * @param position_indices A vector of position indices.
  * @param feature_index    The index of the desired feature. Default is 0.
- * @param match         RangeMatch argument to control range matching behavior. Default is //TODO
+ * @param range_match         RangeMatch argument to control range matching behavior. Default is //TODO
  *
  * @return A vector of the associated data, may be empty.
  */
 NIXAPI std::vector<DataView> featureData(const MultiTag &tag, std::vector<ndsize_t> position_indices,
-                                         ndsize_t feature_index = 0, RangeMatch match = RangeMatch::Inclusive);
+                                         ndsize_t feature_index = 0, RangeMatch range_match = RangeMatch::Inclusive);
 
 /**
  * @brief Returns the feature data associated with the given MuliTag's positions.
@@ -507,13 +515,15 @@ NIXAPI std::vector<DataView> featureData(const MultiTag &tag, std::vector<ndsize
  * @param tag              The MultiTag whos feature data is requested.
  * @param position_indices A vector of position indices.
  * @param feature          The feature of which the tagged data is requested.
- * @param match         RangeMatch argument to control range matching behavior. Default is //TODO
- *
+ * @param range_match   Member of RangeMatch enum to control whether a 
+ *                      data range should include the last position or not
+ *                      (only required for tagged features, otherwise ignored)
+ * 
  * @return A vector of the associated data, may be empty.
  * @deprecated This function has been deprecated! Use featureData(MultiTag, std::vector<ndsize_t>, Feature) instead.
  */
 NIXAPI DEPRECATED std::vector<DataView> retrieveFeatureData(const MultiTag &tag, std::vector<ndsize_t> position_indices,
-                                                            const Feature &feature, RangeMatch match = RangeMatch::Inclusive);
+                                                            const Feature &feature, RangeMatch range_match = RangeMatch::Inclusive);
 
 /**
  * @brief Returns the feature data associated with the given MuliTag's positions.

--- a/include/nix/util/dataAccess.hpp
+++ b/include/nix/util/dataAccess.hpp
@@ -73,6 +73,28 @@ NIXAPI DEPRECATED ndsize_t positionToIndex(double position, const std::string &u
 NIXAPI boost::optional<ndsize_t> positionToIndex(double position, const std::string &unit, const PositionMatch match, const DataFrameDimension &dimension);
 
 /**
+ * @brief Converts a position to an index according to the dimension descriptor.
+ *
+ * This function can be used to get the index of e.g. a certain point in time in
+ * a Dimension that represents time. The units of the position and that provided
+ * by the Dimension must match, i.e.  must be scalable versions of the same SI
+ * unit. In case of a SetDimension the provided position is interpreted as an
+ * index. Units are ignored.
+ * The match argument controls how the position is converted to an index.
+ *
+ * @param position      The position
+ * @param match         PositionMatch argument to control position matching behavior.
+ * @param dimension     The dimension descriptor for the respective dimension, i.e. a DataFrameDimension.
+ *
+ * @return An optional containing the calculated index.
+ *
+ * @throws nix::IncompatibleDimension The the dimensions are incompatible.
+ * @throws nix::OutOfBounds If the position either too large or too small for the dimension.
+ */
+NIXAPI boost::optional<ndsize_t> positionToIndex(double position, const PositionMatch match, const DataFrameDimension &dimension);
+
+
+/**
  * @Brief Converts a position given in a unit into an index according to the dimension descriptor.
  *
  * This function can be used to get the index of e.g. a certain point in time in a Dimension that
@@ -175,6 +197,12 @@ NIXAPI DEPRECATED std::vector<std::pair<ndsize_t, ndsize_t>> positionToIndex(con
                                                                              const std::vector<double> &end_positions,
                                                                              const std::vector<std::string> &units,
                                                                              const RangeDimension &dimension);
+
+
+NIXAPI std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> positionToIndex(const std::vector<double> &start_positions,
+                                                                                   const std::vector<double> &end_positions,
+                                                                                   const RangeMatch range_matching,
+                                                                                   const DataFrameDimension &dimension);
 
 
 /**

--- a/include/nix/util/dataAccess.hpp
+++ b/include/nix/util/dataAccess.hpp
@@ -39,8 +39,9 @@ namespace util {
  * @param position      The position
  * @param match         Member of the PositionMatch enum to control the matching.
  * @param dimension     The dimension descriptor for the respective dimension, i.e. a SetDimension.
+ * @param match         PositionMatch argument to control position matching behavior.
  *
- * @return The calculated index.
+ * @return An optional containing the calculated index.
  *
  * @throws nix::IncompatibleDimension The the dimensions are incompatible.
  * @throws nix::OutOfBounds If the position either too large or too small for the dimension.
@@ -62,13 +63,14 @@ NIXAPI DEPRECATED ndsize_t positionToIndex(double position, const std::string &u
  * @param position      The position
  * @param unit          The unit in which the position is given, may be "none"
  * @param dimension     The dimension descriptor for the respective dimension.
+ * @param match         PositionMatch argument to control position matching behavior.
  *
- * @return The calculated index.
+ * @return an optional conatining the calculated index.
  *
  * @throws nix::IncompatibleDimension The the dimensions are incompatible.
  * @throws nix::OutOfBounds If the position either too large or too small for the dimension.
  */
-NIXAPI ndsize_t positionToIndex(double position, const std::string &unit, const DataFrameDimension &dimension);
+NIXAPI boost::optional<ndsize_t> positionToIndex(double position, const std::string &unit, const PositionMatch match, const DataFrameDimension &dimension);
 
 /**
  * @Brief Converts a position given in a unit into an index according to the dimension descriptor.
@@ -80,8 +82,9 @@ NIXAPI ndsize_t positionToIndex(double position, const std::string &unit, const 
  * @param position      The position
  * @param unit          The unit in which the position is given, may be "none"
  * @param dimension     The dimension descriptor for the respective dimension.
+ * @param match         PositionMatch argument to control position matching behavior.
  *
- * @return The calculated index.
+ * @return an optional containing the calculated index.
  *
  * @throws nix::IncompatibleDimension The the dimensions are incompatible.
  * @throws nix::OutOfBounds If the position either too large or too small for the dimension.
@@ -191,15 +194,18 @@ NIXAPI std::string getDimensionUnit(const nix::Dimension &dim);
  * @param array         A referenced data array.
  * @param[out] offsets  The resulting offset.
  * @param[out] counts   The number of elements to read from data
+ * @param match         Member of the RangeMatch enum, defining wheter the range includes the end position
+ *                      or not. By default this is RangeMatch::Inclusive (Note: this behavior will change 
+ *                      with version 1.5)
  */
-NIXAPI void getOffsetAndCount(const Tag &tag, const DataArray &array, NDSize &offsets, NDSize &counts);
+NIXAPI void getOffsetAndCount(const Tag &tag, const DataArray &array, NDSize &offsets, NDSize &counts, RangeMatch match = RangeMatch::Inclusive);
 
 
-NIXAPI void getOffsetAndCount(const MultiTag &tag, const DataArray &array, ndsize_t index, NDSize &offsets, NDSize &counts);
+NIXAPI void getOffsetAndCount(const MultiTag &tag, const DataArray &array, ndsize_t index, NDSize &offsets, NDSize &counts, RangeMatch match = RangeMatch::Inclusive);
 
 
 NIXAPI void getOffestAndCount(const MultiTag &tag, const DataArray &array, const std::vector<ndsize_t> indices,
-                              std::vector<NDSize> &offsets, std::vector<NDSize> & counts);
+                              std::vector<NDSize> &offsets, std::vector<NDSize> & counts, RangeMatch match = RangeMatch::Inclusive);
 
 
 /**
@@ -219,7 +225,7 @@ NIXAPI void getOffestAndCount(const MultiTag &tag, const DataArray &array, const
  * @returns {@link nix::DataView} the data slice.
  */
 NIXAPI DataView dataSlice(const DataArray &array, const std::vector<double> &start, const std::vector<double> &end,
-                          const std::vector<std::string> &units={});
+                          const std::vector<std::string> &units={}, RangeMatch match = RangeMatch::Inclusive);
 
 /**
  * @brief Retrieve several data segments that are tagged by the given position and extent of the MultiTag.
@@ -227,10 +233,23 @@ NIXAPI DataView dataSlice(const DataArray &array, const std::vector<double> &sta
  * @param tag                   The multi tag.
  * @param position_indices      The indices of the positions.
  * @param array                 The referenced DataArray.
+ * @param match                 Controls the RangeMatch behavior.
  *
  * @return vector of nix::DataViews that contain the data tagged by the specified position indices.
  */
-NIXAPI std::vector<DataView> taggedData(const MultiTag &tag, std::vector<ndsize_t> &position_indices, const DataArray &array);
+NIXAPI std::vector<DataView> taggedData(const MultiTag &tag, std::vector<ndsize_t> &position_indices, const DataArray &array, RangeMatch match = RangeMatch::Inclusive); //TODO range support
+
+/**
+ * @brief Retrieve several data segments that are tagged by the given positions and extents of the MultiTag.
+ *
+ * @param tag                   The multi tag.
+ * @param position_indices      The indices of the position.
+ * @param reference_index       The index of the referenced DataArray.
+ * @param match                 Controls the RangeMatch behavior.
+ *
+ * @return vector of nix::DataViews containing the data tagged by the specified position indices.
+ */
+NIXAPI std::vector<DataView> taggedData(const MultiTag &tag, std::vector<ndsize_t> &position_indices, ndsize_t reference_index, RangeMatch match = RangeMatch::Inclusive);
 
 /**
  * @brief Retrieve several data segments referenced by the given position and extent of the MultiTag.
@@ -242,18 +261,7 @@ NIXAPI std::vector<DataView> taggedData(const MultiTag &tag, std::vector<ndsize_
  * @return The data referenced by the specified indices, respectively their positions and extents.
  * @deprecated This function has been deprecated! Use taggedData(MultiTag, vector<ndsize_t>, DataArray) instead.
  */
-NIXAPI DEPRECATED std::vector<DataView> retrieveData(const MultiTag &tag, std::vector<ndsize_t> &position_indices, const DataArray &array);
-
-/**
- * @brief Retrieve several data segments that are tagged by the given positions and extents of the MultiTag.
- *
- * @param tag                   The multi tag.
- * @param position_indices      The indices of the position.
- * @param reference_index       The index of the referenced DataArray.
- *
- * @return vector of nix::DataViews containing the data tagged by the specified position indices.
- */
-NIXAPI std::vector<DataView> taggedData(const MultiTag &tag, std::vector<ndsize_t> &position_indices, ndsize_t reference_index);
+NIXAPI DEPRECATED std::vector<DataView> retrieveData(const MultiTag &tag, std::vector<ndsize_t> &position_indices, const DataArray &array, RangeMatch match = RangeMatch::Inclusive);
 
 /**
  * @brief Retrieve several segments of data referenced by the given position and extent of the MultiTag.
@@ -265,7 +273,7 @@ NIXAPI std::vector<DataView> taggedData(const MultiTag &tag, std::vector<ndsize_
  * @return The data referenced by the specified indices, respectively their positions and extents.
  * @deprecated This function has been deprecated! Use taggedData(MultiTag, vector<ndsize_t>, reference_index) instead.
  */
-NIXAPI DEPRECATED std::vector<DataView> retrieveData(const MultiTag &tag, std::vector<ndsize_t> &position_indices, ndsize_t reference_index);
+NIXAPI DEPRECATED std::vector<DataView> retrieveData(const MultiTag &tag, std::vector<ndsize_t> &position_indices, ndsize_t reference_index, RangeMatch match = RangeMatch::Inclusive);
 
 /**
  * @brief Retrieve the data tagged by the given position and extent of the MultiTag.
@@ -276,7 +284,9 @@ NIXAPI DEPRECATED std::vector<DataView> retrieveData(const MultiTag &tag, std::v
  *
  * @return nix::DataView containing the data tagged by the specified position index.
  */
-NIXAPI DataView taggedData(const MultiTag &tag, ndsize_t position_index, ndsize_t reference_index);
+NIXAPI DataView taggedData(const MultiTag &tag, ndsize_t position_index, ndsize_t reference_index, RangeMatch match = RangeMatch::Inclusive);
+
+NIXAPI DataView taggedData(const MultiTag &tag, ndsize_t position_index, const DataArray &array, RangeMatch match = RangeMatch::Inclusive);
 
 /**
  * @brief Retrieve the data referenced by the given position and extent of the MultiTag.
@@ -288,7 +298,7 @@ NIXAPI DataView taggedData(const MultiTag &tag, ndsize_t position_index, ndsize_
  * @return The data referenced by position and extent.
  * @deprecated This function has been deprecated! Use taggedData(MultiTag, vector<ndsize_t>, DataArray) instead.
  */
-NIXAPI DEPRECATED DataView retrieveData(const MultiTag &tag, ndsize_t position_index, const DataArray &array);
+NIXAPI DEPRECATED DataView retrieveData(const MultiTag &tag, ndsize_t position_index, const DataArray &array, RangeMatch match = RangeMatch::Inclusive);
 
 /**
  * @brief Retrieve the data referenced by the given position and extent of the MultiTag.
@@ -300,49 +310,53 @@ NIXAPI DEPRECATED DataView retrieveData(const MultiTag &tag, ndsize_t position_i
  * @return The data referenced by position and extent.
  * @deprecated This function has been deprecated! Use taggedData(MultiTag, vector<ndsize_t>, DataArray) instead.
  */
-NIXAPI DEPRECATED DataView retrieveData(const MultiTag &tag, ndsize_t position_index, ndsize_t reference_index);
+NIXAPI DEPRECATED DataView retrieveData(const MultiTag &tag, ndsize_t position_index, ndsize_t reference_index, RangeMatch match = RangeMatch::Inclusive);
 
 /**
  * @brief Retrieve the data tagged by position and extent of the Tag.
  *
  * @param tag                   The tag.
  * @param reference_index       The index of the reference of which data should be returned.
+ * @param match                 RangeMatch to control range matching behavior.
  *
  * @return nix::DataView containing the tagged data.
  */
-NIXAPI DataView taggedData(const Tag &tag, ndsize_t reference_index);
+NIXAPI DataView taggedData(const Tag &tag, ndsize_t reference_index, RangeMatch match = RangeMatch::Inclusive);
 
 /**
  * @brief Retrieve the data referenced by the given position and extent of the Tag.
  *
  * @param tag                   The Tag.
  * @param reference_index       The index of the reference from which data should be returned.
+ * @param match                 RangeMatch to control range matching behavior.
  *
  * @return The data referenced by the position.
  * @deprecated This function has been deprecated! Use taggedData(Tag, ndsize_t) instead.
  */
-NIXAPI DEPRECATED DataView retrieveData(const Tag &tag, ndsize_t reference_index);
+NIXAPI DEPRECATED DataView retrieveData(const Tag &tag, ndsize_t reference_index, RangeMatch match = RangeMatch::Inclusive);
 
 /**
  * @brief Retrieve the data tagged by position and extent of the Tag.
  *
  * @param tag                   The tag.
  * @param array                 The referenced DataArray.
+ * @param match                 The range matching behavior, default //TODO
  *
  * @return nix::DataView containing the tagged data.
  */
-NIXAPI DataView taggedData(const Tag &tag, const DataArray &array);
+NIXAPI DataView taggedData(const Tag &tag, const DataArray &array, RangeMatch match = RangeMatch::Inclusive);
 
 /**
  * @brief Retrieve the data referenced by the given position and extent of the Tag.
  *
  * @param tag                   The tag.
  * @param array                 The referenced DataArray.
+ * @param match                 The range matching behavior, default //TODO
  *
  * @return The data referenced by the position.
  * @deprecated This function has been deprecated! Use taggedData(Tag, DataArray) instead.
  */
-NIXAPI DEPRECATED DataView retrieveData(const Tag &tag, const DataArray &array);
+NIXAPI DEPRECATED DataView retrieveData(const Tag &tag, const DataArray &array, RangeMatch match = RangeMatch::Inclusive);
 
 /**
  * @brief Checks whether a given position is in the extent of the given DataArray.
@@ -370,42 +384,46 @@ NIXAPI bool positionAndExtentInData(const DataArray &data, const NDSize &positio
  *
  * @param tag           The Tag whos feature data is requested
  * @param feature_index The index of the desired feature. Default is 0.
+ * @param match         RangeMatch argument to control range matching behavior. Default is //TODO
  *
  * @return The associated data.
  * @deprecated This function has been deprecated! User featureData(Tag, ndsize_t) instead.
  */
-NIXAPI DEPRECATED DataView retrieveFeatureData(const Tag &tag, ndsize_t feature_index=0);
+NIXAPI DEPRECATED DataView retrieveFeatureData(const Tag &tag, ndsize_t feature_index=0, RangeMatch match = RangeMatch::Inclusive);
 
 /**
  * @brief Retruns the feature data associated with a Tag.
  *
  * @param tag           The Tag whos feature data is requested
  * @param feature_index The index of the desired feature. Default is 0.
+ * @param match         RangeMatch argument to control range matching behavior. Default is //TODO
  *
  * @return The associated data.
  */
-NIXAPI DataView featureData(const Tag &tag, ndsize_t feature_index=0);
+NIXAPI DataView featureData(const Tag &tag, ndsize_t feature_index=0, RangeMatch match = RangeMatch::Inclusive);
 
 /**
  * @brief Retruns the feature data associated with a Tag.
  *
  * @param tag           The Tag whos feature data is requested.
  * @param feature       The Feature of which the tagged data is requested.
+ * @param match         RangeMatch argument to control range matching behavior. Default is //TODO
  *
  * @return The associated data.
  * @deprecated This function has been deprecated! User featureData(Tag, Feature) instead.
  */
-NIXAPI DEPRECATED DataView retrieveFeatureData(const Tag &tag, const Feature &feature);
+NIXAPI DEPRECATED DataView retrieveFeatureData(const Tag &tag, const Feature &feature, RangeMatch match = RangeMatch::Inclusive);
 
 /**
  * @brief Retruns the feature data associated with a Tag.
  *
  * @param tag           The Tag whos feature data is requested.
  * @param feature       The Feature of which the tagged data is requested.
+ * @param match         RangeMatch argument to control range matching behavior. Default is //TODO
  *
  * @return The associated data.
  */
-NIXAPI DataView featureData(const Tag &tag, const Feature &feature);
+NIXAPI DataView featureData(const Tag &tag, const Feature &feature, RangeMatch match = RangeMatch::Inclusive);
 
 /**
  * @brief Returns the feature data associated with the given MuliTag's position.
@@ -413,11 +431,12 @@ NIXAPI DataView featureData(const Tag &tag, const Feature &feature);
  * @param tag            The MultiTag whos feature data is requested.
  * @param position_index The index of the selected position, respectively the selected tag of the MultiTag.
  * @param feature_index  The index of the desired feature. Default is 0.
+ * @param match         RangeMatch argument to control range matching behavior. Default is //TODO
  *
  * @return The associated data.
  * @deprecated This function has been deprecated! Use featureData(MultiTag, ndsize_t, feature_index) instead.
  */
-NIXAPI DEPRECATED DataView retrieveFeatureData(const MultiTag &tag, ndsize_t position_index, ndsize_t feature_index=0);
+NIXAPI DEPRECATED DataView retrieveFeatureData(const MultiTag &tag, ndsize_t position_index, ndsize_t feature_index=0, RangeMatch match = RangeMatch::Inclusive);
 
 /**
  * @brief Returns the feature data associated with the given MuliTag's position.
@@ -425,10 +444,11 @@ NIXAPI DEPRECATED DataView retrieveFeatureData(const MultiTag &tag, ndsize_t pos
  * @param tag            The MultiTag whos feature data is requested.
  * @param position_index The index of the selected position, respectively the selected tag of the MultiTag.
  * @param feature_index  The index of the desired feature. Default is 0.
+ * @param match         RangeMatch argument to control range matching behavior. Default is //TODO
  *
  * @return The associated data.
  */
-NIXAPI DataView featureData(const MultiTag &tag, ndsize_t position_index, ndsize_t feature_index=0);
+NIXAPI DataView featureData(const MultiTag &tag, ndsize_t position_index, ndsize_t feature_index=0, RangeMatch match = RangeMatch::Inclusive);
 
 /**
  * @brief Returns the feature data associated with the given MuliTag's position.
@@ -436,11 +456,12 @@ NIXAPI DataView featureData(const MultiTag &tag, ndsize_t position_index, ndsize
  * @param tag            The MultiTag whos feature data is requested.
  * @param position_index The index of the selected position, respectively the selected tag of the MultiTag.
  * @param feature        The feature of which the tagged data is requested.
+ * @param match         RangeMatch argument to control range matching behavior. Default is //TODO
  *
  * @return The associated data.
  * @deprecated This function has been deprecated! Use featureData(MultiTag, ndsize_t, Feature) instead.
  */
-NIXAPI DEPRECATED DataView retrieveFeatureData(const MultiTag &tag, ndsize_t position_index, const Feature &feature);
+NIXAPI DEPRECATED DataView retrieveFeatureData(const MultiTag &tag, ndsize_t position_index, const Feature &feature, RangeMatch match = RangeMatch::Inclusive);
 
 /**
  * @brief Returns the feature data associated with the given MuliTag's position.
@@ -448,10 +469,11 @@ NIXAPI DEPRECATED DataView retrieveFeatureData(const MultiTag &tag, ndsize_t pos
  * @param tag            The MultiTag whos feature data is requested.
  * @param position_index The index of the selected position, respectively the selected tag of the MultiTag.
  * @param feature        The feature of which the tagged data is requested.
+ * @param match         RangeMatch argument to control range matching behavior. Default is //TODO
  *
  * @return The associated data.
  */
-NIXAPI DataView featureData(const MultiTag &tag, ndsize_t position_index, const Feature &feature);
+NIXAPI DataView featureData(const MultiTag &tag, ndsize_t position_index, const Feature &feature, RangeMatch match = RangeMatch::Inclusive);
 
 /**
  * @brief Retruns the feature data associated with a MultiTag.
@@ -459,25 +481,25 @@ NIXAPI DataView featureData(const MultiTag &tag, ndsize_t position_index, const 
  * @param tag              The MultiTag whos feature data is requested
  * @param position_indices A vector of position indices.
  * @param feature_index    The index of the desired feature. Default is 0.
+ * @param match         RangeMatch argument to control range matching behavior. Default is //TODO
  *
  * @return A vector of the associated data, may be empty.
  * @deprecated This function has been deprecated! Use featureData(MultiTag, std::vector<ndsize_t>, ndsize_t) instead.
  */
-NIXAPI DEPRECATED std::vector<DataView> retrieveFeatureData(const MultiTag &tag,
-                                                            std::vector<ndsize_t> position_indices,
-                                                            ndsize_t feature_index = 0);
+NIXAPI DEPRECATED std::vector<DataView> retrieveFeatureData(const MultiTag &tag, std::vector<ndsize_t> position_indices,
+                                                            ndsize_t feature_index = 0, RangeMatch match = RangeMatch::Inclusive);
 /**
  * @brief Retruns the feature data associated with a MultiTag.
  *
  * @param tag              The MultiTag whos feature data is requested
  * @param position_indices A vector of position indices.
  * @param feature_index    The index of the desired feature. Default is 0.
+ * @param match         RangeMatch argument to control range matching behavior. Default is //TODO
  *
  * @return A vector of the associated data, may be empty.
  */
-NIXAPI std::vector<DataView> featureData(const MultiTag &tag,
-                                         std::vector<ndsize_t> position_indices,
-                                         ndsize_t feature_index = 0);
+NIXAPI std::vector<DataView> featureData(const MultiTag &tag, std::vector<ndsize_t> position_indices,
+                                         ndsize_t feature_index = 0, RangeMatch match = RangeMatch::Inclusive);
 
 /**
  * @brief Returns the feature data associated with the given MuliTag's positions.
@@ -485,13 +507,13 @@ NIXAPI std::vector<DataView> featureData(const MultiTag &tag,
  * @param tag              The MultiTag whos feature data is requested.
  * @param position_indices A vector of position indices.
  * @param feature          The feature of which the tagged data is requested.
+ * @param match         RangeMatch argument to control range matching behavior. Default is //TODO
  *
  * @return A vector of the associated data, may be empty.
  * @deprecated This function has been deprecated! Use featureData(MultiTag, std::vector<ndsize_t>, Feature) instead.
  */
-NIXAPI DEPRECATED std::vector<DataView> retrieveFeatureData(const MultiTag &tag,
-                                                            std::vector<ndsize_t> position_indices,
-                                                            const Feature &feature);
+NIXAPI DEPRECATED std::vector<DataView> retrieveFeatureData(const MultiTag &tag, std::vector<ndsize_t> position_indices,
+                                                            const Feature &feature, RangeMatch match = RangeMatch::Inclusive);
 
 /**
  * @brief Returns the feature data associated with the given MuliTag's positions.
@@ -499,12 +521,12 @@ NIXAPI DEPRECATED std::vector<DataView> retrieveFeatureData(const MultiTag &tag,
  * @param tag              The MultiTag whos feature data is requested.
  * @param position_indices A vector of position indices.
  * @param feature          The feature of which the tagged data is requested.
+ * @param match         RangeMatch argument to control range matching behavior. Default is //TODO
  *
  * @return A vector of the associated data, may be empty.
  */
-NIXAPI std::vector<DataView> featureData(const MultiTag &tag,
-                                         std::vector<ndsize_t> position_indices,
-                                         const Feature &feature);
+NIXAPI std::vector<DataView> featureData(const MultiTag &tag, std::vector<ndsize_t> position_indices,
+                                         const Feature &feature, RangeMatch match = RangeMatch::Inclusive);
 
 } //namespace util
 } //namespace nix

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -429,7 +429,7 @@ boost::optional<ndsize_t> getIndex(const double position, std::vector<double> &t
             idx = 0;
         return idx;
     } else if (position > *prev(ticks.end())) {
-        if (matching == PositionMatch::Less || matching == PositionMatch::LessOrEqual) 
+        if (matching == PositionMatch::Less || matching == PositionMatch::LessOrEqual)
             idx =  prev(ticks.end()) - ticks.begin();
         return idx;
     }
@@ -482,10 +482,10 @@ boost::optional<std::pair<ndsize_t, ndsize_t>> RangeDimension::indexOf(double st
     if (start > end){
         std::swap(start, end);
     }
-    
+
     boost::optional<ndsize_t> si = getIndex(start, ticks, PositionMatch::GreaterOrEqual);
     if (!si) {
-        return range;  
+        return range;
     }
     PositionMatch endMatching = (match == RangeMatch::Inclusive) ? PositionMatch::LessOrEqual : PositionMatch::Less;
     boost::optional<ndsize_t> ei = getIndex(end, ticks, endMatching);
@@ -520,7 +520,7 @@ pair<ndsize_t, ndsize_t> RangeDimension::indexOf(const double start, const doubl
 
 std::vector<std::pair<ndsize_t, ndsize_t>> RangeDimension::indexOf(const std::vector<double> &start_positions,
                                                                    const std::vector<double> &end_positions,
-                                                                   RangeMatch match) const {
+                                                                   RangeMatch match, bool strict) const {
     if (start_positions.size() != end_positions.size()) {
         throw runtime_error("Dimension::IndexOf - Number of start and end positions must match!");
     }
@@ -531,6 +531,9 @@ std::vector<std::pair<ndsize_t, ndsize_t>> RangeDimension::indexOf(const std::ve
     for (size_t i = 0; i < start_positions.size(); ++i) {
         boost::optional<std::pair<ndsize_t, ndsize_t>> range;
         range = this->indexOf(start_positions[i], end_positions[i], std::move(ticks), match);
+        if (!range && strict) {
+            throw nix::OutOfBounds("RangeDimension::indexOf an invalid range occurred!");
+        }
         if (range) {
             indices.push_back(*range);
         }

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -503,9 +503,12 @@ ndsize_t RangeDimension::indexOf(const double position, bool less_or_equal) cons
 
 pair<ndsize_t, ndsize_t> RangeDimension::indexOf(const double start, const double end) const {
     vector<double> ticks = this->ticks();
-    ndsize_t si = getIndex(start, ticks, true);
-    ndsize_t ei = getIndex(end, ticks, false);
-    return std::pair<ndsize_t, ndsize_t>(si, ei);
+    boost::optional<ndsize_t> si = getIndex(start, ticks, PositionMatch::GreaterOrEqual);
+    boost::optional<ndsize_t> ei = getIndex(end, ticks, PositionMatch::LessOrEqual);
+    if (!ei || !si) {
+        throw nix::OutOfBounds("RangeDimension::indexOf: start or end of range are out of Bounds!");
+    }
+    return std::pair<ndsize_t, ndsize_t>(*si, *ei);
 }
 
 

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -198,7 +198,7 @@ void SampledDimension::samplingInterval(double interval) {
 
 ndsize_t getSampledIndex(const double position, const double offset, const double sampling_interval) {
     if (position < offset) {
-        throw nix::OutOfBounds("Position is out of bounds of this dimension!", position);
+        throw nix::OutOfBounds("SampledDimension::indexOf: Position is less than offset!", position);
     }
     ndssize_t index = static_cast<ndssize_t>(round(( position - offset) / sampling_interval));
     return index;
@@ -215,7 +215,6 @@ ndsize_t SampledDimension::indexOf(const double position) const {
 std::pair<ndsize_t, ndsize_t> SampledDimension::indexOf(const double start, const double end, RangeMatch match) const {
     double offset = backend()->offset() ? *(backend()->offset()) : 0.0;
     double sampling_interval = backend()->samplingInterval();
-
     return indexOf(start, end, sampling_interval, offset, match);
 }
 
@@ -224,6 +223,9 @@ std::pair<ndsize_t, ndsize_t> SampledDimension::indexOf(double start, double end
                                                         const double offset, RangeMatch match) const {
     if (start > end) {
         std::swap(start, end);
+    }
+    if (match == RangeMatch::Exclusive && end - start < sampling_interval/2) {
+        throw nix::OutOfBounds("SampledDimension::indexOf: An invalid range occured, difference of start and end is less than the sampling interval.");
     }
     ndsize_t si = getSampledIndex(start, offset, sampling_interval);
     ndsize_t ei = getSampledIndex(end - (match == RangeMatch::Exclusive ? sampling_interval : 0.0), offset, sampling_interval);

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -419,7 +419,6 @@ PositionInRange RangeDimension::positionInRange(const double position) const {
 }
 
 
-    return index;
 boost::optional<ndsize_t> getIndex(const double position, std::vector<double> &ticks, PositionMatch matching) {
     boost::optional<ndsize_t> idx;
     // check easy cases first ...
@@ -520,7 +519,8 @@ pair<ndsize_t, ndsize_t> RangeDimension::indexOf(const double start, const doubl
 
 
 std::vector<std::pair<ndsize_t, ndsize_t>> RangeDimension::indexOf(const std::vector<double> &start_positions,
-                                                                   const std::vector<double> &end_positions) const {
+                                                                   const std::vector<double> &end_positions,
+                                                                   RangeMatch match) const {
     if (start_positions.size() != end_positions.size()) {
         throw runtime_error("Dimension::IndexOf - Number of start and end positions must match!");
     }
@@ -529,8 +529,11 @@ std::vector<std::pair<ndsize_t, ndsize_t>> RangeDimension::indexOf(const std::ve
     vector<double> ticks = this->ticks();
 
     for (size_t i = 0; i < start_positions.size(); ++i) {
-        indices.emplace_back(getIndex(start_positions[i], ticks, true),
-                             getIndex(end_positions[i], ticks, false));
+        boost::optional<std::pair<ndsize_t, ndsize_t>> range;
+        range = this->indexOf(start_positions[i], end_positions[i], ticks, match);
+        if (range) {
+            indices.push_back(*range);
+        }
     }
     return indices;
 }

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -521,25 +521,26 @@ pair<ndsize_t, ndsize_t> RangeDimension::indexOf(const double start, const doubl
 std::vector<std::pair<ndsize_t, ndsize_t>> RangeDimension::indexOf(const std::vector<double> &start_positions,
                                                                    const std::vector<double> &end_positions,
                                                                    RangeMatch match, bool strict) const {
+
+
+std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> RangeDimension::indexOf(const std::vector<double> &start_positions,
+                                                                                    const std::vector<double> &end_positions,
+                                                                                    RangeMatch match) const {
     if (start_positions.size() != end_positions.size()) {
         throw runtime_error("Dimension::IndexOf - Number of start and end positions must match!");
     }
 
-    std::vector<std::pair<ndsize_t, ndsize_t>> indices;
+    std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> indices(start_positions.size());
     vector<double> ticks = this->ticks();
-
+    // add another overload that accepts a reference
     for (size_t i = 0; i < start_positions.size(); ++i) {
         boost::optional<std::pair<ndsize_t, ndsize_t>> range;
         range = this->indexOf(start_positions[i], end_positions[i], std::move(ticks), match);
-        if (!range && strict) {
-            throw nix::OutOfBounds("RangeDimension::indexOf an invalid range occurred!");
-        }
-        if (range) {
-            indices.push_back(*range);
-        }
+        indices.push_back(*range);
     }
     return indices;
 }
+
 
 
 vector<double> RangeDimension::axis(const ndsize_t count, const ndsize_t startIndex) const {

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -316,8 +316,6 @@ std::vector<std::pair<ndsize_t, ndsize_t>> SampledDimension::indexOf(const std::
 
 
 double SampledDimension::positionAt(const ndsize_t index) const {
-
-double SampledDimension::positionAt(const ndsize_t index) const {
     double offset = backend()->offset() ? *(backend()->offset()) : 0.0;
     double sampling_interval = backend()->samplingInterval();
     return index * sampling_interval + offset;

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -402,6 +402,23 @@ double RangeDimension::tickAt(const ndsize_t index) const {
     return ticks[0];
 }
 
+
+PositionInRange RangeDimension::positionInRange(const double position) const {
+    PositionInRange result;
+    vector<double> ticks = this->ticks();
+    if (ticks.size() == 0) {
+        result = PositionInRange::NoRange;
+    } else if (position < *ticks.begin()) {
+        result = PositionInRange::Less;
+    } else if (position > *prev(ticks.end())) {
+        result = PositionInRange::Greater;
+    } else {
+        result = PositionInRange::InRange;
+    }
+    return result;
+}
+
+
 ndsize_t getIndex(const double position, std::vector<double> &ticks, bool lower_bound) {
     if (position < *ticks.begin()) {
         return 0;

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -473,7 +473,7 @@ boost::optional<ndsize_t> RangeDimension::indexOf(const double position, Positio
 
 
 boost::optional<std::pair<ndsize_t, ndsize_t>> RangeDimension::indexOf(double start, double end,
-                                                                       std::vector<double> ticks,
+                                                                       std::vector<double> &&ticks,
                                                                        RangeMatch match) const {
     if (ticks.size() == 0) {
         ticks = this->ticks();
@@ -530,7 +530,7 @@ std::vector<std::pair<ndsize_t, ndsize_t>> RangeDimension::indexOf(const std::ve
 
     for (size_t i = 0; i < start_positions.size(); ++i) {
         boost::optional<std::pair<ndsize_t, ndsize_t>> range;
-        range = this->indexOf(start_positions[i], end_positions[i], ticks, match);
+        range = this->indexOf(start_positions[i], end_positions[i], std::move(ticks), match);
         if (range) {
             indices.push_back(*range);
         }

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -271,14 +271,8 @@ boost::optional<std::pair<ndsize_t, ndsize_t>> SampledDimension::indexOf(double 
     boost::optional<ndsize_t> ei = getSampledIndex(end, offset, sampling_interval, pos_match);
     
     boost::optional<std::pair<ndsize_t, ndsize_t>> indices;
-    if (si && ei) {
-        if (*si <= *ei) {
-            if (match == RangeMatch::Exclusive && *si < *ei) {
-                indices = std::pair<ndsize_t, ndsize_t>(*si, *ei);
-            } else if (match == RangeMatch::Inclusive) {
-                indices = std::pair<ndsize_t, ndsize_t>(*si, *ei);
-            }
-        }
+    if (si && ei && *si <= *ei) {
+        indices = std::pair<ndsize_t, ndsize_t>(*si, *ei);
     }
     return indices;
 }

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -437,6 +437,52 @@ ndsize_t getIndex(const double position, std::vector<double> &ticks, bool lower_
 }
 
 
+boost::optional<ndsize_t> getIndex(const double position, std::vector<double> &ticks, PositionMatch matching) {
+    boost::optional<ndsize_t> idx;
+    // check easy cases first ...
+    if (ticks.size() == 0)
+        return idx;
+    if (position < *ticks.begin()) {
+        if (matching == PositionMatch::Greater || matching == PositionMatch::GreaterOrEqual)
+            idx = 0;
+        return idx;
+    } else if (position > *prev(ticks.end())) {
+        if (matching == PositionMatch::Less || matching == PositionMatch::LessOrEqual) 
+            idx =  prev(ticks.end()) - ticks.begin();
+        return idx;
+    }
+    // need to do some searching --> first element larger or equal to position
+    std::vector<double>::iterator lower = std::lower_bound(ticks.begin(), ticks.end(), position);
+    if (matching == PositionMatch::Greater || matching == PositionMatch::GreaterOrEqual) {
+        idx = lower - ticks.begin();
+        if (matching == PositionMatch::Greater && *lower == position) {
+            if ((lower + 1) < ticks.end()) {
+                idx = lower + 1 - ticks.begin();
+            } else {
+                idx = boost::none;
+            }
+        }
+    } else if (matching == PositionMatch::LessOrEqual && *lower > position) {
+        if (lower - 1 >= ticks.begin()) {
+            idx = lower - 1 - ticks.begin();
+        } else {
+            idx = boost::none;
+        }
+    } else if (matching == PositionMatch::Less && *lower >= position) {
+        if ((lower - 1) >= ticks.begin()) {
+            idx = lower - 1 - ticks.begin();
+        } else {
+            idx = boost::none;
+        }
+    } else { // exact match
+        if (lower != ticks.end() && *lower == position) {
+            idx = lower - ticks.begin();
+        }
+    }
+    return idx;
+}
+
+
 ndsize_t RangeDimension::indexOf(const double position, bool less_or_equal) const {
     vector<double> ticks = this->ticks();
     PositionMatch matching = less_or_equal ? PositionMatch::LessOrEqual : PositionMatch::GreaterOrEqual;

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -262,15 +262,15 @@ boost::optional<std::pair<ndsize_t, ndsize_t>> SampledDimension::indexOf(const d
 
 boost::optional<std::pair<ndsize_t, ndsize_t>> SampledDimension::indexOf(double start, double end, const double sampling_interval, 
                                                                          const double offset, const RangeMatch match) const {
-    if (start > end) {
-        std::swap(start, end);
-    }
+    boost::optional<std::pair<ndsize_t, ndsize_t>> indices;
     PositionMatch pos_match = match == RangeMatch::Inclusive ? PositionMatch::LessOrEqual : PositionMatch::Less;
 
+    if (start > end) {
+        return indices;
+    }
     boost::optional<ndsize_t> si = getSampledIndex(start, offset, sampling_interval, PositionMatch::GreaterOrEqual);
     boost::optional<ndsize_t> ei = getSampledIndex(end, offset, sampling_interval, pos_match);
     
-    boost::optional<std::pair<ndsize_t, ndsize_t>> indices;
     if (si && ei && *si <= *ei) {
         indices = std::pair<ndsize_t, ndsize_t>(*si, *ei);
     }
@@ -442,15 +442,15 @@ boost::optional<std::pair<ndsize_t, ndsize_t>> SetDimension::indexOf(double star
     if (set_labels.size() == 0) {
         set_labels = labels();
     } 
+    boost::optional<std::pair<ndsize_t, ndsize_t>> index;
+
     if (start > end) {
-        std::swap(start, end);
+        return index;
     }
     PositionMatch end_match = match == RangeMatch::Inclusive ? PositionMatch::LessOrEqual : PositionMatch::Less;
-    boost::optional<std::pair<ndsize_t, ndsize_t>> index;
     
     boost::optional<ndsize_t> si = getSetIndex(start, set_labels, PositionMatch::GreaterOrEqual);
     boost::optional<ndsize_t> ei = getSetIndex(end, set_labels, end_match);
-    
     if (si && ei && *si <= *ei) {
         index = std::pair<ndsize_t, ndsize_t>(*si, *ei);    
     }
@@ -649,7 +649,7 @@ boost::optional<std::pair<ndsize_t, ndsize_t>> RangeDimension::indexOf(double st
     }
     boost::optional<std::pair<ndsize_t, ndsize_t>> range;
     if (start > end){
-        std::swap(start, end);
+        return range;
     }
 
     boost::optional<ndsize_t> si = getIndex(start, ticks, PositionMatch::GreaterOrEqual);
@@ -834,11 +834,11 @@ boost::optional<ndsize_t> DataFrameDimension::indexOf(const double position, con
 
 
 boost::optional<std::pair<ndsize_t, ndsize_t>> DataFrameDimension::indexOf(double start, double end, ndsize_t tick_count, const RangeMatch match) const {
+    boost::optional<std::pair<ndsize_t, ndsize_t>> index;
     if (start > end) {
-        std::swap(start, end);
+        return index;
     }
     PositionMatch end_match = (match == RangeMatch::Inclusive ? PositionMatch::LessOrEqual : PositionMatch::Less);
-    boost::optional<std::pair<ndsize_t, ndsize_t>> index;
     
     boost::optional<ndsize_t> si = getDataFrameIndex(start, tick_count, PositionMatch::GreaterOrEqual);
     boost::optional<ndsize_t> ei = getDataFrameIndex(end, tick_count, end_match);

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -419,24 +419,7 @@ PositionInRange RangeDimension::positionInRange(const double position) const {
 }
 
 
-ndsize_t getIndex(const double position, std::vector<double> &ticks, bool lower_bound) {
-    if (position < *ticks.begin()) {
-        return 0;
-    } else if (position > *prev(ticks.end())) {
-        return prev(ticks.end()) - ticks.begin();
-    }
-    ndsize_t index;
-    if (lower_bound) {
-        std::vector<double>::iterator lower = std::lower_bound(ticks.begin(), ticks.end(), position);
-        index = lower - ticks.begin();
-    } else{
-        std::vector<double>::iterator upper = std::upper_bound(ticks.begin(), ticks.end(), position) - 1;
-        index = upper - ticks.begin();
-    }
     return index;
-}
-
-
 boost::optional<ndsize_t> getIndex(const double position, std::vector<double> &ticks, PositionMatch matching) {
     boost::optional<ndsize_t> idx;
     // check easy cases first ...
@@ -487,6 +470,30 @@ boost::optional<ndsize_t> RangeDimension::indexOf(const double position, Positio
     vector<double> ticks = this->ticks();
     boost::optional<ndsize_t> index = getIndex(position, ticks, matching);
     return index;
+}
+
+
+boost::optional<std::pair<ndsize_t, ndsize_t>> RangeDimension::indexOf(double start, double end,
+                                                                       std::vector<double> ticks,
+                                                                       RangeMatch match) const {
+    if (ticks.size() == 0) {
+        ticks = this->ticks();
+    }
+    boost::optional<std::pair<ndsize_t, ndsize_t>> range;
+    if (start > end){
+        std::swap(start, end);
+    }
+    
+    boost::optional<ndsize_t> si = getIndex(start, ticks, PositionMatch::GreaterOrEqual);
+    if (!si) {
+        return range;  
+    }
+    PositionMatch endMatching = (match == RangeMatch::Inclusive) ? PositionMatch::LessOrEqual : PositionMatch::Less;
+    boost::optional<ndsize_t> ei = getIndex(end, ticks, endMatching);
+    if (ei && *si <= *ei) {
+        range = std::pair<ndsize_t, ndsize_t>(*si, *ei);
+    }
+    return range;
 }
 
 

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -439,7 +439,12 @@ ndsize_t getIndex(const double position, std::vector<double> &ticks, bool lower_
 
 ndsize_t RangeDimension::indexOf(const double position, bool less_or_equal) const {
     vector<double> ticks = this->ticks();
-    return getIndex(position, ticks, !less_or_equal);
+    PositionMatch matching = less_or_equal ? PositionMatch::LessOrEqual : PositionMatch::GreaterOrEqual;
+    boost::optional<ndsize_t> index = getIndex(position, ticks, matching);
+    if (index)
+        return *index;
+    else
+        throw nix::OutOfBounds("RangeDimension::indexOf: Position is out of bounds.");
 }
 
 

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -483,6 +483,13 @@ boost::optional<ndsize_t> getIndex(const double position, std::vector<double> &t
 }
 
 
+boost::optional<ndsize_t> RangeDimension::indexOf(const double position, PositionMatch matching) const {
+    vector<double> ticks = this->ticks();
+    boost::optional<ndsize_t> index = getIndex(position, ticks, matching);
+    return index;
+}
+
+
 ndsize_t RangeDimension::indexOf(const double position, bool less_or_equal) const {
     vector<double> ticks = this->ticks();
     PositionMatch matching = less_or_equal ? PositionMatch::LessOrEqual : PositionMatch::GreaterOrEqual;

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -520,7 +520,20 @@ pair<ndsize_t, ndsize_t> RangeDimension::indexOf(const double start, const doubl
 
 std::vector<std::pair<ndsize_t, ndsize_t>> RangeDimension::indexOf(const std::vector<double> &start_positions,
                                                                    const std::vector<double> &end_positions,
-                                                                   RangeMatch match, bool strict) const {
+                                                                   bool strict, RangeMatch match) const {
+    std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> optionalIndices;
+    optionalIndices = indexOf(start_positions, end_positions, match);
+    std::vector<std::pair<ndsize_t, ndsize_t>> indices;
+
+    for(auto o: optionalIndices) {
+        if (o) {
+            indices.push_back(*o);
+        } else if(strict) {
+            throw nix::OutOfBounds("RangeDimension::indexOf: an invalid range was encountered.");
+        }
+    }
+    return indices;
+}
 
 
 std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> RangeDimension::indexOf(const std::vector<double> &start_positions,

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -639,7 +639,7 @@ boost::optional<ndsize_t> RangeDimension::indexOf(const double position, Positio
 
 
 boost::optional<std::pair<ndsize_t, ndsize_t>> RangeDimension::indexOf(double start, double end,
-                                                                       std::vector<double> &&ticks,
+                                                                       std::vector<double> ticks,
                                                                        RangeMatch match) const {
     if (ticks.size() == 0) {
         ticks = this->ticks();
@@ -712,7 +712,7 @@ std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> RangeDimension::inde
     vector<double> ticks = this->ticks();
     for (size_t i = 0; i < start_positions.size(); ++i) {
         boost::optional<std::pair<ndsize_t, ndsize_t>> range;
-        range = this->indexOf(start_positions[i], end_positions[i], std::move(ticks), match);
+        range = this->indexOf(start_positions[i], end_positions[i], ticks, match);
         indices.push_back(range);
     }
     return indices;

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -393,6 +393,47 @@ SetDimension::SetDimension(const SetDimension &other)
 {
 }
 
+boost::optional<ndsize_t> SetDimension::indexOf(const double position, const PositionMatch match) const {
+    boost::optional<ndsize_t> index;
+    if (position < 0 && (match != PositionMatch::Greater && match != PositionMatch::GreaterOrEqual)) {
+        return index;
+    }
+    double tmp;
+    if (match == PositionMatch::Greater || match == PositionMatch::GreaterOrEqual) {
+        tmp = ceil(position);
+        if (tmp < 0.0) {
+            tmp = 0.0;
+        }
+        bool equals = fabs(tmp - position) <= numeric_limits<double>::epsilon();
+        index = (match == PositionMatch::Greater && equals) ? static_cast<ndsize_t>(tmp + 1) : static_cast<ndsize_t>(tmp);
+    } else if (match == PositionMatch::Less || match == PositionMatch::LessOrEqual) {
+        tmp = floor(position);
+        bool equals = fabs(tmp - position) <= numeric_limits<double>::epsilon();
+        if (match == PositionMatch::Less && equals) { 
+            if (tmp >= 1) {
+                index = static_cast<ndsize_t>(tmp - 1);
+            } 
+        } else {
+            index = static_cast<ndsize_t>(tmp);
+        }
+    } else {
+        tmp = round(position);
+        if (fabs(tmp - position) <= numeric_limits<double>::epsilon()) {
+            index = static_cast<ndsize_t>(tmp);
+        }
+    }
+
+    ndsize_t label_count = labels().size();
+    if (index && label_count > 0 && *index > label_count - 1) {
+        if (match == PositionMatch::Less || match == PositionMatch::LessOrEqual) {
+            index = label_count - 1;
+        } else {
+            index = boost::none;
+        }
+    }
+    return index;
+}
+
 
 SetDimension& SetDimension::operator=(const SetDimension &other) {
     shared_ptr<ISetDimension> tmp(other.impl());

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -393,7 +393,8 @@ SetDimension::SetDimension(const SetDimension &other)
 {
 }
 
-boost::optional<ndsize_t> SetDimension::indexOf(const double position, const PositionMatch match) const {
+
+boost::optional<ndsize_t> getSetIndex(const double position, std::vector<std::string> labels, const PositionMatch match) {
     boost::optional<ndsize_t> index;
     if (position < 0 && (match != PositionMatch::Greater && match != PositionMatch::GreaterOrEqual)) {
         return index;
@@ -423,7 +424,7 @@ boost::optional<ndsize_t> SetDimension::indexOf(const double position, const Pos
         }
     }
 
-    ndsize_t label_count = labels().size();
+    ndsize_t label_count = labels.size();
     if (index && label_count > 0 && *index > label_count - 1) {
         if (match == PositionMatch::Less || match == PositionMatch::LessOrEqual) {
             index = label_count - 1;
@@ -432,7 +433,40 @@ boost::optional<ndsize_t> SetDimension::indexOf(const double position, const Pos
         }
     }
     return index;
+
 }
+
+
+boost::optional<ndsize_t> SetDimension::indexOf(const double position, const PositionMatch match) const {
+    std::vector<std::string> lbls = labels();
+    return getSetIndex(position, lbls, match);
+}
+
+
+boost::optional<std::pair<ndsize_t, ndsize_t>> SetDimension::indexOf(double start, double end, std::vector<std::string> &set_labels, const RangeMatch match) const {
+    if (set_labels.size() == 0) {
+        set_labels = labels();
+    } 
+    if (start > end) {
+        std::swap(start, end);
+    }
+    PositionMatch end_match = match == RangeMatch::Inclusive ? PositionMatch::LessOrEqual : PositionMatch::Less;
+    boost::optional<std::pair<ndsize_t, ndsize_t>> index;
+    
+    boost::optional<ndsize_t> si = getSetIndex(start, set_labels, PositionMatch::GreaterOrEqual);
+    boost::optional<ndsize_t> ei = getSetIndex(end, set_labels, end_match);
+    if (ei && si) {
+        index = std::pair<ndsize_t, ndsize_t>(*si, *ei);
+    }
+    return index;
+}
+
+
+boost::optional<std::pair<ndsize_t, ndsize_t>> SetDimension::indexOf(const double start, const double end, const RangeMatch match) const {
+    std::vector<std::string> set_labels = labels();
+    return indexOf(start, end, set_labels, match);
+}
+
 
 
 SetDimension& SetDimension::operator=(const SetDimension &other) {

--- a/src/Dimensions.cpp
+++ b/src/Dimensions.cpp
@@ -449,8 +449,9 @@ boost::optional<std::pair<ndsize_t, ndsize_t>> SetDimension::indexOf(double star
     
     boost::optional<ndsize_t> si = getSetIndex(start, set_labels, PositionMatch::GreaterOrEqual);
     boost::optional<ndsize_t> ei = getSetIndex(end, set_labels, end_match);
-    if (ei && si) {
-        index = std::pair<ndsize_t, ndsize_t>(*si, *ei);
+    
+    if (si && ei && *si <= *ei) {
+        index = std::pair<ndsize_t, ndsize_t>(*si, *ei);    
     }
     return index;
 }
@@ -461,6 +462,21 @@ boost::optional<std::pair<ndsize_t, ndsize_t>> SetDimension::indexOf(const doubl
     return indexOf(start, end, set_labels, match);
 }
 
+
+std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> SetDimension::indexOf(const std::vector<double> &start_positions,
+                                                                                  const std::vector<double> &end_positions,
+                                                                                  const RangeMatch match) const {
+    if (start_positions.size() != end_positions.size()) {
+        throw runtime_error("Dimension::IndexOf - Number of start and end positions must match!");
+    }
+
+    std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> indices;
+    std::vector<std::string> set_labels = labels();
+    for (size_t i = 0; i < start_positions.size(); ++i) {
+        indices.push_back(indexOf(start_positions[i], end_positions[i], set_labels, match));
+    }
+    return indices;
+}
 
 
 SetDimension& SetDimension::operator=(const SetDimension &other) {

--- a/src/util/dataAccess.cpp
+++ b/src/util/dataAccess.cpp
@@ -76,22 +76,6 @@ vector<optional<pair<ndsize_t, ndsize_t>>> positionToIndex(const vector<double> 
     return indices;
 }
 
-vector<pair<ndsize_t, ndsize_t>> positionToIndex(const vector<double> &start_positions,
-                                                 const vector<double> end_positions,
-                                                 const vector<string> &units,
-                                                 const Dimension &dimension) {
-    vector<optional<pair<ndsize_t, ndsize_t>>> opt_indices = positionToIndex(start_positions, end_positions, units, RangeMatch::Inclusive, dimension);
-    vector<pair<ndsize_t, ndsize_t>> indices;
-    for (auto o : opt_indices) {
-        if (o) {
-            indices.push_back(*o);
-        } else {
-            throw nix::OutOfBounds("util::positionToIndex: An invalid range was encountered!");
-        }
-    }
-    return indices;
-}
-
 
 vector<pair<ndsize_t, ndsize_t>> positionToIndex(const vector<double> &start_positions,
                                                  const vector<double> &end_positions,
@@ -221,32 +205,6 @@ optional<ndsize_t> positionToIndex(double position, const string &unit, const Po
     return pos;
 }
 
-ndsize_t positionToIndex(double position, const string &unit, const Dimension &dimension) {
-    boost::optional<ndsize_t> pos;
-
-    if (dimension.dimensionType() == DimensionType::Sample) {
-        SampledDimension dim;
-        dim = dimension;
-        pos = positionToIndex(position, unit, PositionMatch::GreaterOrEqual, dim);
-    } else if (dimension.dimensionType() == DimensionType::Set) {
-        SetDimension dim;
-        dim = dimension;
-        pos = positionToIndex(position, unit, PositionMatch::GreaterOrEqual, dim);
-    } else if (dimension.dimensionType() == DimensionType::DataFrame) {
-       DataFrameDimension dim;
-       dim = dimension;
-       pos = positionToIndex(position, PositionMatch::GreaterOrEqual, dim); 
-    } else {
-        RangeDimension dim;
-        dim = dimension;
-        pos = positionToIndex(position, unit, PositionMatch::GreaterOrEqual, dim);
-    }
-    
-    if (!pos) {
-        throw nix::OutOfBounds("util::positionToIndex: Out of range position was given.");
-    }
-    return *pos;
-}
 
 ndsize_t positionToIndex(double position, const string &unit, const SampledDimension &dimension) {
     optional<ndsize_t> index = positionToIndex(position, unit, PositionMatch::GreaterOrEqual, dimension);

--- a/src/util/dataAccess.cpp
+++ b/src/util/dataAccess.cpp
@@ -536,7 +536,6 @@ void getOffsetAndCount(const MultiTag &tag, const DataArray &array, const vector
                 if (end_positions[dim_index][i] == start_positions[dim_index][i]) {
                     optional<ndsize_t> ofst = positionToIndex(end_positions[dim_index][i], units[dim_index], PositionMatch::GreaterOrEqual, dimensions[dim_index]);  
                     if (!ofst) {
-                        cerr << end_positions[dim_index][i] << "\t" << start_positions[dim_index][i]  << "\t" << units[dim_index] << endl;
                         throw nix::OutOfBounds("util::offsetAndCount:An invalid range was encountered!");
                     }
                     temp_offset[i] = *ofst;

--- a/src/util/dataAccess.cpp
+++ b/src/util/dataAccess.cpp
@@ -442,8 +442,8 @@ void getOffsetAndCount(const Tag &tag, const DataArray &array, NDSize &offset, N
             temp_offset[i] = *ofst;
         } else {
             temp_offset[i] = (*ranges[0]).first;
-            ndsize_t count = (*ranges[0]).second - (*ranges[0]).first;
-            temp_count[i] += count;
+            ndsize_t c = (*ranges[0]).second - (*ranges[0]).first;
+            temp_count[i] += c;
         }
     }
     offset = temp_offset;

--- a/test/BaseTestDataAccess.cpp
+++ b/test/BaseTestDataAccess.cpp
@@ -178,6 +178,11 @@ void BaseTestDataAccess::testPositionToIndexSetDimensionOld() {
     CPPUNIT_ASSERT_NO_THROW(util::positionToIndex(0.5, "none", setDim));
     CPPUNIT_ASSERT(util::positionToIndex(0.5, "none", setDim) == 1);
 
+
+    std::vector<std::pair<ndsize_t, ndsize_t>> ranges;
+    CPPUNIT_ASSERT_THROW(util::positionToIndex({10}, {1.}, {"none"}, setDim), nix::OutOfBounds);
+    CPPUNIT_ASSERT_NO_THROW(util::positionToIndex({1}, {10.}, {"none"}, setDim));
+
     int pos = -1;
     CPPUNIT_ASSERT_NO_THROW(check::converts_to_double(pos, "Does not convert seamlessly to double!"));
     ndsize_t large_pos = pow(10, 16);
@@ -191,6 +196,8 @@ void BaseTestDataAccess::testPositionToIndexSetDimensionOld() {
 void BaseTestDataAccess::testPositionToIndexSetDimension() {
     CPPUNIT_ASSERT(!util::positionToIndex(5.8, PositionMatch::Equal, setDim));
 
+    CPPUNIT_ASSERT_THROW(util::positionToIndex({5.0, 0.}, {10.5}, RangeMatch::Inclusive, setDim), std::runtime_error);
+    
     vector<optional<pair<ndsize_t, ndsize_t>>> ranges = util::positionToIndex({5.0, 0.}, {10.5, 1.0}, RangeMatch::Inclusive, setDim);
     CPPUNIT_ASSERT(ranges.size() == 2);
     CPPUNIT_ASSERT(!ranges[0]);

--- a/test/BaseTestDataAccess.cpp
+++ b/test/BaseTestDataAccess.cpp
@@ -725,7 +725,7 @@ void BaseTestDataAccess::testDataSlice() {
     CPPUNIT_ASSERT_THROW(util::dataSlice(oned_array, {1, 2, 3}, {1, 2}), std::invalid_argument); // different size of start and end
     CPPUNIT_ASSERT_THROW(util::dataSlice(oned_array, {0.0}, {1.0}, {"mV"}), nix::IncompatibleDimensions); // sampledDimension represents time
     CPPUNIT_ASSERT_THROW(util::dataSlice(oned_array, {0.0}, {1.0}, {"ks"}), nix::OutOfBounds); // well beyond data
-    CPPUNIT_ASSERT_THROW(util::dataSlice(oned_array, {1.0}, {0.0}), std::invalid_argument);
+    CPPUNIT_ASSERT_THROW(util::dataSlice(oned_array, {1.0}, {0.0}), std::invalid_argument); // start > end
 
     CPPUNIT_ASSERT_NO_THROW(util::dataSlice(oned_array, {0.0}, {1.0}));
     CPPUNIT_ASSERT_NO_THROW(util::dataSlice(oned_array, {0.0}, {1.0}, {"s"}));
@@ -747,6 +747,10 @@ void BaseTestDataAccess::testDataSlice() {
     slice = util::dataSlice(oned_array, {0.0}, {1.0}, {}, RangeMatch::Exclusive);
     CPPUNIT_ASSERT(slice.dataExtent().size() == 1);
     CPPUNIT_ASSERT(slice.dataExtent()[0] == 100);
+
+    slice = util::dataSlice(oned_array, {1.0}, {1.0}, {}, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(slice.dataExtent().size() == 1);
+    CPPUNIT_ASSERT(slice.dataExtent()[0] == 1);
 
     slice = util::dataSlice(twod_array2, {3.14, 1.0}, {9.6, 2.0}, {}, RangeMatch::Exclusive);
     CPPUNIT_ASSERT(slice.dataExtent()[0] == 3 && slice.dataExtent()[1] == 100);

--- a/test/BaseTestDataAccess.cpp
+++ b/test/BaseTestDataAccess.cpp
@@ -326,20 +326,20 @@ void BaseTestDataAccess::testRetrieveData() {
 
     position_indices[0] = 0;
     std::vector<DataView> views;
-    views = util::taggedData(multi_tag, position_indices, 0);
+    views = util::taggedData(multi_tag, position_indices, 0, RangeMatch::Inclusive);
     CPPUNIT_ASSERT(views.size() == 1);
-    nix::DataView v = util::taggedData(multi_tag, 0, 0);
+    nix::DataView v = util::taggedData(multi_tag, 0, 0, RangeMatch::Inclusive);
     CPPUNIT_ASSERT_EQUAL(v.dataExtent(), views[0].dataExtent());
 
     std::vector<ndsize_t> temp;
-    std::vector<DataView> slices = util::taggedData(mtag2, temp, 0);
+    std::vector<DataView> slices = util::taggedData(mtag2, temp, 0, RangeMatch::Inclusive);
     CPPUNIT_ASSERT(slices.size() == mtag2.positions().dataExtent()[0]);
 
     // old-style calls, deprecated
     CPPUNIT_ASSERT_NO_THROW(util::retrieveData(mtag2, 0, 0));
     CPPUNIT_ASSERT_NO_THROW(util::retrieveData(mtag2, 0, mtag2.references()[0]));
 
-    slices = util::taggedData(pointmtag, temp, 0);
+    slices = util::taggedData(pointmtag, temp, 0, RangeMatch::Inclusive);
     CPPUNIT_ASSERT(slices.size() == pointmtag.positions().dataExtent()[0]);
 
     DataView data_view = views[0];
@@ -350,17 +350,17 @@ void BaseTestDataAccess::testRetrieveData() {
     position_indices[0] = 1;
     CPPUNIT_ASSERT_THROW(util::taggedData(multi_tag, position_indices, 0), nix::OutOfBounds);
 
-    data_view = util::taggedData(position_tag, 0);
+    data_view = util::taggedData(position_tag, 0, RangeMatch::Inclusive);
     data_size = data_view.dataExtent();
     CPPUNIT_ASSERT(data_size.size() == 4);
     CPPUNIT_ASSERT(data_size[0] == 1 && data_size[1] == 1 && data_size[2] == 1 && data_size[3] == 1);
 
-    data_view = util::taggedData(segment_tag, 0);
+    data_view = util::taggedData(segment_tag, 0, RangeMatch::Inclusive);
     data_size = data_view.dataExtent();
     CPPUNIT_ASSERT(data_size.size() == 4);
     CPPUNIT_ASSERT(data_size[0] == 1 && data_size[1] == 7 && data_size[2] == 2 && data_size[3] == 2);
 
-    DataView times_view = util::taggedData(times_tag, 0);
+    DataView times_view = util::taggedData(times_tag, 0, RangeMatch::Inclusive);
     data_size = times_view.dataExtent();
     std::vector<double> times(data_size.size());
     times_view.getData(times);
@@ -414,7 +414,7 @@ void BaseTestDataAccess::testTagFeatureData() {
     data3 = util::featureData(pos_tag, 2);
 
     CPPUNIT_ASSERT(data1.dataExtent().nelms() == 1);
-    CPPUNIT_ASSERT(data2.dataExtent().nelms() == 3);
+    CPPUNIT_ASSERT(data2.dataExtent().nelms() == 2);
     CPPUNIT_ASSERT(data3.dataExtent().nelms() == ramp_data.size());
 
     pos_tag.deleteFeature(f1.id());
@@ -827,15 +827,15 @@ void BaseTestDataAccess::testFlexibleTagging() {
     tag.addReference(array3d);
 
     nix::DataView view = tag.taggedData("1d random data");
-    nix::NDSize exp_shape({501});
+    nix::NDSize exp_shape({500});
     CPPUNIT_ASSERT(view.dataExtent() == exp_shape);
 
     view = tag.taggedData("2d random data");
-    exp_shape = {51, 6};
+    exp_shape = {50, 5};
     CPPUNIT_ASSERT(view.dataExtent() == exp_shape);
 
     view = tag.taggedData("3d random data");
-    exp_shape = {51, 6, 5};
+    exp_shape = {50, 5, 4};
     CPPUNIT_ASSERT(view.dataExtent() == exp_shape);
 
     // Tag, tagging 3 dims without extents, i.e. a point
@@ -911,15 +911,15 @@ void BaseTestDataAccess::testFlexibleTagging() {
     mtag.addReference(array3d);
 
     view = mtag.taggedData(0, "1d random data");
-    exp_shape = {101};
+    exp_shape = {100};
     CPPUNIT_ASSERT(view.dataExtent() == exp_shape);
 
     view = mtag.taggedData(0, "2d random data");
-    exp_shape = {11, 3};
+    exp_shape = {10, 2};
     CPPUNIT_ASSERT(view.dataExtent() == exp_shape);
 
     view = mtag.taggedData(0, "3d random data");
-    exp_shape = {11, 3, 5};
+    exp_shape = {10, 2, 4};
     CPPUNIT_ASSERT(view.dataExtent() == exp_shape);
 
 
@@ -946,14 +946,14 @@ void BaseTestDataAccess::testFlexibleTagging() {
     dfTag.addReference(array3d);
 
     view = dfTag.taggedData("3d random data");
-    exp_shape = {51, 6, 5};
+    exp_shape = {50, 5, 4};
     CPPUNIT_ASSERT(view.dataExtent() == exp_shape);
 
     dfTag.position({25});
     dfTag.extent({50});
 
     view = dfTag.taggedData("3d random data");
-    exp_shape = {51, 10, 5};
+    exp_shape = {50, 9, 4};
     CPPUNIT_ASSERT(view.dataExtent() == exp_shape);
 
     file.deleteBlock(b);

--- a/test/BaseTestDataAccess.cpp
+++ b/test/BaseTestDataAccess.cpp
@@ -143,13 +143,13 @@ void BaseTestDataAccess::testPositionToIndexSampledDimension() {
     CPPUNIT_ASSERT(ranges.size() == 3);
     CPPUNIT_ASSERT(ranges[0] && (*ranges[0]).first == 0 && (*ranges[0]).second == 10);
     CPPUNIT_ASSERT(ranges[1] && (*ranges[1]).first == 2 && (*ranges[1]).second == 2);
-    CPPUNIT_ASSERT(ranges[2] && (*ranges[2]).first == 5 && (*ranges[2]).second == 10);
+    CPPUNIT_ASSERT(!ranges[2]);// && (*ranges[2]).first == 5 && (*ranges[2]).second == 10);
 
     ranges = util::positionToIndex({0.0, 2.0, 10.0}, {10.0, 2.0, 5.0}, {unit, unit, unit}, RangeMatch::Exclusive, sampledDim);
     CPPUNIT_ASSERT(ranges.size() == 3);
     CPPUNIT_ASSERT(ranges[0] && (*ranges[0]).first == 0 && (*ranges[0]).second == 9);
     CPPUNIT_ASSERT(!ranges[1]);
-    CPPUNIT_ASSERT(ranges[2] && (*ranges[2]).first == 5 && (*ranges[2]).second == 9);
+    CPPUNIT_ASSERT(!ranges[2]); // && (*ranges[2]).first == 5 && (*ranges[2]).second == 9);
 }
 
 void BaseTestDataAccess::testPositionToIndexSampledDimensionOld() {
@@ -163,7 +163,9 @@ void BaseTestDataAccess::testPositionToIndexSampledDimensionOld() {
     CPPUNIT_ASSERT(util::positionToIndex(0.005, scaled_unit, sampledDim) == 5);
 
     CPPUNIT_ASSERT_THROW(util::positionToIndex({},{1.0}, {unit}, sampledDim), std::runtime_error);
-    CPPUNIT_ASSERT(util::positionToIndex({0.0, 1.0}, {3.5, 0.5}, {unit, unit}, sampledDim).size() == 2);
+    CPPUNIT_ASSERT_THROW(util::positionToIndex({0.0, 1.0}, {3.5, 0.5}, {unit, unit}, sampledDim), nix::OutOfBounds);
+    CPPUNIT_ASSERT(util::positionToIndex({0.0, 0.5}, {3.5, 1.0}, {unit, unit}, sampledDim).size() == 2);
+
     vector<pair<ndsize_t, ndsize_t>> ranges = util::positionToIndex({0.0}, {0.0}, {unit}, sampledDim);
     CPPUNIT_ASSERT(ranges[0].first == 0 && ranges[0].second == 0);
 }
@@ -212,7 +214,7 @@ void BaseTestDataAccess::testPositionToIndexDataFrameDimension() {
     CPPUNIT_ASSERT(ranges.size() == 3);
     CPPUNIT_ASSERT(ranges[0]);
     CPPUNIT_ASSERT(!ranges[1]);
-    CPPUNIT_ASSERT(ranges[2]);
+    CPPUNIT_ASSERT(!ranges[2]);
 }
 
 

--- a/test/BaseTestDataAccess.cpp
+++ b/test/BaseTestDataAccess.cpp
@@ -28,21 +28,79 @@
 #include "BaseTestDataAccess.hpp"
 
 using namespace nix;
+using namespace std;
+using namespace boost;
 
 void BaseTestDataAccess::testPositionToIndexRangeDimension() {
-    std::string unit = "ms";
-    std::string invalid_unit = "kV";
-    std::string scaled_unit = "s";
-    CPPUNIT_ASSERT_THROW(util::positionToIndex(5.0, invalid_unit, rangeDim), nix::IncompatibleDimensions);
+    string unit = "ms";
+    string invalid_unit = "kV";
+    string scaled_unit = "s";
 
-    CPPUNIT_ASSERT(util::positionToIndex(1.0, unit, rangeDim) == 0);
-    CPPUNIT_ASSERT(util::positionToIndex(8.0, unit, rangeDim) == 4);
+    CPPUNIT_ASSERT_THROW(util::positionToIndex(5.0, invalid_unit, rangeDim), nix::IncompatibleDimensions);
+    CPPUNIT_ASSERT(*util::positionToIndex(5.0, unit, PositionMatch::Less, rangeDim) == 3);
+    CPPUNIT_ASSERT(*util::positionToIndex(0.005, scaled_unit, PositionMatch::Less, rangeDim) == 3);
+
+    CPPUNIT_ASSERT(!util::positionToIndex(1.0, unit, PositionMatch::Less, rangeDim));
+    CPPUNIT_ASSERT(!util::positionToIndex(1.0, unit, PositionMatch::LessOrEqual, rangeDim));
+    CPPUNIT_ASSERT(!util::positionToIndex(1.0, unit, PositionMatch::Equal, rangeDim));
+    CPPUNIT_ASSERT(*(util::positionToIndex(1.0, unit, PositionMatch::GreaterOrEqual, rangeDim)) == 0);
+    CPPUNIT_ASSERT(*(util::positionToIndex(1.0, unit, PositionMatch::Greater, rangeDim)) == 0);
+
+    CPPUNIT_ASSERT(!util::positionToIndex(1.2, unit, PositionMatch::Less, rangeDim));
+    CPPUNIT_ASSERT(util::positionToIndex(1.2, unit, PositionMatch::LessOrEqual, rangeDim));
+    CPPUNIT_ASSERT(util::positionToIndex(1.2, unit, PositionMatch::Equal, rangeDim));
+    CPPUNIT_ASSERT(*(util::positionToIndex(1.2, unit, PositionMatch::GreaterOrEqual, rangeDim)) == 0);
+    CPPUNIT_ASSERT(*(util::positionToIndex(1.2, unit, PositionMatch::Greater, rangeDim)) == 1);
+
+    CPPUNIT_ASSERT(*util::positionToIndex(4.5, unit, PositionMatch::Less, rangeDim) == 2);
+    CPPUNIT_ASSERT(*util::positionToIndex(4.5, unit, PositionMatch::LessOrEqual, rangeDim) == 3);
+    CPPUNIT_ASSERT(*util::positionToIndex(4.5, unit, PositionMatch::Equal, rangeDim) == 3);
+    CPPUNIT_ASSERT(*(util::positionToIndex(4.5, unit, PositionMatch::GreaterOrEqual, rangeDim)) == 3);
+    CPPUNIT_ASSERT(*(util::positionToIndex(4.5, unit, PositionMatch::Greater, rangeDim)) == 4);
+
+    CPPUNIT_ASSERT(*util::positionToIndex(7.0, unit, PositionMatch::Less, rangeDim) == 4);
+    CPPUNIT_ASSERT(*util::positionToIndex(7.0, unit, PositionMatch::LessOrEqual, rangeDim) == 4);
+    CPPUNIT_ASSERT(!util::positionToIndex(7.0, unit, PositionMatch::Equal, rangeDim));
+    CPPUNIT_ASSERT(!(util::positionToIndex(7.0, unit, PositionMatch::GreaterOrEqual, rangeDim)));
+    CPPUNIT_ASSERT(!util::positionToIndex(7.0, unit, PositionMatch::Greater, rangeDim));
+
+    CPPUNIT_ASSERT_THROW(util::positionToIndex({5.0, 1.2}, {1.4}, {unit, unit}, RangeMatch::Inclusive, rangeDim), std::runtime_error);
+
+    vector<optional<pair<ndsize_t, ndsize_t>>> range = util::positionToIndex({0.0}, {7.0}, {unit}, RangeMatch::Inclusive, rangeDim);
+    CPPUNIT_ASSERT(range[0] && (*range[0]).first == 0 && (*range[0]).second == 4);
+    range = util::positionToIndex({0.0}, {7.0}, {unit}, RangeMatch::Exclusive, rangeDim);
+    CPPUNIT_ASSERT(range[0] && (*range[0]).first == 0 && (*range[0]).second == 4);
+    
+    range = util::positionToIndex({2.0}, {6.7}, {unit}, RangeMatch::Inclusive, rangeDim);
+    CPPUNIT_ASSERT(range[0] && (*range[0]).first == 1 && (*range[0]).second == 4);
+    range = util::positionToIndex({2.0}, {6.7}, {unit}, RangeMatch::Exclusive, rangeDim);
+    CPPUNIT_ASSERT(range[0] && (*range[0]).first == 1 && (*range[0]).second == 3);
+
+    range = util::positionToIndex({1.2}, {1.2}, {unit}, RangeMatch::Inclusive, rangeDim);
+    CPPUNIT_ASSERT(range[0] && (*range[0]).first == 0 && (*range[0]).second == 0);
+    range = util::positionToIndex({1.2}, {1.2}, {unit}, RangeMatch::Exclusive, rangeDim);
+    CPPUNIT_ASSERT(!range[0]);
+}
+
+void BaseTestDataAccess::testPositionToIndexRangeDimensionOld() {
+    string unit = "ms";
+    string invalid_unit = "kV";
+    string scaled_unit = "s";
+
+    CPPUNIT_ASSERT_THROW(util::positionToIndex(0.001, invalid_unit, rangeDim), nix::IncompatibleDimensions);
+    CPPUNIT_ASSERT_THROW(util::positionToIndex(8.0, unit, rangeDim), nix::OutOfBounds);
+    CPPUNIT_ASSERT(util::positionToIndex(0.001, unit, rangeDim) == 0);
     CPPUNIT_ASSERT(util::positionToIndex(0.001, scaled_unit, rangeDim) == 0);
-    CPPUNIT_ASSERT(util::positionToIndex(0.008, scaled_unit, rangeDim) == 4);
+    CPPUNIT_ASSERT_THROW(util::positionToIndex(0.008, scaled_unit, rangeDim), nix::OutOfBounds);
     CPPUNIT_ASSERT(util::positionToIndex(3.4, unit, rangeDim) == 2);
-    CPPUNIT_ASSERT(util::positionToIndex(3.6, unit, rangeDim) == 2);
-    CPPUNIT_ASSERT(util::positionToIndex(4.0, unit, rangeDim) == 2);
-    CPPUNIT_ASSERT(util::positionToIndex(0.0036, scaled_unit, rangeDim) == 2);
+    CPPUNIT_ASSERT(util::positionToIndex(3.6, unit, rangeDim) == 3);
+    CPPUNIT_ASSERT(util::positionToIndex(4.0, unit, rangeDim) == 3);
+    CPPUNIT_ASSERT(util::positionToIndex(0.0034, scaled_unit, rangeDim) == 2);
+
+    vector<pair<ndsize_t, ndsize_t>> range = util::positionToIndex({0.001}, {3.4}, {unit}, rangeDim);
+    CPPUNIT_ASSERT(range[0].first == 0 && range[0].second == 2);
+    CPPUNIT_ASSERT_THROW(util::positionToIndex({0.001, 2.0}, {3.4}, {unit}, rangeDim), std::runtime_error);
+    CPPUNIT_ASSERT_THROW(util::positionToIndex({7.5}, {8.0}, {unit}, rangeDim), nix::OutOfBounds);
 }
 
 
@@ -69,24 +127,56 @@ void BaseTestDataAccess::testGetDimensionUnit() {
 
 
 void BaseTestDataAccess::testPositionToIndexSampledDimension() {
-    std::string unit = "ms";
-    std::string invalid_unit = "kV";
-    std::string scaled_unit = "s";
+    string unit = "ms";
+    string invalid_unit = "kV";
+    string scaled_unit = "s";
+    // test incompatible dims
+    CPPUNIT_ASSERT_THROW(util::positionToIndex(1.0, invalid_unit, sampledDim), nix::IncompatibleDimensions);
+    CPPUNIT_ASSERT_NO_THROW(util::positionToIndex(1.0, unit, sampledDim));
+    CPPUNIT_ASSERT_NO_THROW(util::positionToIndex(1.0, scaled_unit, sampledDim));
 
-    CPPUNIT_ASSERT_THROW(util::positionToIndex(-1.0, unit, sampledDim), nix::OutOfBounds);
+    sampledDim.unit(nix::none);
+    CPPUNIT_ASSERT_THROW(util::positionToIndex(1.0, unit, sampledDim), nix::IncompatibleDimensions);
+    sampledDim.unit(unit);
+
+    vector<optional<pair<ndsize_t, ndsize_t>>> ranges = util::positionToIndex({0.0, 2.0, 10.0}, {10.0, 2.0, 5.0}, {unit, unit, unit}, RangeMatch::Inclusive, sampledDim);
+    CPPUNIT_ASSERT(ranges.size() == 3);
+    CPPUNIT_ASSERT(ranges[0] && (*ranges[0]).first == 0 && (*ranges[0]).second == 10);
+    CPPUNIT_ASSERT(ranges[1] && (*ranges[1]).first == 2 && (*ranges[1]).second == 2);
+    CPPUNIT_ASSERT(ranges[2] && (*ranges[2]).first == 5 && (*ranges[2]).second == 10);
+
+    ranges = util::positionToIndex({0.0, 2.0, 10.0}, {10.0, 2.0, 5.0}, {unit, unit, unit}, RangeMatch::Exclusive, sampledDim);
+    CPPUNIT_ASSERT(ranges.size() == 3);
+    CPPUNIT_ASSERT(ranges[0] && (*ranges[0]).first == 0 && (*ranges[0]).second == 9);
+    CPPUNIT_ASSERT(!ranges[1]);
+    CPPUNIT_ASSERT(ranges[2] && (*ranges[2]).first == 5 && (*ranges[2]).second == 9);
+}
+
+void BaseTestDataAccess::testPositionToIndexSampledDimensionOld() {
+    string unit = "ms";
+    string invalid_unit = "kV";
+    string scaled_unit = "s";
+
+    CPPUNIT_ASSERT(util::positionToIndex(-8.0, unit, sampledDim) == 0);
     CPPUNIT_ASSERT_THROW(util::positionToIndex(0.005, invalid_unit, sampledDim), nix::IncompatibleDimensions);
     CPPUNIT_ASSERT(util::positionToIndex(5.0, unit, sampledDim) == 5);
     CPPUNIT_ASSERT(util::positionToIndex(0.005, scaled_unit, sampledDim) == 5);
+
+    CPPUNIT_ASSERT_THROW(util::positionToIndex({},{1.0}, {unit}, sampledDim), std::runtime_error);
+    CPPUNIT_ASSERT(util::positionToIndex({0.0, 1.0}, {3.5, 0.5}, {unit, unit}, sampledDim).size() == 2);
+    vector<pair<ndsize_t, ndsize_t>> ranges = util::positionToIndex({0.0}, {0.0}, {unit}, sampledDim);
+    CPPUNIT_ASSERT(ranges[0].first == 0 && ranges[0].second == 0);
 }
 
 
-void BaseTestDataAccess::testPositionToIndexSetDimension() {
+void BaseTestDataAccess::testPositionToIndexSetDimensionOld() {
     std::string unit = "ms";
     CPPUNIT_ASSERT_THROW(util::positionToIndex(-5.9, "none", setDim), nix::OutOfBounds);
     CPPUNIT_ASSERT_THROW(util::positionToIndex(5.8, "none", setDim), nix::OutOfBounds);
-    CPPUNIT_ASSERT_THROW(util::positionToIndex(0.5, unit, setDim), nix::IncompatibleDimensions);
     CPPUNIT_ASSERT_NO_THROW(util::positionToIndex(0.5, "none", setDim));
     CPPUNIT_ASSERT(util::positionToIndex(0.5, "none", setDim) == 1);
+
+
     CPPUNIT_ASSERT(util::positionToIndex(0.45, "none", setDim) == 0);
 
     int pos = -1;
@@ -99,6 +189,20 @@ void BaseTestDataAccess::testPositionToIndexSetDimension() {
 }
 
 
+void BaseTestDataAccess::testPositionToIndexSetDimension() {
+    CPPUNIT_ASSERT(!util::positionToIndex(5.8, PositionMatch::Equal, setDim));
+
+    vector<optional<pair<ndsize_t, ndsize_t>>> ranges = util::positionToIndex({5.0, 0.}, {10.5, 1.0}, RangeMatch::Inclusive, setDim);
+    CPPUNIT_ASSERT(ranges.size() == 2);
+    CPPUNIT_ASSERT(!ranges[0]);
+    CPPUNIT_ASSERT(ranges[1] && (*ranges[1]).first == 0 && (*ranges[1]).second == 1);
+
+    ranges = util::positionToIndex({5.0, 0.}, {10.5, 1.0}, RangeMatch::Exclusive, setDim);
+    CPPUNIT_ASSERT(ranges.size() == 2);
+    CPPUNIT_ASSERT(!ranges[0]);
+    CPPUNIT_ASSERT(ranges[1] && (*ranges[1]).first == 0 && (*ranges[1]).second == 0);   
+}
+
 void BaseTestDataAccess::testPositionToIndexDataFrameDimension() {
     std::string unit = "ms";
     CPPUNIT_ASSERT_THROW(util::positionToIndex(-1.1, "none", dfDim), nix::OutOfBounds);
@@ -107,8 +211,9 @@ void BaseTestDataAccess::testPositionToIndexDataFrameDimension() {
     CPPUNIT_ASSERT_NO_THROW(util::positionToIndex(0.5, "none", dfDim));
     CPPUNIT_ASSERT(util::positionToIndex(0.5, "none", dfDim) == 1);
     CPPUNIT_ASSERT(util::positionToIndex(0.45, "none", dfDim) == 0);
+    CPPUNIT_ASSERT(util::positionToIndex(0.45, unit, setDim) == 1);
+    CPPUNIT_ASSERT(util::positionToIndex(1., "none", setDim) == 1);
 }
-
 
 void BaseTestDataAccess::testOffsetAndCount() {
     NDSize offsets, counts;
@@ -430,9 +535,9 @@ void BaseTestDataAccess::testMultiTagUnitSupport() {
     testTag.units(valid_units);
     testTag.addReference(data_array);
     position_indices[0] = 0;
-    CPPUNIT_ASSERT_NO_THROW(util::taggedData(testTag, position_indices, 0));
-    testTag.units(none);
-    CPPUNIT_ASSERT_NO_THROW(util::taggedData(testTag, position_indices, 0));
+    CPPUNIT_ASSERT_NO_THROW(util::retrieveData(testTag, position_indices, 0));
+    testTag.units(nix::none);
+    CPPUNIT_ASSERT_NO_THROW(util::retrieveData(testTag, position_indices, 0));
     testTag.units(invalid_units);
     CPPUNIT_ASSERT_THROW(util::taggedData(testTag, position_indices, 0), nix::IncompatibleDimensions);
 }

--- a/test/BaseTestDataAccess.hpp
+++ b/test/BaseTestDataAccess.hpp
@@ -28,10 +28,13 @@ protected:
 
 public:
     void testPositionToIndexSetDimension();
+    void testPositionToIndexSetDimensionOld();
     void testPositionToIndexSampledDimension();
+    void testPositionToIndexSampledDimensionOld();
     void testPositionToIndexRangeDimension();
     void testGetDimensionUnit();
     void testPositionToIndexDataFrameDimension();
+    void testPositionToIndexRangeDimensionOld();
     void testOffsetAndCount();
     void testPositionInData();
     void testRetrieveData();

--- a/test/BaseTestDimension.cpp
+++ b/test/BaseTestDimension.cpp
@@ -434,6 +434,13 @@ void BaseTestDimension::testRangeDimIndexOfOld() {
     CPPUNIT_ASSERT_THROW(rd.indexOf(257.28, false), nix::OutOfBounds);
     CPPUNIT_ASSERT_THROW(rd.indexOf(-257.28), nix::OutOfBounds);
     CPPUNIT_ASSERT_NO_THROW(rd.indexOf(-257.28, false));
+
+    CPPUNIT_ASSERT_THROW(rd.indexOf(110., 120.), nix::OutOfBounds);
+    CPPUNIT_ASSERT_THROW(rd.indexOf(-120., -110.), nix::OutOfBounds);
+    std::pair<ndsize_t, ndsize_t> range = rd.indexOf(-100., 100.);
+    CPPUNIT_ASSERT(range.first == 0 && range.second == 4);
+    range = rd.indexOf(-200., 200.);
+    CPPUNIT_ASSERT(range.first == 0 && range.second == 4);
     
     CPPUNIT_ASSERT_THROW(rd.indexOf({-100.0, -90, 0.0}, {10.}), std::runtime_error);
     CPPUNIT_ASSERT_NO_THROW(rd.indexOf({-100.0, 20.0, 40.0}, {-45, 120., 100.}));

--- a/test/BaseTestDimension.cpp
+++ b/test/BaseTestDimension.cpp
@@ -179,7 +179,14 @@ void BaseTestDimension::testSampledDimIndexOf() {
     CPPUNIT_ASSERT(sd.indexOf(1.0, 1.01).first == 0);
     CPPUNIT_ASSERT_THROW(sd.indexOf(1.01, 0.0), nix::OutOfBounds);
     CPPUNIT_ASSERT_THROW(sd.indexOf(1.01, 0.99), nix::OutOfBounds);
-
+    CPPUNIT_ASSERT_THROW(sd.indexOf(3.14, 3.14 + samplingInterval/2 - 0.2, RangeMatch::Exclusive), nix::OutOfBounds);
+    CPPUNIT_ASSERT_NO_THROW(sd.indexOf(3.14, 3.14 + samplingInterval/2 - 0.2, RangeMatch::Inclusive));
+    CPPUNIT_ASSERT_NO_THROW(sd.indexOf(3.14, 3.14 + samplingInterval/2 + 0.2, RangeMatch::Exclusive));
+    
+    std::pair<ndsize_t, ndsize_t> range = sd.indexOf(3.14, 3.14 + samplingInterval/2 - 0.2, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range.first == 1 && range.second == 1);
+    range = sd.indexOf(3.14, 3.14 + samplingInterval/2 + 0.2, RangeMatch::Exclusive);    
+    CPPUNIT_ASSERT(range.first == 1 && range.second == 0); // this actually an invalid range!
 
     CPPUNIT_ASSERT_THROW(sd.indexOf({0.0, 20.0, 40.0}, {10.9}), std::runtime_error);
     CPPUNIT_ASSERT_THROW(sd.indexOf({0.0, 20.0, 40.0}, {10.9, 12., 1.}), nix::OutOfBounds);

--- a/test/BaseTestDimension.cpp
+++ b/test/BaseTestDimension.cpp
@@ -494,6 +494,43 @@ void BaseTestDimension::testRangeDimIndexOf() {
     CPPUNIT_ASSERT(*rd.indexOf(110., PositionMatch::Less) == 4);
     CPPUNIT_ASSERT(!rd.indexOf(110., PositionMatch::Equal));
 
+    boost::optional<std::pair<ndsize_t, ndsize_t>> range;
+    range = rd.indexOf(40., 100., {}, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 4 && (*range).second == 4);
+    range = rd.indexOf(40., 100., {}, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(!range);
+    range = rd.indexOf(-100., -45., {}, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 0);
+    range = rd.indexOf(-100., -45., {}, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 0);
+    range = rd.indexOf(10., 120., {}, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 3 && (*range).second == 4);
+    range = rd.indexOf(10., 120., {}, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 3 && (*range).second == 4);
+    range = rd.indexOf(100., 120., {}, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 4 && (*range).second == 4);
+    range = rd.indexOf(100., 120., {}, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 4 && (*range).second == 4);
+    range = rd.indexOf(110., 150., {}, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(!range);
+    range = rd.indexOf(100., -100., {}, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 4);
+    range = rd.indexOf(100., -100., {}, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 3);
+
+    range = rd.indexOf(100., -100., rd.ticks(), RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 3);
+
+    std::vector<std::pair<ndsize_t, ndsize_t>> ranges;
+    ranges = rd.indexOf({40., -100.}, {100., 100.}, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(ranges.size() == 2);
+    CPPUNIT_ASSERT(ranges[0].first == 4 && ranges[0].second == 4);
+    CPPUNIT_ASSERT(ranges[1].first == 0 && ranges[1].second == 4);
+
+    ranges = rd.indexOf({40., -100., -100.}, {100., 100., 101.}, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(ranges.size() == 2);
+    CPPUNIT_ASSERT(ranges[0].first == 0 && ranges[0].second == 3);
+    CPPUNIT_ASSERT(ranges[1].first == 0 && ranges[1].second == 4);
     data_array.deleteDimensions();
 }
 

--- a/test/BaseTestDimension.cpp
+++ b/test/BaseTestDimension.cpp
@@ -581,7 +581,7 @@ void BaseTestDimension::testSetDimIndexOf() {
     sd.labels(labels);
     range = sd.indexOf(0.0, 0.0, RangeMatch::Inclusive);
     CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 0);
-    range = sd.indexOf(0.0, 0.0, RangeMatch::Exclusive);
+    range = sd.indexOf(1.0, 1.0, RangeMatch::Exclusive);
     CPPUNIT_ASSERT(!range);
     range = sd.indexOf(0.0, 3.0, RangeMatch::Inclusive);
     CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 3);
@@ -595,6 +595,24 @@ void BaseTestDimension::testSetDimIndexOf() {
     CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 4);
     range = sd.indexOf(3.0, 7.0, RangeMatch::Exclusive);
     CPPUNIT_ASSERT(range && (*range).first == 3 && (*range).second == 4);
+
+    std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> ranges;
+    CPPUNIT_ASSERT_THROW(sd.indexOf({0.0, -1.0, 1.0}, {1.0, 2.0}, RangeMatch::Inclusive), std::runtime_error);
+    ranges = sd.indexOf({0.0, -1.0, 1.0, 1.0}, {1.0, 4.0, 9.0, 1.0}, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(ranges.size() == 4);
+    CPPUNIT_ASSERT(ranges[0] && (*ranges[0]).first == 0 && (*ranges[0]).second == 1);
+    CPPUNIT_ASSERT(ranges[1] && (*ranges[1]).first == 0 && (*ranges[1]).second == 4);
+    CPPUNIT_ASSERT(ranges[2] && (*ranges[2]).first == 1 && (*ranges[2]).second == 4);
+    CPPUNIT_ASSERT(ranges[3] && (*ranges[3]).first == 1 && (*ranges[3]).second == 1);
+
+    ranges = sd.indexOf({0.0, -1.0, 1.0, 1.0}, {1.0, 4.0, 9.0, 1.0}, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(ranges.size() == 4);
+    CPPUNIT_ASSERT(ranges[0] && (*ranges[0]).first == 0 && (*ranges[0]).second == 0);
+    CPPUNIT_ASSERT(ranges[1] && (*ranges[1]).first == 0 && (*ranges[1]).second == 3);
+    CPPUNIT_ASSERT(ranges[2] && (*ranges[2]).first == 1 && (*ranges[2]).second == 4);
+    CPPUNIT_ASSERT(!ranges[3]);
+
+
 }
 
 void BaseTestDimension::testRangeDimLabel() {

--- a/test/BaseTestDimension.cpp
+++ b/test/BaseTestDimension.cpp
@@ -429,9 +429,12 @@ void BaseTestDimension::testRangeDimIndexOf() {
     CPPUNIT_ASSERT(rd.indexOf(-10.0) == 1);
     CPPUNIT_ASSERT(rd.indexOf(-5.0) == 1);
     CPPUNIT_ASSERT(rd.indexOf(5.0) == 2);
-    CPPUNIT_ASSERT(rd.indexOf(257.28) == 4);
-    CPPUNIT_ASSERT(rd.indexOf(-257.28) == 0);
-
+    
+    CPPUNIT_ASSERT_NO_THROW(rd.indexOf(257.28));
+    CPPUNIT_ASSERT_THROW(rd.indexOf(257.28, false), nix::OutOfBounds);
+    CPPUNIT_ASSERT_THROW(rd.indexOf(-257.28), nix::OutOfBounds);
+    CPPUNIT_ASSERT_NO_THROW(rd.indexOf(-257.28, false));
+    
     CPPUNIT_ASSERT_THROW(rd.indexOf({-100.0, -90, 0.0}, {10.}), std::runtime_error);
     CPPUNIT_ASSERT_NO_THROW(rd.indexOf({-100.0, 20.0, 40.0}, {-45, 120., 100.}));
     CPPUNIT_ASSERT(rd.indexOf({-100.0, 20.0, 40.0}, {-45, 120., 100.}).size() == 3);

--- a/test/BaseTestDimension.cpp
+++ b/test/BaseTestDimension.cpp
@@ -415,7 +415,7 @@ void BaseTestDimension::testRangeTicks() {
 }
 
 
-void BaseTestDimension::testRangeDimIndexOf() {
+void BaseTestDimension::testRangeDimIndexOfOld() {
     std::vector<double> ticks = {-100.0, -10.0, 0.0, 10.0, 100.0};
     Dimension d = data_array.appendRangeDimension(ticks);
 
@@ -438,6 +438,55 @@ void BaseTestDimension::testRangeDimIndexOf() {
     CPPUNIT_ASSERT_THROW(rd.indexOf({-100.0, -90, 0.0}, {10.}), std::runtime_error);
     CPPUNIT_ASSERT_NO_THROW(rd.indexOf({-100.0, 20.0, 40.0}, {-45, 120., 100.}));
     CPPUNIT_ASSERT(rd.indexOf({-100.0, 20.0, 40.0}, {-45, 120., 100.}).size() == 3);
+    data_array.deleteDimensions();
+}
+
+
+void BaseTestDimension::testRangeDimIndexOf() {
+    std::vector<double> ticks = {-100.0, -10.0, 0.0, 10.0, 100.0};
+    Dimension d = data_array.appendRangeDimension(ticks);
+
+    CPPUNIT_ASSERT(d.dimensionType() == DimensionType::Range);
+
+    RangeDimension rd;
+    rd = d;
+
+    CPPUNIT_ASSERT(*rd.indexOf(-110., PositionMatch::GreaterOrEqual) == 0);
+    CPPUNIT_ASSERT(*rd.indexOf(-110., PositionMatch::GreaterOrEqual) == 0);
+    CPPUNIT_ASSERT(!rd.indexOf(-110., PositionMatch::LessOrEqual));
+    CPPUNIT_ASSERT(!rd.indexOf(-110., PositionMatch::Less));
+    CPPUNIT_ASSERT(!rd.indexOf(-110., PositionMatch::Equal));
+    
+    CPPUNIT_ASSERT(*rd.indexOf(-100., PositionMatch::GreaterOrEqual) == 0);
+    CPPUNIT_ASSERT(*rd.indexOf(-100., PositionMatch::Greater) == 1);
+    CPPUNIT_ASSERT(*rd.indexOf(-100., PositionMatch::LessOrEqual) == 0);
+    CPPUNIT_ASSERT(!rd.indexOf(-100., PositionMatch::Less));
+    CPPUNIT_ASSERT(*rd.indexOf(-100., PositionMatch::Equal) == 0);
+    
+    CPPUNIT_ASSERT(*rd.indexOf(-50., PositionMatch::GreaterOrEqual) == 1);
+    CPPUNIT_ASSERT(*rd.indexOf(-50., PositionMatch::Greater) == 1);
+    CPPUNIT_ASSERT(*rd.indexOf(-50., PositionMatch::LessOrEqual) == 0);
+    CPPUNIT_ASSERT(*rd.indexOf(-50., PositionMatch::Less) == 0);
+    CPPUNIT_ASSERT(!rd.indexOf(-50., PositionMatch::Equal));
+
+    CPPUNIT_ASSERT(*rd.indexOf(7., PositionMatch::GreaterOrEqual) == 3);
+    CPPUNIT_ASSERT(*rd.indexOf(7., PositionMatch::Greater) == 3);
+    CPPUNIT_ASSERT(*rd.indexOf(7., PositionMatch::LessOrEqual) == 2);
+    CPPUNIT_ASSERT(*rd.indexOf(7., PositionMatch::Less) == 2);
+    CPPUNIT_ASSERT(!rd.indexOf(7., PositionMatch::Equal));
+
+    CPPUNIT_ASSERT(*rd.indexOf(10., PositionMatch::GreaterOrEqual) == 3);
+    CPPUNIT_ASSERT(*rd.indexOf(10., PositionMatch::Greater) == 4);
+    CPPUNIT_ASSERT(*rd.indexOf(10., PositionMatch::LessOrEqual) == 3);
+    CPPUNIT_ASSERT(*rd.indexOf(10., PositionMatch::Less) == 2);
+    CPPUNIT_ASSERT(*rd.indexOf(10., PositionMatch::Equal) == 3);
+
+    CPPUNIT_ASSERT(!rd.indexOf(110., PositionMatch::GreaterOrEqual));
+    CPPUNIT_ASSERT(!rd.indexOf(110., PositionMatch::Greater));
+    CPPUNIT_ASSERT(*rd.indexOf(110., PositionMatch::LessOrEqual) == 4);
+    CPPUNIT_ASSERT(*rd.indexOf(110., PositionMatch::Less) == 4);
+    CPPUNIT_ASSERT(!rd.indexOf(110., PositionMatch::Equal));
+
     data_array.deleteDimensions();
 }
 

--- a/test/BaseTestDimension.cpp
+++ b/test/BaseTestDimension.cpp
@@ -313,6 +313,10 @@ void BaseTestDimension::testSampledDimIndexOf() {
     CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 3);
     range = sd.indexOf(2., -2.0, RangeMatch::Exclusive);
     CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 2);
+    range = sd.indexOf(2.0, 2.0, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 3 && (*range).second == 3);
+    range = sd.indexOf(2., 2.0, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(!range);
 
     // test vector of ranges, offset = -1, sampling interval = 1
     CPPUNIT_ASSERT_THROW(sd.indexOf({1.0, 20.0, 40.0}, {10.9, 12.}, RangeMatch::Exclusive), std::runtime_error);

--- a/test/BaseTestDimension.cpp
+++ b/test/BaseTestDimension.cpp
@@ -429,7 +429,7 @@ void BaseTestDimension::testRangeDimIndexOfOld() {
     CPPUNIT_ASSERT(rd.indexOf(-10.0) == 1);
     CPPUNIT_ASSERT(rd.indexOf(-5.0) == 1);
     CPPUNIT_ASSERT(rd.indexOf(5.0) == 2);
-    
+
     CPPUNIT_ASSERT_NO_THROW(rd.indexOf(257.28));
     CPPUNIT_ASSERT_THROW(rd.indexOf(257.28, false), nix::OutOfBounds);
     CPPUNIT_ASSERT_THROW(rd.indexOf(-257.28), nix::OutOfBounds);
@@ -441,7 +441,7 @@ void BaseTestDimension::testRangeDimIndexOfOld() {
     CPPUNIT_ASSERT(range.first == 0 && range.second == 4);
     range = rd.indexOf(-200., 200.);
     CPPUNIT_ASSERT(range.first == 0 && range.second == 4);
-    
+
     CPPUNIT_ASSERT_THROW(rd.indexOf({-100.0, -90, 0.0}, {10.}), std::runtime_error);
     CPPUNIT_ASSERT_NO_THROW(rd.indexOf({-100.0, 20.0, 40.0}, {-45, 120., 100.}));
     CPPUNIT_ASSERT(rd.indexOf({-100.0, 20.0, 40.0}, {-45, 120., 100.}).size() == 3);
@@ -463,13 +463,13 @@ void BaseTestDimension::testRangeDimIndexOf() {
     CPPUNIT_ASSERT(!rd.indexOf(-110., PositionMatch::LessOrEqual));
     CPPUNIT_ASSERT(!rd.indexOf(-110., PositionMatch::Less));
     CPPUNIT_ASSERT(!rd.indexOf(-110., PositionMatch::Equal));
-    
+
     CPPUNIT_ASSERT(*rd.indexOf(-100., PositionMatch::GreaterOrEqual) == 0);
     CPPUNIT_ASSERT(*rd.indexOf(-100., PositionMatch::Greater) == 1);
     CPPUNIT_ASSERT(*rd.indexOf(-100., PositionMatch::LessOrEqual) == 0);
     CPPUNIT_ASSERT(!rd.indexOf(-100., PositionMatch::Less));
     CPPUNIT_ASSERT(*rd.indexOf(-100., PositionMatch::Equal) == 0);
-    
+
     CPPUNIT_ASSERT(*rd.indexOf(-50., PositionMatch::GreaterOrEqual) == 1);
     CPPUNIT_ASSERT(*rd.indexOf(-50., PositionMatch::Greater) == 1);
     CPPUNIT_ASSERT(*rd.indexOf(-50., PositionMatch::LessOrEqual) == 0);
@@ -527,7 +527,8 @@ void BaseTestDimension::testRangeDimIndexOf() {
     CPPUNIT_ASSERT(ranges[0].first == 4 && ranges[0].second == 4);
     CPPUNIT_ASSERT(ranges[1].first == 0 && ranges[1].second == 4);
 
-    ranges = rd.indexOf({40., -100., -100.}, {100., 100., 101.}, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT_THROW(rd.indexOf({40., -100., -100.}, {100., 100., 101.}, RangeMatch::Exclusive), nix::OutOfBounds);
+    ranges = rd.indexOf({40., -100., -100.}, {100., 100., 101.}, RangeMatch::Exclusive, false);
     CPPUNIT_ASSERT(ranges.size() == 2);
     CPPUNIT_ASSERT(ranges[0].first == 0 && ranges[0].second == 3);
     CPPUNIT_ASSERT(ranges[1].first == 0 && ranges[1].second == 4);

--- a/test/BaseTestDimension.cpp
+++ b/test/BaseTestDimension.cpp
@@ -484,6 +484,23 @@ void BaseTestDimension::testRangeDimAxis() {
 }
 
 
+void BaseTestDimension::testRangeDimPositionInRange() {
+    std::vector<double> ticks = {-100.0, -10.0, 0.0, 10.0, 100.0};
+    Dimension d = data_array.appendRangeDimension(ticks);
+
+    CPPUNIT_ASSERT(d.dimensionType() == DimensionType::Range);
+    RangeDimension rd = d.asRangeDimension();
+
+    CPPUNIT_ASSERT(rd.positionInRange(-99.0) == nix::PositionInRange::InRange);
+    CPPUNIT_ASSERT(rd.positionInRange(99.0) == nix::PositionInRange::InRange);
+    CPPUNIT_ASSERT(rd.positionInRange(100.1) == nix::PositionInRange::Greater);
+    CPPUNIT_ASSERT(rd.positionInRange(-100.1) == nix::PositionInRange::Less);
+
+    rd.ticks({});
+    CPPUNIT_ASSERT(rd.positionInRange(0.1) == nix::PositionInRange::NoRange);
+}
+
+
 void BaseTestDimension::testAsDimensionMethods() {
     std::vector<double> ticks = {-100.0, -10.0, 0.0, 10.0, 100.0};
     Dimension x;

--- a/test/BaseTestDimension.cpp
+++ b/test/BaseTestDimension.cpp
@@ -560,6 +560,37 @@ void BaseTestDimension::testSetDimIndexOf() {
     CPPUNIT_ASSERT(index && *index == 6);
     index = sd.indexOf(5.5, PositionMatch::Greater);
     CPPUNIT_ASSERT(index && *index == 6);
+
+    boost::optional<std::pair<ndsize_t, ndsize_t>> range = sd.indexOf(0.0, 0.0, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 0);
+    range = sd.indexOf(0.0, 0.0, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(!range);
+    range = sd.indexOf(0.0, 3.0, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 3);
+    range = sd.indexOf(0.0, 3.0, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 2);
+    range = sd.indexOf(3.0, 0.0, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 3);
+    range = sd.indexOf(3.0, 0.0, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 2);
+
+    sd.labels(labels);
+    range = sd.indexOf(0.0, 0.0, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 0);
+    range = sd.indexOf(0.0, 0.0, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(!range);
+    range = sd.indexOf(0.0, 3.0, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 3);
+    range = sd.indexOf(0.0, 3.0, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 2);
+    range = sd.indexOf(3.0, 0.0, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 3);
+    range = sd.indexOf(3.0, 0.0, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 2);
+    range = sd.indexOf(0.0, 7.0, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 4);
+    range = sd.indexOf(3.0, 7.0, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(range && (*range).first == 3 && (*range).second == 4);
 }
 
 void BaseTestDimension::testRangeDimLabel() {

--- a/test/BaseTestDimension.cpp
+++ b/test/BaseTestDimension.cpp
@@ -522,16 +522,29 @@ void BaseTestDimension::testRangeDimIndexOf() {
     CPPUNIT_ASSERT(range && (*range).first == 0 && (*range).second == 3);
 
     std::vector<std::pair<ndsize_t, ndsize_t>> ranges;
-    ranges = rd.indexOf({40., -100.}, {100., 100.}, RangeMatch::Inclusive);
+    ranges = rd.indexOf({40., -100.}, {100., 100.}, true, RangeMatch::Inclusive);
     CPPUNIT_ASSERT(ranges.size() == 2);
     CPPUNIT_ASSERT(ranges[0].first == 4 && ranges[0].second == 4);
     CPPUNIT_ASSERT(ranges[1].first == 0 && ranges[1].second == 4);
 
-    CPPUNIT_ASSERT_THROW(rd.indexOf({40., -100., -100.}, {100., 100., 101.}, RangeMatch::Exclusive), nix::OutOfBounds);
-    ranges = rd.indexOf({40., -100., -100.}, {100., 100., 101.}, RangeMatch::Exclusive, false);
+    CPPUNIT_ASSERT_THROW(rd.indexOf({40., -100., -100.}, {100., 100., 101.}, true, RangeMatch::Exclusive), nix::OutOfBounds);
+    ranges = rd.indexOf({40., -100., -100.}, {100., 100., 101.}, false, RangeMatch::Exclusive);
     CPPUNIT_ASSERT(ranges.size() == 2);
     CPPUNIT_ASSERT(ranges[0].first == 0 && ranges[0].second == 3);
     CPPUNIT_ASSERT(ranges[1].first == 0 && ranges[1].second == 4);
+
+    std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> optranges;
+    optranges = rd.indexOf({40., -100.}, {100., 100.}, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(optranges.size() == 2);
+    CPPUNIT_ASSERT(optranges[0] && (*optranges[0]).first == 4 && (*optranges[0]).second == 4);
+    CPPUNIT_ASSERT(optranges[1] && (*optranges[1]).first == 0 && (*optranges[1]).second == 4);
+
+    optranges = rd.indexOf({40., -100., -100.}, {100., 100., 101.}, RangeMatch::Exclusive);
+    CPPUNIT_ASSERT(optranges.size() == 3);
+    CPPUNIT_ASSERT(!optranges[0]);
+    CPPUNIT_ASSERT(optranges[1] && (*optranges[1]).first == 0 && (*optranges[1]).second == 3);
+    CPPUNIT_ASSERT(optranges[2] && (*optranges[2]).first == 0 && (*optranges[2]).second == 4);
+    
     data_array.deleteDimensions();
 }
 

--- a/test/BaseTestDimension.cpp
+++ b/test/BaseTestDimension.cpp
@@ -162,7 +162,8 @@ void BaseTestDimension::testSampledDimIndexOf() {
     SampledDimension sd;
     sd = d;
     CPPUNIT_ASSERT_THROW(sd.indexOf(-3.14), nix::OutOfBounds);
-    CPPUNIT_ASSERT_NO_THROW(sd.indexOf(-1.14));
+    CPPUNIT_ASSERT_NO_THROW(sd.indexOf(0));
+
     CPPUNIT_ASSERT(sd.indexOf(3.14) == 1);
     CPPUNIT_ASSERT(sd.indexOf(6.28) == 2);
     CPPUNIT_ASSERT(sd.indexOf(4.28) == 1);
@@ -170,16 +171,27 @@ void BaseTestDimension::testSampledDimIndexOf() {
 
     sd.offset(offset);
     CPPUNIT_ASSERT(*(sd.offset()) == offset);
-    CPPUNIT_ASSERT(sd.indexOf(-1 * samplingInterval / 2 + offset + 0.001) == 0);
     CPPUNIT_ASSERT_THROW(sd.indexOf(-3.14), nix::OutOfBounds);
     CPPUNIT_ASSERT(sd.indexOf(2.14) == 0);
     CPPUNIT_ASSERT(sd.indexOf(6.28) == 2);
     CPPUNIT_ASSERT(sd.indexOf(4.28) == 1);
     CPPUNIT_ASSERT(sd.indexOf(7.28) == 2);
+    CPPUNIT_ASSERT(sd.indexOf(1.0, 1.01).first == 0);
+    CPPUNIT_ASSERT_THROW(sd.indexOf(1.01, 0.0), nix::OutOfBounds);
+    CPPUNIT_ASSERT_THROW(sd.indexOf(1.01, 0.99), nix::OutOfBounds);
+
 
     CPPUNIT_ASSERT_THROW(sd.indexOf({0.0, 20.0, 40.0}, {10.9}), std::runtime_error);
-    CPPUNIT_ASSERT_NO_THROW(sd.indexOf({0.0, 20.0, 40.0}, {10.9, 12., 1.}));
-    CPPUNIT_ASSERT(sd.indexOf({0.0, 20.0, 40.0}, {10.9, 12., 1.}).size() == 3);
+    CPPUNIT_ASSERT_THROW(sd.indexOf({0.0, 20.0, 40.0}, {10.9, 12., 1.}), nix::OutOfBounds);
+    CPPUNIT_ASSERT_NO_THROW(sd.indexOf({1.0, 20.0, 40.0}, {10.9, 12., 1.}));
+
+    CPPUNIT_ASSERT(sd.indexOf({1.0, 20.0, 40.0}, {10.9, 12., 1.}).size() == 3);
+
+    std::vector<std::pair<ndsize_t, ndsize_t>> ranges = sd.indexOf({1.0, 20.0, 40.0}, {10.9, 12., 1.}, RangeMatch::Inclusive);
+    CPPUNIT_ASSERT(ranges.size() == 3);
+    CPPUNIT_ASSERT(ranges[0].first == 0 && ranges[0].second == 3);
+
+
     data_array.deleteDimensions();
 }
 
@@ -444,7 +456,7 @@ void BaseTestDimension::testRangeDimIndexOfOld() {
 
     CPPUNIT_ASSERT_THROW(rd.indexOf({-100.0, -90, 0.0}, {10.}), std::runtime_error);
     CPPUNIT_ASSERT_NO_THROW(rd.indexOf({-100.0, 20.0, 40.0}, {-45, 120., 100.}));
-    CPPUNIT_ASSERT(rd.indexOf({-100.0, 20.0, 40.0}, {-45, 120., 100.}).size() == 3);
+    CPPUNIT_ASSERT(rd.indexOf({-100.0, 20.0, 40.0}, {-45, 120., 100.}, false).size() == 3);
     data_array.deleteDimensions();
 }
 
@@ -526,13 +538,14 @@ void BaseTestDimension::testRangeDimIndexOf() {
     CPPUNIT_ASSERT(ranges.size() == 2);
     CPPUNIT_ASSERT(ranges[0].first == 4 && ranges[0].second == 4);
     CPPUNIT_ASSERT(ranges[1].first == 0 && ranges[1].second == 4);
-
+    
     CPPUNIT_ASSERT_THROW(rd.indexOf({40., -100., -100.}, {100., 100., 101.}, true, RangeMatch::Exclusive), nix::OutOfBounds);
+    
     ranges = rd.indexOf({40., -100., -100.}, {100., 100., 101.}, false, RangeMatch::Exclusive);
     CPPUNIT_ASSERT(ranges.size() == 2);
     CPPUNIT_ASSERT(ranges[0].first == 0 && ranges[0].second == 3);
     CPPUNIT_ASSERT(ranges[1].first == 0 && ranges[1].second == 4);
-
+    
     std::vector<boost::optional<std::pair<ndsize_t, ndsize_t>>> optranges;
     optranges = rd.indexOf({40., -100.}, {100., 100.}, RangeMatch::Inclusive);
     CPPUNIT_ASSERT(optranges.size() == 2);

--- a/test/BaseTestDimension.cpp
+++ b/test/BaseTestDimension.cpp
@@ -482,6 +482,85 @@ void BaseTestDimension::testSetDimLabels() {
     data_array.deleteDimensions();
 }
 
+void BaseTestDimension::testSetDimIndexOf() {
+    std::vector<std::string> labels = {"label_a", "label_b","label_c","label_d","label_e"};
+
+    Dimension d = data_array.appendSetDimension();
+    CPPUNIT_ASSERT(d.dimensionType() == DimensionType::Set);
+    SetDimension sd;
+    sd = d;
+    sd.labels(labels);
+
+    boost::optional<ndsize_t> index;
+    index = sd.indexOf(-1.0, PositionMatch::Less);
+    CPPUNIT_ASSERT(!index);
+    index = sd.indexOf(-1.0, PositionMatch::LessOrEqual);
+    CPPUNIT_ASSERT(!index);
+    index = sd.indexOf(-1.0, PositionMatch::Equal);
+    CPPUNIT_ASSERT(!index);
+    index = sd.indexOf(-1.0, PositionMatch::GreaterOrEqual);
+    CPPUNIT_ASSERT(index && *index == 0);
+    index = sd.indexOf(-1.0, PositionMatch::Greater);
+    CPPUNIT_ASSERT(index && *index == 0);
+
+    index = sd.indexOf(0.0, PositionMatch::Less);
+    CPPUNIT_ASSERT(!index);
+    index = sd.indexOf(0.0, PositionMatch::LessOrEqual);
+    CPPUNIT_ASSERT(index && *index == 0);
+    index = sd.indexOf(0.0, PositionMatch::Equal);
+    CPPUNIT_ASSERT(index && *index == 0);
+    index = sd.indexOf(0.0000001, PositionMatch::Equal);
+    CPPUNIT_ASSERT(!index);
+    index = sd.indexOf(0.0, PositionMatch::GreaterOrEqual);
+    CPPUNIT_ASSERT(index && *index == 0);
+    index = sd.indexOf(0.0, PositionMatch::Greater);
+    CPPUNIT_ASSERT(index && *index == 1);
+
+    index = sd.indexOf(4.0, PositionMatch::Less);
+    CPPUNIT_ASSERT(index && *index == 3);
+    index = sd.indexOf(4.0, PositionMatch::LessOrEqual);
+    CPPUNIT_ASSERT(index && *index == 4);
+    index = sd.indexOf(4.0, PositionMatch::Equal);
+    CPPUNIT_ASSERT(index && *index == 4);
+    index = sd.indexOf(4.0, PositionMatch::GreaterOrEqual);
+    CPPUNIT_ASSERT(index && *index == 4);
+    index = sd.indexOf(4.0, PositionMatch::Greater);
+    CPPUNIT_ASSERT(!index);
+
+    index = sd.indexOf(5.0, PositionMatch::Less);
+    CPPUNIT_ASSERT(index && *index == 4);
+    index = sd.indexOf(5.0, PositionMatch::LessOrEqual);
+    CPPUNIT_ASSERT(index && *index == 4);
+    index = sd.indexOf(5.0, PositionMatch::Equal);
+    CPPUNIT_ASSERT(!index);
+    index = sd.indexOf(5.0, PositionMatch::GreaterOrEqual);
+    CPPUNIT_ASSERT(!index);
+    index = sd.indexOf(5.0, PositionMatch::Greater);
+    CPPUNIT_ASSERT(!index);
+
+    sd.labels(boost::none);
+    index = sd.indexOf(5.0, PositionMatch::Less);
+    CPPUNIT_ASSERT(index && *index == 4);
+    index = sd.indexOf(5.0, PositionMatch::LessOrEqual);
+    CPPUNIT_ASSERT(index && *index == 5);
+    index = sd.indexOf(5.0, PositionMatch::Equal);
+    CPPUNIT_ASSERT(index && *index == 5);
+    index = sd.indexOf(5.0, PositionMatch::GreaterOrEqual);
+    CPPUNIT_ASSERT(index && *index == 5);
+    index = sd.indexOf(5.0, PositionMatch::Greater);
+    CPPUNIT_ASSERT(index && *index == 6);
+
+    index = sd.indexOf(5.5, PositionMatch::Less);
+    CPPUNIT_ASSERT(index && *index == 5);
+    index = sd.indexOf(5.5, PositionMatch::LessOrEqual);
+    CPPUNIT_ASSERT(index && *index == 5);
+    index = sd.indexOf(5.5, PositionMatch::Equal);
+    CPPUNIT_ASSERT(!index);
+    index = sd.indexOf(5.5, PositionMatch::GreaterOrEqual);
+    CPPUNIT_ASSERT(index && *index == 6);
+    index = sd.indexOf(5.5, PositionMatch::Greater);
+    CPPUNIT_ASSERT(index && *index == 6);
+}
 
 void BaseTestDimension::testRangeDimLabel() {
     std::string label = "aLabel";

--- a/test/BaseTestDimension.hpp
+++ b/test/BaseTestDimension.hpp
@@ -39,6 +39,7 @@ public:
     void testSampledDimAxis();
 
     void testSetDimLabels();
+    void testSetDimIndexOf();
 
     void testRangeDimLabel();
     void testRangeTicks();

--- a/test/BaseTestDimension.hpp
+++ b/test/BaseTestDimension.hpp
@@ -33,6 +33,7 @@ public:
     void testSampledDimUnit();
     void testSampledDimSamplingInterval();
     void testSampledDimOperators();
+    void testSampledDimIndexOfOld();
     void testSampledDimIndexOf();
     void testSampledDimPositionAt();
     void testSampledDimAxis();

--- a/test/BaseTestDimension.hpp
+++ b/test/BaseTestDimension.hpp
@@ -50,6 +50,8 @@ public:
     void testRangeDimAxis();
     void testRangeDimPositionInRange();
     
+    void testDataFrameDimIndexOf();
+
     void testAsDimensionMethods();
 };
 

--- a/test/BaseTestDimension.hpp
+++ b/test/BaseTestDimension.hpp
@@ -42,6 +42,7 @@ public:
     void testRangeDimLabel();
     void testRangeTicks();
     void testRangeDimUnit();
+    void testRangeDimIndexOfOld();
     void testRangeDimIndexOf();
     void testRangeDimTickAt();
     void testRangeDimAxis();

--- a/test/BaseTestDimension.hpp
+++ b/test/BaseTestDimension.hpp
@@ -45,7 +45,8 @@ public:
     void testRangeDimIndexOf();
     void testRangeDimTickAt();
     void testRangeDimAxis();
-
+    void testRangeDimPositionInRange();
+    
     void testAsDimensionMethods();
 };
 

--- a/test/BaseTestMultiTag.cpp
+++ b/test/BaseTestMultiTag.cpp
@@ -380,12 +380,12 @@ void BaseTestMultiTag::testDataAccess() {
     DataView ret_data = multi_tag.taggedData(0, 0);
     NDSize data_size = ret_data.dataExtent();
     CPPUNIT_ASSERT(data_size.size() == 3);
-    CPPUNIT_ASSERT(data_size[0] == 1 && data_size[1] == 7 && data_size[2] == 2);
+    CPPUNIT_ASSERT(data_size[0] == 1 && data_size[1] == 6 && data_size[2] == 2);
 
     ret_data = multi_tag.taggedData(0, data_array.name());
     data_size = ret_data.dataExtent();
     CPPUNIT_ASSERT(data_size.size() == 3);
-    CPPUNIT_ASSERT(data_size[0] == 1 && data_size[1] == 7 && data_size[2] == 2);
+    CPPUNIT_ASSERT(data_size[0] == 1 && data_size[1] == 6 && data_size[2] == 2);
 
     CPPUNIT_ASSERT_THROW(multi_tag.taggedData(1, 0), nix::OutOfBounds);
 

--- a/test/BaseTestTag.cpp
+++ b/test/BaseTestTag.cpp
@@ -327,22 +327,22 @@ void BaseTestTag::testDataAccess() {
     segment_tag.extent(extent);
     segment_tag.units(units);
 
-    DataView retrieved_data = position_tag.retrieveData(0);
+    DataView retrieved_data = position_tag.taggedData(0);
     NDSize data_size = retrieved_data.dataExtent();
     CPPUNIT_ASSERT(data_size.size() == 3);
     CPPUNIT_ASSERT(data_size[0] == 1 && data_size[1] == 1 &&  data_size[2] == 1);
 
-    CPPUNIT_ASSERT_THROW(position_tag.retrieveData("invalid name"), std::invalid_argument);
+    CPPUNIT_ASSERT_THROW(position_tag.taggedData("invalid name"), std::invalid_argument);
 
-    retrieved_data = position_tag.retrieveData(data_array.name());
+    retrieved_data = position_tag.taggedData(data_array.name());
     data_size = retrieved_data.dataExtent();
     CPPUNIT_ASSERT(data_size.size() == 3);
     CPPUNIT_ASSERT(data_size[0] == 1 && data_size[1] == 1 &&  data_size[2] == 1);
 
-    retrieved_data = segment_tag.retrieveData( 0);
+    retrieved_data = segment_tag.taggedData(0);
     data_size = retrieved_data.dataExtent();
     CPPUNIT_ASSERT(data_size.size() == 3);
-    CPPUNIT_ASSERT(data_size[0] == 1 && data_size[1] == 7 && data_size[2] == 2);
+    CPPUNIT_ASSERT(data_size[0] == 1 && data_size[1] == 6 && data_size[2] == 2);
 
     block.deleteTag(position_tag);
     block.deleteTag(segment_tag);

--- a/test/hdf5/TestDataAccessHDF5.hpp
+++ b/test/hdf5/TestDataAccessHDF5.hpp
@@ -17,9 +17,12 @@ class TestDataAccessHDF5 : public BaseTestDataAccess {
 
     CPPUNIT_TEST_SUITE(TestDataAccessHDF5);
     CPPUNIT_TEST(testPositionToIndexSampledDimension);
+    CPPUNIT_TEST(testPositionToIndexSampledDimensionOld);
     CPPUNIT_TEST(testPositionToIndexSetDimension);
+    CPPUNIT_TEST(testPositionToIndexSetDimensionOld);
     CPPUNIT_TEST(testPositionToIndexRangeDimension);
     CPPUNIT_TEST(testPositionToIndexDataFrameDimension);
+    CPPUNIT_TEST(testPositionToIndexRangeDimensionOld);
     CPPUNIT_TEST(testOffsetAndCount);
     CPPUNIT_TEST(testPositionInData);
     CPPUNIT_TEST(testRetrieveData);

--- a/test/hdf5/TestDimensionHDF5.hpp
+++ b/test/hdf5/TestDimensionHDF5.hpp
@@ -32,6 +32,7 @@ class TestDimensionHDF5 : public BaseTestDimension {
     CPPUNIT_TEST(testRangeDimLabel);
     CPPUNIT_TEST(testRangeDimUnit);
     CPPUNIT_TEST(testRangeTicks);
+    CPPUNIT_TEST(testRangeDimIndexOfOld);
     CPPUNIT_TEST(testRangeDimIndexOf);
     CPPUNIT_TEST(testRangeDimPositionInRange);
     CPPUNIT_TEST(testRangeDimTickAt);

--- a/test/hdf5/TestDimensionHDF5.hpp
+++ b/test/hdf5/TestDimensionHDF5.hpp
@@ -26,6 +26,7 @@ class TestDimensionHDF5 : public BaseTestDimension {
     CPPUNIT_TEST(testSampledDimSamplingInterval);
     CPPUNIT_TEST(testSampledDimOperators);
     CPPUNIT_TEST(testSampledDimIndexOf);
+    CPPUNIT_TEST(testSampledDimIndexOfOld);
     CPPUNIT_TEST(testSampledDimPositionAt);
     CPPUNIT_TEST(testSampledDimAxis);
     CPPUNIT_TEST(testSetDimLabels);

--- a/test/hdf5/TestDimensionHDF5.hpp
+++ b/test/hdf5/TestDimensionHDF5.hpp
@@ -33,6 +33,7 @@ class TestDimensionHDF5 : public BaseTestDimension {
     CPPUNIT_TEST(testRangeDimUnit);
     CPPUNIT_TEST(testRangeTicks);
     CPPUNIT_TEST(testRangeDimIndexOf);
+    CPPUNIT_TEST(testRangeDimPositionInRange);
     CPPUNIT_TEST(testRangeDimTickAt);
     CPPUNIT_TEST(testRangeDimAxis);
     CPPUNIT_TEST(testAsDimensionMethods);

--- a/test/hdf5/TestDimensionHDF5.hpp
+++ b/test/hdf5/TestDimensionHDF5.hpp
@@ -30,6 +30,7 @@ class TestDimensionHDF5 : public BaseTestDimension {
     CPPUNIT_TEST(testSampledDimPositionAt);
     CPPUNIT_TEST(testSampledDimAxis);
     CPPUNIT_TEST(testSetDimLabels);
+    CPPUNIT_TEST(testSetDimIndexOf);
     CPPUNIT_TEST(testRangeDimLabel);
     CPPUNIT_TEST(testRangeDimUnit);
     CPPUNIT_TEST(testRangeTicks);

--- a/test/hdf5/TestDimensionHDF5.hpp
+++ b/test/hdf5/TestDimensionHDF5.hpp
@@ -39,6 +39,7 @@ class TestDimensionHDF5 : public BaseTestDimension {
     CPPUNIT_TEST(testRangeDimPositionInRange);
     CPPUNIT_TEST(testRangeDimTickAt);
     CPPUNIT_TEST(testRangeDimAxis);
+    CPPUNIT_TEST(testDataFrameDimIndexOf);
     CPPUNIT_TEST(testAsDimensionMethods);
     CPPUNIT_TEST_SUITE_END ();
 


### PR DESCRIPTION
companion to #819 but for 1.5 with slight adaptations:
* adds indexOf methods to DataFrameDim
* changes the default RangeMatching behaviour to Exclusive 