### PR TITLE
[File] disambiguate bfs::exist constructor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ compiler:
 os:
   - linux
   - osx
+    osx_image: xcode12.2
 
 env:
  - FS_BACKEND=ON
@@ -19,6 +20,27 @@ matrix:
   exclude:
     - os: osx
       compiler: gcc
+    - os: osx
+      env: FS_BACKEND=ON DOCKERFILE=ub1804
+    - os: osx
+      env: FS_BACKEND=OFF DOCKERFILE=ub1804
+
+addons:
+  homebrew:
+    packages:
+      - cmake
+      - boost
+      - cppunit
+      - hdf5
+      - yaml-cpp
+    update: false
+
+before_cache:
+  - brew cleanup
+
+cache:
+  directories:
+    - $HOME/Library/Caches/Homebrew
 
 before_install:
   - if [[ "$CXX" == "g++" ]];

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ compiler:
 os:
   - linux
   - osx
-    osx_image: xcode12.2
+
+osx_image:
+  - xcode12.2
 
 env:
  - FS_BACKEND=ON

--- a/src/File.cpp
+++ b/src/File.cpp
@@ -26,7 +26,7 @@ File File::open(const std::string &name,
                 const std::string &impl,
                 Compression compression,
                 OpenFlags flags) {
-    if (mode == nix::FileMode::ReadOnly && !bfs::exists({name})) {
+    if (mode == nix::FileMode::ReadOnly && !bfs::exists(bfs::path{name})) {
         throw std::runtime_error("Cannot open non-existent file in ReadOnly mode!");
     }
     if (compression == Compression::Auto) {


### PR DESCRIPTION
Explicitly instantiate a boost::filesystem::path object to avoid
any ambiguity via implicit type conversion; as seems to be happen
with boost 1.71:

/src/src/File.cpp: In static member function ‘static nix::File nix::File::open(const string&, nix::FileMode, const string&, nix::Compression, nix::OpenFlags)’:
/src/src/File.cpp:29:63: error: call of overloaded ‘exists(<brace-enclosed initializer list>)’ is ambiguous
   29 |     if (mode == nix::FileMode::ReadOnly && !bfs::exists({name})) {
      |                                                               ^
In file included from /usr/include/boost/filesystem.hpp:17,
                 from /src/src/File.cpp:18:
/usr/include/boost/filesystem/operations.hpp:463:8: note: candidate: ‘bool boost::filesystem::exists(const boost::filesystem::path&)’
  463 |   bool exists(const path& p)           {return exists(detail::status(p));}
      |        ^~~~~~
In file included from /usr/include/boost/filesystem.hpp:17,
                 from /src/src/File.cpp:18:
/usr/include/boost/filesystem/operations.hpp:874:20: note: candidate: ‘bool boost::filesystem::exists(const boost::filesystem::directory_entry&)’
  874 | inline bool        exists         (const directory_entry& e) BOOST_NOEXCEPT { return filesystem::exists(e.status()); }
      |                    ^~~~~~