### PR TITLE
Add gh-actions build

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,62 @@
+name: build-test
+
+on:
+  push:
+    branches:
+      - master
+      - dev
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build-ub1804:
+    name: ubuntu-18.04-build
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Install dependecies
+      run: |
+        sudo apt-get update -y &&
+        sudo apt-get install -yy --no-install-recommends \
+          bash \
+          cmake \
+          clang-7 \
+          curl \
+          doxygen \
+          git \
+          gcc-8 \
+          g++-8 \
+          libcppunit-dev \
+          libboost-all-dev \
+          libhdf5-dev \
+          libhdf5-serial-dev \
+          libyaml-cpp-dev \
+          libstdc++-8-dev \
+          lcov \
+          valgrind
+    - uses: actions/checkout@v2
+    - name: Build
+      run: |
+        mkdir build
+        pushd build
+        cmake ..
+        make
+        make test
+        popd
+
+  build-macos:
+    name: Build on macOS
+    runs-on: macOS-10.14
+    steps:
+    - name: Install dependecies
+      run: |
+        brew update
+        brew install cmake boost cppunit hdf5 yaml-cpp
+    - uses: actions/checkout@v1
+    - name: Build
+      run: |
+        mkdir build
+        cd build
+        cmake ..
+        make
+        make test

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -44,10 +44,17 @@ jobs:
       run: |
         mkdir build
         pushd build
-        cmake ..
+        cmake -DBUILD_COVERAGE=ON ..
         make
         make test
         popd
+    - name: Coverage
+      if: endsWith(matrix.compiler, 'gcc')
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      run: |
+        lcov -q --capture --directory . --no-extern --output-file coverage.info
+        bash <(curl -s https://codecov.io/bash) -f coverage.info -C $GITHUB_SHA -B ${GITHUB_REF#refs/heads/} -Z
 
   build-macos:
     name: Build on macOS

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,6 +13,9 @@ jobs:
   build-ub1804:
     name: ubuntu-18.04-build
     runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        compiler: [gcc, clang]
     steps:
     - name: Install dependecies
       run: |
@@ -35,7 +38,9 @@ jobs:
           lcov \
           valgrind
     - uses: actions/checkout@v2
-    - name: Build
+    - name: Build-Test
+      env:
+        CC: ${{ matrix.compiler }}
       run: |
         mkdir build
         pushd build
@@ -52,8 +57,8 @@ jobs:
       run: |
         brew update
         brew install cmake boost cppunit hdf5 yaml-cpp
-    - uses: actions/checkout@v1
-    - name: Build
+    - uses: actions/checkout@v2
+    - name: Build-Test
       run: |
         mkdir build
         cd build

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/G-Node/nix.svg?branch=master)](https://travis-ci.org/G-Node/nix)
+[![gh actions tests](https://github.com/G-Node/nix/workflows/build-test/badge.svg?branch=master)](https://github.com/G-Node/nix/actions)
 [![Build status](https://ci.appveyor.com/api/projects/status/1qlcasjg2fpqotig/branch/master?svg=true)](https://ci.appveyor.com/project/G-Node/nix/branch/master)
 [![Coverage](https://codecov.io/gh/G-Node/nix/branch/master/graph/badge.svg)](https://codecov.io/gh/G-Node/nix)
 


### PR DESCRIPTION
This PR adds a viable github actions build - test setup for Ubuntu gcc/clang and MacOS.

Also removed the travis-CI build requirement for the master branch, since Travis is no longer accepting jobs.