### PR TITLE
Fix for Dockerfile smell DL3008

### DIFF
--- a/dockerfiles/ub1804.Dockerfile
+++ b/dockerfiles/ub1804.Dockerfile
@@ -2,19 +2,19 @@
 FROM ubuntu:18.04
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -q && apt-get install -yy \
-    cmake \
-    clang-7 \
-    doxygen \
-    git \
-    gcc-8 \
-    g++-8 \
-    libcppunit-dev \
-    libboost-all-dev \
-    libhdf5-dev \
-    libhdf5-serial-dev \
-    libstdc++-8-dev \
-    python-pip \
-    valgrind \
+    cmake=3.10.* \ 
+    clang-7=1:7-3~ubuntu0.* \ 
+    doxygen=1.8.* \ 
+    git=1:2.17.* \ 
+    gcc-8=8.4.* \ 
+    g++-8=8.4.* \ 
+    libcppunit-dev=1.14.* \ 
+    libboost-all-dev=1.65.* \ 
+    libhdf5-dev=1.10.* \ 
+    libhdf5-serial-dev=1.10.* \ 
+    libstdc++-8-dev=8.4.* \ 
+    python-pip=9.0.* \ 
+    valgrind=1:3.13.* \ 
     && rm -rf /var/lib/apt/lists/*
 
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-7 1000


### PR DESCRIPTION
Hi!
The Dockerfile placed at "dockerfiles/ub1804.Dockerfile" contains the best practice violation [DL3008](https://github.com/hadolint/hadolint/wiki/DL3008) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3008 occurs when the version pinning for the installed packages with apt is not specified. This could lead to unexpected behavior when building the Dockerfile.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, we use a heuristic approach that selects the most probable version tag for a given apt package corresponding to the latest version at the current date. The package versions are retrieved using the Canonical Launchpad APIs.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance